### PR TITLE
Minor fixes for op parsing script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ torch-mlir
 torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
 -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
 black
+mdutils
 ninja
 pre-commit
 pybind11

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -7,6 +7,7 @@ import json
 import csv
 import xlsxwriter
 from mdutils.mdutils import MdUtils
+from pathlib import Path
 
 import subprocess
 
@@ -49,8 +50,14 @@ def extract_shapes_md(shape_list):
     return shape_str
 
 
+def create_test_dirs():
+    Path("results/mlir_tests/ttir").mkdir(parents=True, exist_ok=True)
+    Path("results/mlir_tests/stable_hlo").mkdir(parents=True, exist_ok=True)
+
+
 def process_json_files():
     json_files = find_json_files()
+    create_test_dirs()
 
     ops_per_model = {}
     stable_hlo_ops_per_model = {}

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -47,9 +47,7 @@ def test_bert(record_property, mode):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    compiler_config = CompilerConfig()
-    compiler_config.set_compile_depth(CompileDepth.STABLEHLO)
-    tester = ThisTester(model_name, mode, compiler_config)
+    tester = ThisTester(model_name, mode)
     results = tester.test_model()
 
     if mode == "eval":


### PR DESCRIPTION
* Update requirements.txt to install mdutils.
* Create directories for dumping ttir and stablehlo test graphs.
* Use default CompilerConfig options for BERT model to match the others.