### PR TITLE
Nightly action partial match job-name

### DIFF
--- a/.github/workflows/run-model-tests.yml
+++ b/.github/workflows/run-model-tests.yml
@@ -41,7 +41,7 @@ jobs:
       id: strings
       shell: bash
       env:
-        job-name: "${{ github.job }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}, ${{ matrix.build.test_names }})"
+        job-name: "${{ github.job }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }}"
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
We need to partial match the job-name because GH truncates this string with an ellipse:

    tests (n150, run2, MobileNetV2, clip, flan_t5, mlpmixer, resnet, vilt, albert, codegen, glpn_kitt...

The fix is just to partial match i.e.:

    tests (n150, run2,