### PR TITLE
Pytest skip mgp-str-base when mode is train. [#96]

### DIFF
--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -32,12 +32,13 @@ class ThisTester(ModelTester):
         return inputs
 
 
-@pytest.mark.skip("https://github.com/tenstorrent/tt-torch/issues/96")
 @pytest.mark.parametrize(
     "mode",
     ["train", "eval"],
 )
 def test_mgp_str_base(record_property, mode):
+    if mode == "train":
+        pytest.skip()
     model_name = "alibaba-damo/mgp-str-base"
     record_property("model_name", model_name)
     record_property("mode", mode)


### PR DESCRIPTION
Undid skipping entire mgp-str-base test, enabled skip when mode is train. 
Ran only mgp-str-base with nightly test: https://github.com/tenstorrent/tt-torch/actions/runs/12184290865 

