### PR TITLE
Added decomp for bilinear upsample that uses matmul

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -236,3 +236,4 @@ distributed as part of the software:
 - pillow - Custom License (https://github.com/python-pillow/Pillow/blob/main/LICENSE)
 - kornia - Apache v2.0 (https://github.com/kornia/kornia/blob/main/LICENSE)
 - timm - MIT License (https://github.com/guigrpa/timm/blob/master/LICENSE)
+- jax - Apache v2.0 (https://github.com/jax-ml/jax/blob/main/LICENSE)

--- a/tests/torch/test_interpolation.py
+++ b/tests/torch/test_interpolation.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn
+import pytest
+
+import tt_torch
+from tt_torch.tools.verify import verify_module
+from tt_torch.tools.utils import CompilerConfig, CompileDepth
+import torch.nn.functional as F
+
+
+@pytest.mark.parametrize("inH", [50, 128, 224, 960])
+@pytest.mark.parametrize("inW", [50, 128, 224, 540])
+@pytest.mark.parametrize("inC", [3])
+@pytest.mark.parametrize("scale_factor", [2, 3])
+@pytest.mark.parametrize("align_corners", [False, True])
+def test_bilinear_interpolation(inH, inW, inC, scale_factor, align_corners):
+    class Interpolate(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return F.interpolate(
+                x,
+                scale_factor=scale_factor,
+                mode="bilinear",
+                align_corners=align_corners,
+            )
+
+    input_shape = (1, inC, inH, inW)
+    small = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=3,
+        required_pcc=0.99 - 0.05 * scale_factor,
+    )


### PR DESCRIPTION
Added custom decomposition for `aten.upsample_bilinear2d` which uses matmuls to compute the upsample.

Added a `CUSTOM_DECOMPOSITION_TABLE` so we can distinguish between which decompositions are ours and which are not. 

Pass a table to `apply_decompositions` instead.