### PR TITLE
Remove files from lfs

### DIFF
--- a/tests/models/hand_landmark/.gitattributes
+++ b/tests/models/hand_landmark/.gitattributes
@@ -1,2 +1,0 @@
-woman_hands.jpg filter=lfs diff=lfs merge=lfs -text
-hand_landmarker.task filter=lfs diff=lfs merge=lfs -text

--- a/tests/models/hand_landmark/hand_landmarker.task
+++ b/tests/models/hand_landmark/hand_landmarker.task
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fbc2a30080c3c557093b5ddfc334698132eb341044ccee322ccf8bcf3607cde1
-size 7819105

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://colab.research.google.com/github/googlesamples/mediapipe/blob/main/examples/hand_landmarker/python/hand_landmarker.ipynb
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -47,12 +48,13 @@ def test_hand_landmark(record_property, mode):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    """
-     Forcely do `git lfs pull` to make sure the LFS files needed by this test are available.
-    """
-    subprocess.run(
-        ["git", "lfs", "pull"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-    )
+    # Download required files unless they already exist
+    urls = [
+        "https://storage.googleapis.com/mediapipe-models/hand_landmarker/hand_landmarker/float16/1/hand_landmarker.task",
+        "https://storage.googleapis.com/mediapipe-tasks/hand_landmarker/woman_hands.jpg",
+    ]
+    for file_url in urls:
+        os.system(f"wget -P {Path(__file__).parent} -nc {file_url}")
 
     """
     Workaround!

--- a/tests/models/hand_landmark/woman_hands.jpg
+++ b/tests/models/hand_landmark/woman_hands.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:70cbeb38e198c9862202e0979c21a99b40ca980d3e7b250176c85b1636a40f12
-size 67719


### PR DESCRIPTION
Running `git lfs ls-files` returns nothing after this change.
Files in the URLs have the same content as the ones we had in lfs.