### PR TITLE
Add workflow for ttnn md files generation

### DIFF
--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -1,0 +1,58 @@
+name: Generate TTNN MD Files
+
+on:
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Build pipeline run ID to download artifacts from'
+        required: true
+        type: string
+
+jobs:
+  generate_md:
+    timeout-minutes: 120
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setpyenv
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+          echo "install-output-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
+          echo "test-output-dir=$(pwd)/results/models/tests/" >> "$GITHUB_OUTPUT"
+
+      - name: Git safe dir
+        run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: models_op_per_op.xlsx
+          path: ${{ steps.strings.outputs.work-dir }}/results
+
+      - name: Generate TTNN MD Files
+        shell: bash
+        run: |
+          source env/activate
+          echo "${{ steps.strings.outputs.work-dir }}/tt_torch/tools/generate_md.py"
+          echo "${{ steps.strings.outputs.work-dir }}/results/models_op_per_op.xlsx"
+          python ${{ steps.strings.outputs.work-dir }}/tt_torch/tools/generate_md.py --excel_path ${{ steps.strings.outputs.work-dir }}/results/models_op_per_op.xlsx --md_dir ${{ steps.strings.outputs.work-dir }}/docs/ops/ttnn --json_dir ${{ steps.strings.outputs.work-dir }}/docs/ops/ttnn
+
+      - name: Upload TTNN MD Files to archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ttnn-md
+          path: ${{ steps.strings.outputs.work-dir }}/docs/ops/ttnn

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -27,3 +27,7 @@ jobs:
     needs: test
     uses: ./.github/workflows/generate-model-report.yml
     secrets: inherit
+  generate-ttnn-md:
+    needs: download-report
+    uses: ./.github/workflows/generate-ttnn-md.yml
+    secrets: inherit


### PR DESCRIPTION
Add workflow for ttnn md files generation to nightly tests. Currently, created files are not pushed to docs/ops/ttnn. As next iteration, these files could be published on Pages. Removed "Runs on hardware" from created files.