### PR TITLE
Remove unused getitems in op by op flow [#105] 

### DIFF
--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -412,6 +412,29 @@ def test_multiple_ops():
     )
 
 
+def test_unused_output():
+    class Basic_var_only(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            var, mean = torch.var_mean(x)
+            return var
+
+    class Basic_mean_only(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            var, mean = torch.var_mean(x)
+            return mean
+
+    for module in [Basic_var_only, Basic_mean_only]:
+        cc = CompilerConfig()
+        cc.compile_depth = tt_torch.tools.utils.CompileDepth.COMPILE_OP_BY_OP
+        verify_module(module(), input_shapes=[(256, 256)], compiler_config=cc)
+
+
 @pytest.mark.parametrize(
     ("input_range", "input_shapes", "input_type"),
     [

--- a/tests/torch/test_maxpool2d.py
+++ b/tests/torch/test_maxpool2d.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn
+import pytest
+
+import tt_torch
+from tt_torch.tools.verify import verify_module
+from tt_torch.tools.utils import CompilerConfig, CompileDepth
+
+
+def test_maxpool2d():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return torch.nn.functional.max_pool2d(x, kernel_size=2, stride=2)
+
+    cc = CompilerConfig()
+    cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+    verify_module(
+        Basic(),
+        inputs=[torch.randn(1, 1, 224, 224).to(torch.bfloat16)],
+        compiler_config=cc,
+    )


### PR DESCRIPTION
This prevented `nn.MaxPool2D` from being lowered to TTIR.