### PR TITLE
fix checking unused getitems in op by op flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pre-commit
 pybind11
 pytest
 tabulate
-transformers
+transformers==4.47.1
 protobuf
 tiktoken
 sentencepiece

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -449,6 +449,25 @@ def test_unused_output():
         verify_module(module(), input_shapes=[(256, 256)], compiler_config=cc)
 
 
+def test_multiple_users():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            x2 = x + x  # add op
+            y1 = x2 + x  # user 1 of add op
+            y2 = x2 + x  # user 2 of add op
+            z = y1 + y2
+            return z
+
+    cc = CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    verify_module(
+        Basic(), input_shapes=[(256, 256)], compiler_config=cc, do_assert=False
+    )
+
+
 @pytest.mark.parametrize(
     ("input_range", "input_shapes", "input_type"),
     [

--- a/tests/torch/test_softmax.py
+++ b/tests/torch/test_softmax.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn
+import pytest
+
+import tt_torch
+from tt_torch.tools.verify import verify_module
+
+
+@pytest.mark.xfail(reason="softmax_kernel_impl not implemented for Bool")
+def test_safe_softmax_bool():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return torch._safe_softmax(x, 1)
+
+    input_tensor = torch.randint(0, 2, (1, 16, 197, 197), dtype=torch.bool)
+    verify_module(Basic(), inputs=[input_tensor])

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -203,14 +203,14 @@ class Executor:
                 getitem_nodes.append(getitem_node)
                 getitem_node.meta["tensor_meta"] = tensor_meta
             out = graph.output(tuple(getitem_nodes))
+            if len(node.users) != len(graph_node.users):
+                raise ValueError(
+                    f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
+                )
         else:
             out = graph.output((graph_node,))
         if "tensor_meta" not in node.meta:
             raise ValueError(f"Node {node} does not have tensor_meta")
-        if len(node.users) != len(graph_node.users):
-            raise ValueError(
-                f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
-            )
 
         op.compilation_status = OpCompilationStatus.CREATED_GRAPH
         out.meta["tensor_meta"] = node.meta["tensor_meta"]


### PR DESCRIPTION
This resolves failure in model tests
where ops with single output that are consumed by multiple other ops result in an exception