### PR TITLE
Add container to generate-ttnn-md.yml.

### DIFF
--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -13,18 +13,12 @@ jobs:
   generate_md:
     timeout-minutes: 120
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest
+      options: --user root
+
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setpyenv
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.11
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
 
       - name: Set reusable strings
         id: strings


### PR DESCRIPTION
Use ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest instead of installing requirements.