### PR TITLE
Update TT_TORCH_ENABLE_IR_PRINTING env variable usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ You can use the following environment variables to override default behaviour:
 | TT_TORCH_CONSTEVAL | Enables evaluation of constant expressions (consteval) in the Torch FX graph prior to compilation. | False |
 | TT_TORCH_CONSTEVAL_PARAMETERS | Extends consteval to include parameters (e.g., model weights) as well as embedded constants. | False |
 | TT_TORCH_EMBEDDEDD_CONSTANTS | Remove embedded constants from the Torch FX graph and convert them to constant inputs | False |
-| TT_TORCH_ENABLE_IR_PRINTING | Enables printing MLIR for all conversion steps from StableHLO to TTNN. Be warned, this forces single core compile, so is much slower. | False |
+| TT_TORCH_IR_LOG_LEVEL | Enables printing MLIR from Torch to TTNN. It supports two modes; `INFO` and `DEBUG`. `INFO` prints MLIR for all conversions steps (Torch, StableHLO, TTIR and TTNN MLIR graphs). `DEBUG` prints intermediate MLIR for all passes (IR dump before and after each pass) additionally. Be warned, `DEBUG` IR printing forces single core compile, so it is much slower. | Disable |

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -75,8 +75,8 @@ std::string compileStableHLOToTTIR(std::string_view code) {
   // conversion.
   mlir::PassManager shlo_pm(mlir_module.get()->getName(),
                             mlir::PassManager::Nesting::Implicit);
-  const char *enable_printing = std::getenv("TT_TORCH_ENABLE_IR_PRINTING");
-  if (enable_printing && std::string(enable_printing) == "1") {
+  const char *enable_printing = std::getenv("TT_TORCH_IR_LOG_LEVEL");
+  if (enable_printing && std::string(enable_printing) == "DEBUG") {
     shlo_pm.getContext()->disableMultithreading();
     shlo_pm.enableIRPrinting();
   }
@@ -127,8 +127,8 @@ compileTTIRToTTNN(std::string_view code) {
   mlir::tt::ttnn::registerPasses();
 
   mlir::PassManager pm(mlir_module.get()->getName());
-  const char *enable_printing = std::getenv("TT_TORCH_ENABLE_IR_PRINTING");
-  if (enable_printing && std::string(enable_printing) == "1") {
+  const char *enable_printing = std::getenv("TT_TORCH_IR_LOG_LEVEL");
+  if (enable_printing && std::string(enable_printing) == "DEBUG") {
     pm.getContext()->disableMultithreading();
     pm.enableIRPrinting();
   }


### PR DESCRIPTION
IR printing supports two modes:
1. INFO: Prints Torch, StableHLO, TTIR, and TTNN MLIR graphs.
2. DEBUG: Prints intermediate IR for all passes (IR dump before and after each
   pass) as well.