### PR TITLE
Ddilbaz/op by op shlo

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -4,16 +4,19 @@
 import torch
 import os
 import tt_mlir
+import sys
 
 from tt_torch.dynamo.torch_backend import (
     TorchFXExecutor,
     import_graph,
 )
-from tt_torch.dynamo.shlo_backend import StableHLOExecutor
+from tt_torch.dynamo.shlo_backend import (
+    StableHLOExecutor,
+    parse_module_from_str,
+)
 from tt_torch.dynamo.passes import pass_pipeline
 from tt_torch.tools.utils import (
     CompilerConfig,
-    FrontEnd,
     CompileDepth,
 )
 
@@ -41,7 +44,7 @@ def _shlo_backend(module_str, options=None):
     return executor
 
 
-def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
+def _torch_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     # Apply environment overrides at start of compilation to allow overriding what was set in the test
     compiler_config.apply_environment_overrides()
     with torch.no_grad():
@@ -93,16 +96,130 @@ def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     return executor
 
 
-def backend(gm_or_module, example_inputs, options=None):
+def torch_to_shlo(gm: torch.fx.GraphModule, example_inputs, compiler_config):
+    # Apply environment overrides at start of compilation to allow overriding what was set in the test
+    compiler_config.apply_environment_overrides()
+    with torch.no_grad():
+        gm, graph_constants = pass_pipeline(gm, example_inputs, compiler_config)
+    executor = TorchFXExecutor(gm, graph_constants, compiler_config)
+    if compiler_config.compile_depth in (
+        CompileDepth.EXECUTE_OP_BY_OP,
+        CompileDepth.COMPILE_OP_BY_OP,
+        CompileDepth.TORCH_FX,
+    ):
+        return executor
+
+    dump_intermediates = os.environ.get("TT_TORCH_IR_LOG_LEVEL")
+    dump_intermediates = dump_intermediates and (
+        dump_intermediates == "INFO" or dump_intermediates == "DEBUG"
+    )
+
+    module = import_graph(gm.graph)
+    if dump_intermediates:
+        print("Torch module", file=sys.stderr)
+        module.dump()
+
+    if compiler_config.profile_ops:
+        compiler_config.set_torch_mlir_module(module.operation.get_asm())
+    if compiler_config.compile_depth == CompileDepth.TORCH_MLIR:
+        return executor
+
+    lower_to_stable_hlo(module)
+    if dump_intermediates:
+        print("StableHLO module", file=sys.stderr)
+        module.dump()
+
+
+def shlo_to_flatbuffer(module, compiler_config):
+    breakpoint()
+    if compiler_config.profile_ops:
+        compiler_config.set_stablehlo_mlir_module(module.operation.get_asm())
+    if compiler_config.compile_depth == CompileDepth.STABLEHLO:
+        return executor
+
+    ttir = tt_mlir.compile_stable_hlo_to_ttir(module.operation.get_asm())
+    dump_intermediates = os.environ.get("TT_TORCH_IR_LOG_LEVEL")
+    if dump_intermediates:
+        print("TTIR module", file=sys.stderr)
+        print(ttir, file=sys.stderr)
+
+    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
+    if dump_intermediates:
+        print("TTNN module", file=sys.stderr)
+        print(ttnn, file=sys.stderr)
+
+    return binary
+
+
+def _base_backend(gm_or_shlo, example_inputs, compiler_config):
+    if isinstance(gm_or_shlo, torch.fx.GraphModule):
+        shlo = torch_to_shlo()
+    elif isinstance(gm_or_shlo, str):
+        shlo = parse_module_from_str(gm_or_shlo)
+    else:
+        print("Compiler input not valid", file=sys.stderr)
+        exit(1)
+    binary = shlo_to_flatbuffer(shlo, compiler_config)
+    new_inputs = ()
+    type_conversion = {torch.bool: torch.bfloat16}
+    for input in example_inputs:
+        # Handle scalar inputs.
+        if not hasattr(input, "dtype"):
+            assert (
+                type(input) is not bool
+            ), "Conversion for scalar boolean is not supported."
+            new_inputs = new_inputs + ((input),)
+            continue
+
+        # Apply type conversion if required.
+        input_type = input.dtype
+        if input_type in type_conversion.keys():
+            new_inputs = new_inputs + ((input.to(dtype=type_conversion[input_type])),)
+            continue
+
+        # No conversion required.
+        new_inputs = new_inputs + ((input),)
+
+    example_inputs = new_inputs
+    tt_mlir.run(example_inputs, binary)
+
+
+def backend(gm_or_shlo, example_inputs, options=None):
     if options is None:
         options = CompilerConfig()
-    if options.compiler_front_end == FrontEnd.STABLEHLO:
-        if not isinstance(gm_or_module, str):
+    if (
+        options.compile_depth == CompileDepth.COMPILE_OP_BY_OP
+        or options.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+    ):
+        # run op-by-op
+        if isinstance(gm_or_shlo, torch.fx.GraphModule):
+            # run torch op-by-op
+            return _torch_backend(gm_or_shlo, example_inputs, compiler_config=options)
+        elif isinstance(gm_or_shlo, str):
+            # run shlo op-by-op
+            return _shlo_backend(gm_or_shlo, options)
+        else:
+            print("Compiler input not valid", file=sys.stderr)
             exit(1)
-        return _shlo_backend(gm_or_module, options)
-    return _base_backend(gm_or_module, example_inputs, compiler_config=options)
+
+    return _base_backend(gm_or_shlo, example_inputs, compiler_config=options)
 
 
+def generate_random_inputs(module_str):
+    # Parse tensor shapes from the module string
+    import re
+
+    tensor_shapes = re.findall(r"tensor<([\dx]+)xf32>", module_str)
+
+    inputs = []
+    for shape_str in tensor_shapes:
+        shape = [int(dim) for dim in shape_str.split("x")]
+        inputs.append(torch.randn(shape, dtype=torch.float32))
+
+    return inputs
+
+
+# Usage
 MODULE_STRING = """
 module {
   func.func @main(%arg0: tensor<1x128xf32>, %arg1: tensor<128xf32>) -> tensor<1x128xf32> {
@@ -113,7 +230,8 @@ module {
   }
 }
 """
+example_inputs = generate_random_inputs(MODULE_STRING)
+breakpoint()
 compiler_config = CompilerConfig()
-compiler_config.compiler_front_end = FrontEnd.STABLEHLO
-compiler_config.compile_depth = CompileDepth.COMPILE_OP_BY_OP
-backend(MODULE_STRING, None, compiler_config)
+compiler_config.compile_depth = CompileDepth.EXECUTE
+backend(MODULE_STRING, example_inputs, compiler_config)

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -2,49 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import os
+import tt_mlir
 
-from torch._dynamo.backends.common import aot_autograd
-from torch.fx.experimental.proxy_tensor import make_fx
-from torch._functorch.compile_utils import strip_overloads
-import operator
-
+from tt_torch.dynamo.torch_backend import (
+    TorchFXExecutor,
+    import_graph,
+)
+from tt_torch.dynamo.shlo_backend import StableHLOExecutor
 from tt_torch.dynamo.passes import pass_pipeline
 from tt_torch.tools.utils import (
     CompilerConfig,
+    FrontEnd,
     CompileDepth,
-    Op,
-    OpCompilationStatus,
-    calculate_atol,
-    calculate_pcc,
 )
-
-import tt_mlir
-from torch_mlir.ir import Context
-from torch_mlir.extras.fx_importer import FxImporter
-
-from torch_mlir.dialects import torch as torch_dialect
-
-from torch_mlir.compiler_utils import (
-    OutputType,
-    run_pipeline_with_repro_report,
-    lower_mlir_module,
-)
-from typing import List, Tuple, Union
-import os
-import multiprocessing as mp
-import time
-import faulthandler
-import re
-import sys
-import tempfile
-
-
-def import_graph(graph: torch.fx.GraphModule):
-    context = Context()
-    torch_dialect.register_dialect(context)
-    importer = FxImporter(context=context)
-    importer.import_stateless_graph(graph)
-    return importer.module
 
 
 def lower_to_stable_hlo(module, op=None):
@@ -61,397 +32,13 @@ def lower_to_stable_hlo(module, op=None):
         op.compilation_status = OpCompilationStatus.CONVERTED_TO_STABLE_HLO
 
 
-def compile_process(receiver, sender, ttir_event, ttnn_event):
-    obj = receiver.get()
-    faulthandler.disable()
-    asm = obj["asm"]
-    ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
-    sender.put({"ttir": ttir})
-    ttir_event.wait()
-    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
-    sender.put({"binary": binary, "ttnn": ttnn})
-    ttnn_event.wait()
-    sys.exit(0)
-
-
-def execute_process(receiver, sender, exec_event):
-    obj = receiver.get()
-    faulthandler.disable()
-    binary = obj["binary"]
-    inputs = obj["inputs"]
-    outputs = tt_mlir.run(inputs, binary)
-    sender.put({"outputs": outputs})
-    exec_event.wait()
-    sys.exit(0)
-
-
-class Executor:
-    def __init__(
-        self,
-        gm,
-        graph_constants,
-        compiler_config=None,
-        required_pcc=0.99,
-        required_atol=1e-2,
-    ):
-        self.gm = gm
-        self.binary = None
-        self.graph_constants = tuple(graph_constants)
-        if compiler_config is None:
-            compiler_config = CompilerConfig()
-        self.compiler_config = compiler_config
-        self.required_atol = required_atol
-        self.required_pcc = required_pcc
-        # Dictionary to keep track of the type conversion for unsupported hardware
-        # types and use it to convert the input arguments to supported types.
-        self.type_conversion = {torch.bool: torch.bfloat16}
-
-    def set_binary(self, binary):
-        self.binary = binary
-
-    def compile_op(self, node, *inputs, **kwargs):
-        input_shapes_and_constants = []
-        for inp in inputs:
-            if isinstance(inp, torch.Tensor):
-                input_shapes_and_constants.append(inp.shape)
-            elif isinstance(inp, (list, tuple)):
-                sub = []
-                for sub_inp in inp:
-                    if isinstance(sub_inp, torch.Tensor):
-                        sub.append(sub_inp.shape)
-                    else:
-                        sub.append(sub_inp)
-                input_shapes_and_constants.append(sub)
-            elif isinstance(inp, (int, float, bool)):
-                input_shapes_and_constants.append(inp)
-            elif isinstance(inp, torch.dtype):
-                input_shapes_and_constants.append(inp.__str__())
-            elif inp is None:
-                input_shapes_and_constants.append(None)
-            else:
-                raise ValueError(f"Unexpected input type: {type(inp)}")
-
-        name = node.target.name() if hasattr(node.target, "name") else node.name
-        if not isinstance(node.target, torch._ops.OpOverload):
-            if "getitem" not in name:
-                raise ValueError(f"Node target is not an OpOverload: {name}")
-            return None, None
-
-        op = Op(name, input_shapes_and_constants)
-        if op.unique_key() not in self.compiler_config.unique_ops:
-            self.compiler_config.unique_ops[op.unique_key()] = op
-        else:
-            self.compiler_config.unique_ops[op.unique_key()].num_ops += 1
-            return None, None
-
-        graph = torch.fx.Graph()
-        placeholders = []
-        for inp in inputs:
-            if isinstance(inp, torch.Tensor):
-                placeholders.append(graph.placeholder("input"))
-            elif isinstance(inp, (list, tuple)):
-                inps = torch.fx.immutable_collections.immutable_list(
-                    [
-                        graph.placeholder(f"input_{idx}")
-                        if isinstance(sub_inp, torch.Tensor)
-                        else sub_inp
-                        for idx, sub_inp in enumerate(inp)
-                    ]
-                )
-                placeholders.append(inps)
-            else:
-                placeholders.append(inp)
-
-        if len(placeholders) != len(node.args):
-            # are any of the args duplicates? If so, we need to duplicate the placeholders
-            for idx, arg in enumerate(node.args):
-                if arg in node.args[idx + 1 :]:
-                    placeholders.append(placeholders[idx])
-
-        placeholders = tuple(placeholders)
-        for placeholder, arg in zip(placeholders, node.args):
-            if isinstance(placeholder, torch.fx.node.Node):
-                placeholder.meta["tensor_meta"] = arg.meta["tensor_meta"]
-            elif isinstance(placeholder, (list, tuple)):
-                for sub_placeholder, sub_arg in zip(placeholder, arg):
-                    if isinstance(sub_placeholder, torch.fx.node.Node):
-                        sub_placeholder.meta["tensor_meta"] = sub_arg.meta[
-                            "tensor_meta"
-                        ]
-
-        graph_node = graph.call_function(node.target, placeholders, kwargs)
-        graph_node.meta["tensor_meta"] = node.meta["tensor_meta"]
-
-        # if the node has multiple outputs, add a getitem for each and append to graph
-        if not isinstance(
-            node.meta["tensor_meta"], torch.fx.passes.shape_prop.TensorMetadata
-        ):
-            getitem_nodes = []
-            graph_node.meta["val"] = node.meta["val"]
-
-            for idx, tensor_meta in enumerate(node.meta["tensor_meta"]):
-                # filter out unused outputs that do not exist in the reduced graph
-                users = self.gm.graph.find_nodes(
-                    op="call_function", target=operator.getitem
-                )
-                if not any(user_node.args == (node, idx) for user_node in users):
-                    continue
-
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(graph_node, idx)
-                )
-                getitem_nodes.append(getitem_node)
-                getitem_node.meta["tensor_meta"] = tensor_meta
-            out = graph.output(tuple(getitem_nodes))
-            if len(node.users) != len(graph_node.users):
-                raise ValueError(
-                    f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
-                )
-        else:
-            out = graph.output((graph_node,))
-        if "tensor_meta" not in node.meta:
-            raise ValueError(f"Node {node} does not have tensor_meta")
-
-        op.compilation_status = OpCompilationStatus.CREATED_GRAPH
-        out.meta["tensor_meta"] = node.meta["tensor_meta"]
-
-        out_meta = out.meta["tensor_meta"]
-        if isinstance(out_meta, torch.fx.passes.shape_prop.TensorMetadata):
-            out_meta = (out_meta,)
-        for out in out_meta:
-            op.output_shapes.append([dim for dim in out.shape])
-
-        module = import_graph(graph)
-        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_IR
-        op.add_torch_ir_graph(module.operation.get_asm())
-        lower_to_stable_hlo(module, op=op)
-        op.add_stable_hlo_graph(module.operation.get_asm())
-
-        sender = mp.Queue()
-        receiver = mp.Queue()
-        ttir_event = mp.Event()
-        ttnn_event = mp.Event()
-        obj = {"asm": module.operation.get_asm()}
-        process = mp.Process(
-            target=compile_process, args=(sender, receiver, ttir_event, ttnn_event)
-        )
-        process.start()
-        sender.put(obj)
-        start = time.time()
-        binary = None
-        while True:
-            try:
-                result = receiver.get_nowait()
-                if "ttir" in result:
-                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTIR
-                    op.add_ttir_graph(result["ttir"])
-                    ttir_event.set()
-                if "binary" in result:
-                    binary = result["binary"]
-                    op.binary = binary
-                    op.json = tt_mlir.bytestream_to_json(binary)
-                    op.add_ttnn_graph(result["ttnn"])
-                    ttnn_event.set()
-                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
-                    break
-            except mp.queues.Empty:
-                pass
-            except Exception as e:
-                process.terminate()
-                raise e
-            if time.time() - start > self.compiler_config.single_op_timeout:
-                process.terminate()
-                break
-            if not process.is_alive():
-                break
-            time.sleep(0.01)
-        process.join()
-        return binary, op
-
-    def pre_process_inputs(self, *inputs):
-        # Remove scalar constants as they're absorbed into the binary
-        # Convert torch.nn.Parameter to torch.Tensor
-        processed_inputs = []
-        for inp in inputs:
-            if isinstance(inp, torch.nn.Parameter):
-                processed_inputs.append(inp.data)
-            elif isinstance(inp, torch.Tensor):
-                processed_inputs.append(inp)
-
-        return processed_inputs
-
-    def run_op(self, binary, *inputs):
-        inputs = self.pre_process_inputs(*inputs)
-        sender = mp.Queue()
-        receiver = mp.Queue()
-        obj = {"binary": binary, "inputs": inputs}
-
-        f_stderr = tempfile.TemporaryFile(mode="w+t")
-        old_stderr = sys.stderr
-        sys.stderr = f_stderr
-
-        exec_event = mp.Event()
-        process = mp.Process(
-            target=execute_process, args=(sender, receiver, exec_event)
-        )
-        process.start()
-        sender.put(obj)
-        result = {}
-        start = time.time()
-        outputs = [None]
-        while True:
-            if not process.is_alive():
-                break
-            try:
-                result = receiver.get_nowait()
-                outputs = result["outputs"]
-                exec_event.set()
-                break
-            except mp.queues.Empty:
-                pass
-            if time.time() - start > self.compiler_config.single_op_timeout:
-                process.terminate()
-                print("Timeout")
-                break
-            time.sleep(0.05)
-        process.join()
-        if len(outputs) == 1:
-            outputs = outputs[0]
-
-        sys.stderr = old_stderr
-        stderr_data = ""
-        if outputs is None:
-            f_stderr.seek(0)
-            stderr_data = f_stderr.read()
-            stderr_data = stderr_data.replace("\n", "\\n")
-            stderr_data = re.sub(r"[^\x20-\x7E]", "", stderr_data)
-        f_stderr.close()
-
-        return outputs, stderr_data
-
-    def run_gm_op_by_op(self, *inputs):
-        node_to_tensor = {}
-        input_index = 0
-        outputs = []
-        num_nodes = len(self.gm.graph.nodes)
-        out_degree = {}
-        for idx, node in enumerate(self.gm.graph.nodes):
-            print(f"Compiling {idx}/{num_nodes}: {node.target}")
-            out_degree[node] = len(node.users)
-            if node.op == "placeholder":
-                node_to_tensor[node] = inputs[input_index]
-                input_index += 1
-            elif node.op == "get_attr":
-                for buffer in self.gm.named_buffers():
-                    if buffer[0] == node.target:
-                        node_to_tensor[node] = buffer[1]
-                        break
-            elif node.op == "call_function":
-                args = []
-                for arg in node.args:
-                    if isinstance(arg, torch.fx.node.Node):
-                        args.append(node_to_tensor[arg])
-                    elif isinstance(arg, list):
-                        args.append(
-                            [
-                                node_to_tensor[a]
-                                if isinstance(a, torch.fx.node.Node)
-                                else a
-                                for a in arg
-                            ]
-                        )
-                    else:
-                        args.append(arg)
-                try:
-                    binary, op = self.compile_op(node, *args, **node.kwargs)
-                except Exception as e:
-                    binary = None
-                    print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
-
-                if (
-                    self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
-                    and binary is not None
-                ):
-                    try:
-                        calculated, runtime_stack_dump = self.run_op(binary, *args)
-                        self.compiler_config.unique_ops[
-                            op.unique_key()
-                        ].runtime_stack_dump = runtime_stack_dump
-
-                        print(f"Ran: {idx}/{num_nodes}: {node.target}")
-                        if calculated is None:
-                            raise ValueError("Failed to execute")
-                        op.compilation_status = OpCompilationStatus.EXECUTED
-                        tensor = node.target(*args, **node.kwargs)
-                        if self.compiler_config.enable_intermediate_verification:
-                            atol = calculate_atol(calculated, tensor)
-                            op.atol = atol
-                            if atol > self.required_atol:
-                                print(f"atol too high for {idx}: {atol}")
-                            pcc = calculate_pcc(calculated, tensor)
-                            op.pcc = pcc
-                            if pcc < self.required_pcc:
-                                print(f"pcc too low for {idx}: {pcc}")
-                    except Exception as e:
-                        print(
-                            f"Failed to execute {idx}/{num_nodes}: {node.target}: {e}"
-                        )
-                        tensor = node.target(*args, **node.kwargs)
-                else:
-                    tensor = node.target(*args, **node.kwargs)
-                node_to_tensor[node] = tensor
-            elif node.op == "output":
-                args = node.args[0]
-                output_tensors = [node_to_tensor[arg] for arg in args]
-                outputs = output_tensors
-            args_set = set()
-            for arg in node.args:
-                if arg in args_set:
-                    continue
-                args_set.add(arg)
-                if isinstance(arg, torch.fx.node.Node):
-                    out_degree[arg] -= 1
-                    if out_degree[arg] == 0 and arg.op != "output":
-                        del node_to_tensor[arg]
-                        out_degree.pop(arg)
-
-        self.compiler_config.save_unique_ops()
-        return outputs
-
-    def __call__(self, *inputs):
-        new_inputs = ()
-        for input in inputs:
-            # Handle scalar inputs.
-            if not hasattr(input, "dtype"):
-                assert (
-                    type(input) is not bool
-                ), "Conversion for scalar boolean is not supported."
-                new_inputs = new_inputs + ((input),)
-                continue
-
-            # Apply type conversion if required.
-            input_type = input.dtype
-            if input_type in self.type_conversion.keys():
-                new_inputs = new_inputs + (
-                    (input.to(dtype=self.type_conversion[input_type])),
-                )
-                continue
-
-            # No conversion required.
-            new_inputs = new_inputs + ((input),)
-
-        inputs = new_inputs
-
-        if self.compiler_config.compile_depth == CompileDepth.EXECUTE:
-            assert self.binary is not None, "Binary must be set for EXECUTE mode"
-            return tt_mlir.run(inputs + self.graph_constants, self.binary)
-        elif self.compiler_config.compile_depth in (
-            CompileDepth.EXECUTE_OP_BY_OP,
-            CompileDepth.COMPILE_OP_BY_OP,
-        ):
-            return self.run_gm_op_by_op(*(inputs + self.graph_constants))
-        else:
-            return self.gm(*inputs)
+def _shlo_backend(module_str, options=None):
+    if options is None:
+        options = CompilerConfig()
+    options.graph_type = "STABLEHLO"
+    executor = StableHLOExecutor(module_str, compiler_config=options)
+    executor()
+    return executor
 
 
 def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
@@ -459,7 +46,7 @@ def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     compiler_config.apply_environment_overrides()
     with torch.no_grad():
         gm, graph_constants = pass_pipeline(gm, example_inputs, compiler_config)
-    executor = Executor(gm, graph_constants, compiler_config)
+    executor = TorchFXExecutor(gm, graph_constants, compiler_config)
     if compiler_config.compile_depth in (
         CompileDepth.EXECUTE_OP_BY_OP,
         CompileDepth.COMPILE_OP_BY_OP,
@@ -506,18 +93,27 @@ def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     return executor
 
 
-def backend(gm, example_inputs, options=None):
+def backend(gm_or_module, example_inputs, options=None):
     if options is None:
         options = CompilerConfig()
-
-    concrete_inputs = [
-        x.view(x.shape) if isinstance(x, torch.Tensor) else x for x in example_inputs
-    ]
-    # fake_tensor_mode = torch._dynamo.utils.detect_fake_mode(example_inputs)
-    # fake_tensor_mode.allow_non_fake_inputs = True
-    # aten = make_fx(gm, tracing_mode="symbolic", decomposition_table={}, _allow_non_fake_inputs=True)(*example_inputs)
-    # return _base_backend(aten, example_inputs)
-    return _base_backend(gm, example_inputs, compiler_config=options)
+    if options.compiler_front_end == FrontEnd.STABLEHLO:
+        if not isinstance(gm_or_module, str):
+            exit(1)
+        return _shlo_backend(gm_or_module, options)
+    return _base_backend(gm_or_module, example_inputs, compiler_config=options)
 
 
-# backend = aot_autograd(fw_compiler=_base_backend)
+MODULE_STRING = """
+module {
+  func.func @main(%arg0: tensor<1x128xf32>, %arg1: tensor<128xf32>) -> tensor<1x128xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<1x128xf32>) -> tensor<1x128xf32>
+    %1 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<128xf32>) -> tensor<1x128xf32>
+    %2 = stablehlo.add %0, %1 : tensor<1x128xf32>
+    return %2 : tensor<1x128xf32>
+  }
+}
+"""
+compiler_config = CompilerConfig()
+compiler_config.compiler_front_end = FrontEnd.STABLEHLO
+compiler_config.compile_depth = CompileDepth.COMPILE_OP_BY_OP
+backend(MODULE_STRING, None, compiler_config)

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import mlir
+import tt_mlir
+from mlir.ir import Context, Location, Module
+import numpy as np
+import multiprocessing as mp
+import time
+import sys
+import tempfile
+import re
+import os
+import mlir.dialects.stablehlo as stablehlo
+
+from tt_torch.tools.utils import (
+    CompilerConfig,
+    CompileDepth,
+    Op,
+    OpCompilationStatus,
+    calculate_atol,
+    calculate_pcc,
+)
+
+
+def parse_module_from_str(module_str: str):
+    module = None
+    with Context() as ctx:
+        stablehlo.register_dialect(ctx)
+        module = Module.parse(module_str)
+    return module
+
+
+class StableHLOOp:
+    def __init__(self, op_id, shlo, original_shlo):
+        self.op_id = op_id
+        self.original_shlo = original_shlo
+        self.shlo = shlo
+        self.binary = ""
+        self.ttir = ""
+        self.ttnn = ""
+        self.pcc = None
+        self.atol = None
+        self.compilation_status = OpCompilationStatus.CONVERTED_TO_STABLE_HLO
+
+    def add_ttir_graph(self, ttir):
+        self.ttir = ttir
+
+    def add_ttnn_graph(self, ttnn):
+        self.ttnn = ttnn
+
+    def __str__(self):
+        return (
+            f"StableHLOOp(op_id={self.op_id}, \nshlo=\n{self.shlo},"
+            f"\noriginal_shlo=\n{self.original_shlo}, \nttir=\n{self.ttir}, \nttnn=\n{self.ttnn},"
+            f"\npcc={self.pcc}, \natol={self.atol},"
+            f"\ncompilation_status={self.compilation_status})"
+        )
+
+
+class StableHLOExecutor:
+    def __init__(
+        self, module_str, compiler_config=None, required_pcc=0.99, required_atol=1e-2
+    ):
+        self.module_str = module_str
+        self.parsed_module = parse_module_from_str(module_str)
+        self.binary = None
+        self.compiler_config = compiler_config or CompilerConfig()
+        self.required_pcc = required_pcc
+        self.required_atol = required_atol
+        self.sub_modules = []
+        self.get_ops_in_module(self.parsed_module)
+
+    def get_ops_in_module(self, module):
+        for func_op in module.body.operations:
+            for block in func_op.regions[0].blocks:
+                for op in block.operations:
+                    if op.name.startswith(("func.", "return")):
+                        continue
+                    if op.name in ["stablehlo.pad", "stablehlo.reduce_window"]:
+                        continue
+
+                    inputs = {
+                        operand.get_name(): str(operand.type) for operand in op.operands
+                    }
+                    args_str = ", ".join(f"{key}: {typ}" for key, typ in inputs.items())
+                    result_type = str(op.result.type)
+                    result_name = str(op.result.get_name())
+
+                    new_module_str = f"""module {{
+    func.func @main({args_str}) -> {result_type} {{
+        {str(op)}
+        return {result_name} : {result_type}
+    }}
+}}"""
+                    op_obj = StableHLOOp(result_name, new_module_str, op)
+                    op_obj.pcc = self.required_pcc
+                    op_obj.atol = self.required_atol
+                    self.sub_modules.append(op_obj)
+
+    def compile_process(self, asm):
+        ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
+        binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
+        return ttir, binary, ttnn
+
+    def compile_op(self, op):
+        parsed = parse_module_from_str(op.shlo)
+        asm = parsed.operation.get_asm()
+
+        ttir, binary, ttnn = self.compile_process(asm)
+
+        op.add_ttir_graph(ttir)
+        op.add_ttnn_graph(ttnn)
+        op.binary = binary
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
+        return
+
+    def compile_op_by_op(self):
+        for op in self.sub_modules:
+            try:
+                self.compile_op(op)
+            except Exception as e:
+                print(f"Error in compiling op {op.op_id}: {e}")
+
+    def print_graph(self):
+        for op in self.sub_modules:
+            print(f"Running: {op.op_id}\n\n\n")
+            print(op)
+            print("\n\n\n")
+
+    def __call__(self, *inputs):
+        if (
+            self.compiler_config.compile_depth == CompileDepth.EXECUTE
+            or self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+        ):
+            print("Execution not supported for StableHLO")
+            exit(1)
+
+        elif self.compiler_config.compile_depth == CompileDepth.COMPILE_OP_BY_OP:
+            print("Ok")
+            self.compile_op_by_op()
+            self.print_graph()
+            return
+
+        else:
+            raise ValueError("Unsupported compilation depth")

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -1,0 +1,431 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import operator
+import multiprocessing as mp
+import time
+import faulthandler
+import re
+import sys
+import tempfile
+import tt_mlir
+
+from typing import List, Tuple, Union
+from tt_torch.tools.utils import (
+    CompilerConfig,
+    CompileDepth,
+    Op,
+    OpCompilationStatus,
+    calculate_atol,
+    calculate_pcc,
+)
+from torch_mlir.ir import Context
+from torch_mlir.extras.fx_importer import FxImporter
+from torch_mlir.dialects import torch as torch_dialect
+from torch_mlir.compiler_utils import (
+    OutputType,
+    run_pipeline_with_repro_report,
+    lower_mlir_module,
+)
+
+
+def import_graph(graph: torch.fx.GraphModule):
+    context = Context()
+    torch_dialect.register_dialect(context)
+    importer = FxImporter(context=context)
+    importer.import_stateless_graph(graph)
+    return importer.module
+
+
+def compile_process(receiver, sender, ttir_event, ttnn_event):
+    obj = receiver.get()
+    faulthandler.disable()
+    asm = obj["asm"]
+    ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
+    sender.put({"ttir": ttir})
+    ttir_event.wait()
+    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
+    sender.put({"binary": binary, "ttnn": ttnn})
+    ttnn_event.wait()
+    sys.exit(0)
+
+
+def execute_process(receiver, sender, exec_event):
+    obj = receiver.get()
+    faulthandler.disable()
+    binary = obj["binary"]
+    inputs = obj["inputs"]
+    outputs = tt_mlir.run(inputs, binary)
+    sender.put({"outputs": outputs})
+    exec_event.wait()
+    sys.exit(0)
+
+
+class TorchFXExecutor:
+    def __init__(
+        self,
+        gm,
+        graph_constants,
+        compiler_config=None,
+        required_pcc=0.99,
+        required_atol=1e-2,
+    ):
+        self.gm = gm
+        self.binary = None
+        self.graph_constants = tuple(graph_constants)
+        if compiler_config is None:
+            compiler_config = CompilerConfig()
+        self.compiler_config = compiler_config
+        self.required_atol = required_atol
+        self.required_pcc = required_pcc
+        # Dictionary to keep track of the type conversion for unsupported hardware
+        # types and use it to convert the input arguments to supported types.
+        self.type_conversion = {torch.bool: torch.bfloat16}
+
+    def set_binary(self, binary):
+        self.binary = binary
+
+    def compile_op(self, node, *inputs, **kwargs):
+        input_shapes_and_constants = []
+        for inp in inputs:
+            if isinstance(inp, torch.Tensor):
+                input_shapes_and_constants.append(inp.shape)
+            elif isinstance(inp, (list, tuple)):
+                sub = []
+                for sub_inp in inp:
+                    if isinstance(sub_inp, torch.Tensor):
+                        sub.append(sub_inp.shape)
+                    else:
+                        sub.append(sub_inp)
+                input_shapes_and_constants.append(sub)
+            elif isinstance(inp, (int, float, bool)):
+                input_shapes_and_constants.append(inp)
+            elif isinstance(inp, torch.dtype):
+                input_shapes_and_constants.append(inp.__str__())
+            elif inp is None:
+                input_shapes_and_constants.append(None)
+            else:
+                raise ValueError(f"Unexpected input type: {type(inp)}")
+
+        name = node.target.name() if hasattr(node.target, "name") else node.name
+        if not isinstance(node.target, torch._ops.OpOverload):
+            if "getitem" not in name:
+                raise ValueError(f"Node target is not an OpOverload: {name}")
+            return None, None
+
+        op = Op(name, input_shapes_and_constants)
+        if op.unique_key() not in self.compiler_config.unique_ops:
+            self.compiler_config.unique_ops[op.unique_key()] = op
+        else:
+            self.compiler_config.unique_ops[op.unique_key()].num_ops += 1
+            return None, None
+
+        graph = torch.fx.Graph()
+        placeholders = []
+        for inp in inputs:
+            if isinstance(inp, torch.Tensor):
+                placeholders.append(graph.placeholder("input"))
+            elif isinstance(inp, (list, tuple)):
+                inps = torch.fx.immutable_collections.immutable_list(
+                    [
+                        graph.placeholder(f"input_{idx}")
+                        if isinstance(sub_inp, torch.Tensor)
+                        else sub_inp
+                        for idx, sub_inp in enumerate(inp)
+                    ]
+                )
+                placeholders.append(inps)
+            else:
+                placeholders.append(inp)
+
+        if len(placeholders) != len(node.args):
+            # are any of the args duplicates? If so, we need to duplicate the placeholders
+            for idx, arg in enumerate(node.args):
+                if arg in node.args[idx + 1 :]:
+                    placeholders.append(placeholders[idx])
+
+        placeholders = tuple(placeholders)
+        for placeholder, arg in zip(placeholders, node.args):
+            if isinstance(placeholder, torch.fx.node.Node):
+                placeholder.meta["tensor_meta"] = arg.meta["tensor_meta"]
+            elif isinstance(placeholder, (list, tuple)):
+                for sub_placeholder, sub_arg in zip(placeholder, arg):
+                    if isinstance(sub_placeholder, torch.fx.node.Node):
+                        sub_placeholder.meta["tensor_meta"] = sub_arg.meta[
+                            "tensor_meta"
+                        ]
+
+        graph_node = graph.call_function(node.target, placeholders, kwargs)
+        graph_node.meta["tensor_meta"] = node.meta["tensor_meta"]
+
+        # if the node has multiple outputs, add a getitem for each and append to graph
+        if not isinstance(
+            node.meta["tensor_meta"], torch.fx.passes.shape_prop.TensorMetadata
+        ):
+            getitem_nodes = []
+            graph_node.meta["val"] = node.meta["val"]
+
+            for idx, tensor_meta in enumerate(node.meta["tensor_meta"]):
+                # filter out unused outputs that do not exist in the reduced graph
+                users = self.gm.graph.find_nodes(
+                    op="call_function", target=operator.getitem
+                )
+                if not any(user_node.args == (node, idx) for user_node in users):
+                    continue
+
+                getitem_node = graph.call_function(
+                    operator.getitem, args=(graph_node, idx)
+                )
+                getitem_nodes.append(getitem_node)
+                getitem_node.meta["tensor_meta"] = tensor_meta
+            out = graph.output(tuple(getitem_nodes))
+            if len(node.users) != len(graph_node.users):
+                raise ValueError(
+                    f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
+                )
+        else:
+            out = graph.output((graph_node,))
+        if "tensor_meta" not in node.meta:
+            raise ValueError(f"Node {node} does not have tensor_meta")
+
+        op.compilation_status = OpCompilationStatus.CREATED_GRAPH
+        out.meta["tensor_meta"] = node.meta["tensor_meta"]
+
+        out_meta = out.meta["tensor_meta"]
+        if isinstance(out_meta, torch.fx.passes.shape_prop.TensorMetadata):
+            out_meta = (out_meta,)
+        for out in out_meta:
+            op.output_shapes.append([dim for dim in out.shape])
+
+        module = import_graph(graph)
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_IR
+        op.add_torch_ir_graph(module.operation.get_asm())
+        lower_to_stable_hlo(module, op=op)
+        op.add_stable_hlo_graph(module.operation.get_asm())
+
+        sender = mp.Queue()
+        receiver = mp.Queue()
+        ttir_event = mp.Event()
+        ttnn_event = mp.Event()
+        obj = {"asm": module.operation.get_asm()}
+        process = mp.Process(
+            target=compile_process, args=(sender, receiver, ttir_event, ttnn_event)
+        )
+        process.start()
+        sender.put(obj)
+        start = time.time()
+        binary = None
+        while True:
+            try:
+                result = receiver.get_nowait()
+                if "ttir" in result:
+                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTIR
+                    op.add_ttir_graph(result["ttir"])
+                    ttir_event.set()
+                if "binary" in result:
+                    binary = result["binary"]
+                    op.binary = binary
+                    op.json = tt_mlir.bytestream_to_json(binary)
+                    op.add_ttnn_graph(result["ttnn"])
+                    ttnn_event.set()
+                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
+                    break
+            except mp.queues.Empty:
+                pass
+            except Exception as e:
+                process.terminate()
+                raise e
+            if time.time() - start > self.compiler_config.single_op_timeout:
+                process.terminate()
+                break
+            if not process.is_alive():
+                break
+            time.sleep(0.01)
+        process.join()
+        return binary, op
+
+    def pre_process_inputs(self, *inputs):
+        # Remove scalar constants as they're absorbed into the binary
+        # Convert torch.nn.Parameter to torch.Tensor
+        processed_inputs = []
+        for inp in inputs:
+            if isinstance(inp, torch.nn.Parameter):
+                processed_inputs.append(inp.data)
+            elif isinstance(inp, torch.Tensor):
+                processed_inputs.append(inp)
+
+        return processed_inputs
+
+    def run_op(self, binary, *inputs):
+        inputs = self.pre_process_inputs(*inputs)
+        sender = mp.Queue()
+        receiver = mp.Queue()
+        obj = {"binary": binary, "inputs": inputs}
+
+        f_stderr = tempfile.TemporaryFile(mode="w+t")
+        old_stderr = sys.stderr
+        sys.stderr = f_stderr
+
+        exec_event = mp.Event()
+        process = mp.Process(
+            target=execute_process, args=(sender, receiver, exec_event)
+        )
+        process.start()
+        sender.put(obj)
+        result = {}
+        start = time.time()
+        outputs = [None]
+        while True:
+            if not process.is_alive():
+                break
+            try:
+                result = receiver.get_nowait()
+                outputs = result["outputs"]
+                exec_event.set()
+                break
+            except mp.queues.Empty:
+                pass
+            if time.time() - start > self.compiler_config.single_op_timeout:
+                process.terminate()
+                print("Timeout")
+                break
+            time.sleep(0.05)
+        process.join()
+        if len(outputs) == 1:
+            outputs = outputs[0]
+
+        sys.stderr = old_stderr
+        stderr_data = ""
+        if outputs is None:
+            f_stderr.seek(0)
+            stderr_data = f_stderr.read()
+            stderr_data = stderr_data.replace("\n", "\\n")
+            stderr_data = re.sub(r"[^\x20-\x7E]", "", stderr_data)
+        f_stderr.close()
+
+        return outputs, stderr_data
+
+    def run_gm_op_by_op(self, *inputs):
+        node_to_tensor = {}
+        input_index = 0
+        outputs = []
+        num_nodes = len(self.gm.graph.nodes)
+        out_degree = {}
+        for idx, node in enumerate(self.gm.graph.nodes):
+            print(f"Compiling {idx}/{num_nodes}: {node.target}")
+            out_degree[node] = len(node.users)
+            if node.op == "placeholder":
+                node_to_tensor[node] = inputs[input_index]
+                input_index += 1
+            elif node.op == "get_attr":
+                for buffer in self.gm.named_buffers():
+                    if buffer[0] == node.target:
+                        node_to_tensor[node] = buffer[1]
+                        break
+            elif node.op == "call_function":
+                args = []
+                for arg in node.args:
+                    if isinstance(arg, torch.fx.node.Node):
+                        args.append(node_to_tensor[arg])
+                    elif isinstance(arg, list):
+                        args.append(
+                            [
+                                node_to_tensor[a]
+                                if isinstance(a, torch.fx.node.Node)
+                                else a
+                                for a in arg
+                            ]
+                        )
+                    else:
+                        args.append(arg)
+                try:
+                    binary, op = self.compile_op(node, *args, **node.kwargs)
+                except Exception as e:
+                    binary = None
+                    print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
+
+                if (
+                    self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+                    and binary is not None
+                ):
+                    try:
+                        calculated, runtime_stack_dump = self.run_op(binary, *args)
+                        self.compiler_config.unique_ops[
+                            op.unique_key()
+                        ].runtime_stack_dump = runtime_stack_dump
+
+                        print(f"Ran: {idx}/{num_nodes}: {node.target}")
+                        if calculated is None:
+                            raise ValueError("Failed to execute")
+                        op.compilation_status = OpCompilationStatus.EXECUTED
+                        tensor = node.target(*args, **node.kwargs)
+                        if self.compiler_config.enable_intermediate_verification:
+                            atol = calculate_atol(calculated, tensor)
+                            op.atol = atol
+                            if atol > self.required_atol:
+                                print(f"atol too high for {idx}: {atol}")
+                            pcc = calculate_pcc(calculated, tensor)
+                            op.pcc = pcc
+                            if pcc < self.required_pcc:
+                                print(f"pcc too low for {idx}: {pcc}")
+                    except Exception as e:
+                        print(
+                            f"Failed to execute {idx}/{num_nodes}: {node.target}: {e}"
+                        )
+                        tensor = node.target(*args, **node.kwargs)
+                else:
+                    tensor = node.target(*args, **node.kwargs)
+                node_to_tensor[node] = tensor
+            elif node.op == "output":
+                args = node.args[0]
+                output_tensors = [node_to_tensor[arg] for arg in args]
+                outputs = output_tensors
+            args_set = set()
+            for arg in node.args:
+                if arg in args_set:
+                    continue
+                args_set.add(arg)
+                if isinstance(arg, torch.fx.node.Node):
+                    out_degree[arg] -= 1
+                    if out_degree[arg] == 0 and arg.op != "output":
+                        del node_to_tensor[arg]
+                        out_degree.pop(arg)
+
+        self.compiler_config.save_unique_ops()
+        return outputs
+
+    def __call__(self, *inputs):
+        new_inputs = ()
+        for input in inputs:
+            # Handle scalar inputs.
+            if not hasattr(input, "dtype"):
+                assert (
+                    type(input) is not bool
+                ), "Conversion for scalar boolean is not supported."
+                new_inputs = new_inputs + ((input),)
+                continue
+
+            # Apply type conversion if required.
+            input_type = input.dtype
+            if input_type in self.type_conversion.keys():
+                new_inputs = new_inputs + (
+                    (input.to(dtype=self.type_conversion[input_type])),
+                )
+                continue
+
+            # No conversion required.
+            new_inputs = new_inputs + ((input),)
+
+        inputs = new_inputs
+
+        if self.compiler_config.compile_depth == CompileDepth.EXECUTE:
+            assert self.binary is not None, "Binary must be set for EXECUTE mode"
+            return tt_mlir.run(inputs + self.graph_constants, self.binary)
+        elif self.compiler_config.compile_depth in (
+            CompileDepth.EXECUTE_OP_BY_OP,
+            CompileDepth.COMPILE_OP_BY_OP,
+        ):
+            return self.run_gm_op_by_op(*(inputs + self.graph_constants))
+        else:
+            return self.gm(*inputs)

--- a/tt_torch/shlo_compile/shlo_compile.py
+++ b/tt_torch/shlo_compile/shlo_compile.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+### PRE-REQUISITES
+#   pip install --pre torch-mlir torchvision
+#   pip install stablehlo -f https://github.com/openxla/stablehlo/releases/expanded_assets/dev-wheels
+
+import mlir
+import tt_mlir
+import mlir.ir as ir
+from mlir.ir import Context, Location, Module
+import mlir.dialects.stablehlo as stablehlo
+import mlir.execution_engine as ex
+import numpy as np
+
+
+def parse_module_from_str(module_str: str):
+    module = None
+    with ir.Context() as ctx:
+        stablehlo.register_dialect(ctx)
+        module = Module.parse(module_str)
+    return module
+
+
+class StableHLOOp:
+    def __init__(self, op_id, shlo):
+        self.op_id = op_id
+        self.shlo = shlo
+        self.result = None
+        self.ttir = ""
+        self.ttnn = ""
+
+
+class ShloCompiler:
+    def __init__(self, top_level_module_str):
+        self.top_level_module_str = top_level_module_str
+        self.parsed_top_level = parse_module_from_str(self.top_level_module_str)
+        self.sub_modules = []
+        self.get_ops_in_module(self.parsed_top_level)
+
+    def get_ops_in_module(self, module: mlir.ir.Module):
+        # Iterate through all functions in the module
+        for func_op in module.body.operations:
+            for block in func_op.regions[0].blocks:
+                for op in block.operations:
+                    inputs = {}
+                    result_type = None
+                    if not op.name.startswith(("func.", "return")):
+                        if (
+                            op.name == "stablehlo.pad"
+                            or op.name == "stablehlo.reduce_window"
+                        ):
+                            continue
+                        for operand in op.operands:
+                            inputs[operand.get_name()] = str(operand.type)
+                        args_str = ", ".join(
+                            f"{key}: {typ}" for key, typ in inputs.items()
+                        )
+                        result_type = str(
+                            op.result.type
+                        )  # assuming there is only one return value
+                        result_name = str(op.result.get_name())
+                        new_module_str = f"""module {{ \n\tfunc.func @main({args_str}) -> {result_type} {{ \n\t\t{str(op)} \n\t\treturn {result_name} : {result_type} \n\t}} \n}}"""
+                        shlo_op = StableHLOOp(result_name, new_module_str)
+                        self.sub_modules.append(shlo_op)
+
+    def compile(self):
+        for shlo_op in self.sub_modules:
+            parsed = parse_module_from_str(shlo_op.shlo)
+            try:
+                shlo_op.ttir = tt_mlir.compile_stable_hlo_to_ttir(
+                    parsed.operation.get_asm()
+                )
+                __, shlo_op.ttnn = tt_mlir.compile_ttir_to_bytestream(shlo_op.ttir)
+            except:
+                print("Error in compilation")
+                with ir.Context() as ctx:
+                    stablehlo.register_dialect(ctx)
+                    module = parse_module_from_str(shlo_op.shlo)
+                    print(module)
+                    print(module.operation.get_asm())
+
+
+mlir_code = """
+module {
+  func.func @main(%arg0: tensor<1x128xf32>, %arg1: tensor<128xf32>) -> tensor<1x128xf32> {
+    %0 = stablehlo.broadcast_in_dim %arg0, dims = [0, 1] : (tensor<1x128xf32>) -> tensor<1x128xf32>
+    %1 = stablehlo.broadcast_in_dim %arg1, dims = [1] : (tensor<128xf32>) -> tensor<1x128xf32>
+    %2 = stablehlo.add %0, %1 : tensor<1x128xf32>
+    return %2 : tensor<1x128xf32>
+  }
+}
+"""
+shlo_compiler = ShloCompiler(mlir_code)
+shlo_compiler.compile()
+for shlo_op in shlo_compiler.sub_modules:
+    print(f"Op: {shlo_op.op_id}")
+    print(f"TTIR: {shlo_op.ttir}")
+    print(f"TTNN: {shlo_op.ttnn}")
+    print("\n")
+
+
+MODULE_STRING = """
+module {
+  func.func @main(%arg0: tensor<1xf32>, %arg1: tensor<1xf32>) -> tensor<1xf32> {
+    %0 = stablehlo.add %arg0, %arg1 : tensor<1xf32>
+    return %0 : tensor<1xf32>
+  }
+}
+"""
+module = parse_module_from_str(MODULE_STRING)
+with ir.Context() as ctx:
+    with ex.ExecutionEngine(module) as engine:
+        arg0 = np.array([3.0], dtype=np.float32)  # Example input
+        arg1 = np.array([2.0], dtype=np.float32)  # Example bias
+
+#         # Create a list of inputs
+#         inputs = [arg0, arg1]
+
+#         # Execute the function 'main' with the provided inputs
+#         result = engine.invoke("main", *inputs)
+
+#         print("Output:")
+#         print(result)

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -22,13 +22,6 @@ class CompileDepth(Enum):
     EXECUTE = 7
 
 
-class FrontEnd(Enum):
-    TORCH_FX = 1
-    TORCH_MLIR = 2
-    STABLEHLO = 3
-    TTNN_IR = 4
-
-
 class OpCompilationStatus(IntEnum):
     NOT_STARTED = 0
     CREATED_GRAPH = 1
@@ -128,7 +121,6 @@ class Op:
 class CompilerConfig:
     def __init__(self):
         self.compile_depth = CompileDepth.EXECUTE
-        self.compiler_front_end = FrontEnd.TORCH_FX
         self.profile_ops = True
         self.torch_mlir_module = None
         self.stablehlo_mlir_module = None

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -22,6 +22,13 @@ class CompileDepth(Enum):
     EXECUTE = 7
 
 
+class FrontEnd(Enum):
+    TORCH_FX = 1
+    TORCH_MLIR = 2
+    STABLEHLO = 3
+    TTNN_IR = 4
+
+
 class OpCompilationStatus(IntEnum):
     NOT_STARTED = 0
     CREATED_GRAPH = 1
@@ -121,6 +128,7 @@ class Op:
 class CompilerConfig:
     def __init__(self):
         self.compile_depth = CompileDepth.EXECUTE
+        self.compiler_front_end = FrontEnd.TORCH_FX
         self.profile_ops = True
         self.torch_mlir_module = None
         self.stablehlo_mlir_module = None


### PR DESCRIPTION
Hi all,

This is a POC for incorporating the shlo op-by-op compiler to our existing backend. I would appreciate any and all inputs. 

- shlo compiler is based on `tt_torch/shlo_compile/shlo_compile.py` however, this file will not exist in the final draft
- `backend.py` only has calls to `_shlo_backend `or `_base_backend`, everything else is moved under torch_compile.py
- current `Op` class does not translate well with shlo compiler, so implemented an `StableHLOOp` Class which resembles it. 
- currently, we only support `COMPILE_OP_BY_OP`. As of writing, I realize I could also add `COMPILE` support but I want to know if we still want to divide shlo module into sub modules for each op if we follow that route.

Thank you.