### PR TITLE
Add support for OpModel pydantic model in downstream parser

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -13,6 +13,7 @@ from tt_torch.tools.utils import (
     CompilerConfig,
     CompileDepth,
     Op,
+    Tensor,
     OpCompilationStatus,
     calculate_atol,
     calculate_pcc,
@@ -162,7 +163,7 @@ class Executor:
                 raise ValueError(f"Node target is not an OpOverload: {name}")
             return None, None
 
-        op = Op(name, input_shapes_and_constants)
+        op = Op(name, input_shapes_and_constants, self.compiler_config.model_name)
         if op.unique_key() not in self.compiler_config.unique_ops:
             self.compiler_config.unique_ops[op.unique_key()] = op
         else:
@@ -278,6 +279,7 @@ class Executor:
                     op.add_ttnn_graph(result["ttnn"])
                     ttnn_event.set()
                     op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
+                    op.parse_json()
                     break
             except mp.queues.Empty:
                 pass

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -133,6 +133,7 @@ class Op:
 
         return {
             "framework_op_name": self.framework_op_name,
+            "torch_name": self.framework_op_name,  # For backward compatibility
             "frontend": self.frontend,
             "model_name": self.model_name,
             "input_shapes": self.print_shapes(self.input_shapes),


### PR DESCRIPTION
### Problem description
We want to switch to OpModel pydantic model in tt-github-actions. This PR should allow us to do that. 

