### PR TITLE
Switch to using TTMLIR dylib instead of static deps

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -63,7 +63,7 @@ else()
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON
-        BUILD_BYPRODUCTS 
+        BUILD_BYPRODUCTS
             ${TT_MLIR_COMPILER_LIBRARY_PATH} 
             ${TT_MLIR_RUNTIME_LIBRARY_PATH}
     )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON
         BUILD_BYPRODUCTS
-            ${TT_MLIR_COMPILER_LIBRARY_PATH} 
+            ${TT_MLIR_COMPILER_LIBRARY_PATH}
             ${TT_MLIR_RUNTIME_LIBRARY_PATH}
     )
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -42,8 +42,6 @@ else()
 
     include(ExternalProject)
     set(TT_MLIR_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIR.so)
-    set(TT_MLIR_SHLO_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/libTTMLIRStableHLOToTTIR.a)
-    set(TT_MLIR_PIPELINES_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/libMLIRTTIRPipelines.a)
     ExternalProject_Add(
         tt-mlir
         PREFIX ${TTTORCH_SOURCE_DIR}/third_party/tt-mlir
@@ -64,20 +62,12 @@ else()
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON
-        BUILD_BYPRODUCTS ${TT_MLIR_LIBRARY_PATH} ${TT_MLIR_SHLO_LIBRARY_PATH} ${TT_MLIR_PIPELINES_LIBRARY_PATH}
+        BUILD_BYPRODUCTS ${TT_MLIR_LIBRARY_PATH}
     )
 
     add_library(TTMLIRShared SHARED IMPORTED GLOBAL)
     set_target_properties(TTMLIRShared PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_LIBRARY_PATH})
     add_dependencies(TTMLIRShared tt-mlir)
-
-    add_library(TTMLIRStableHLOToTTIR STATIC IMPORTED GLOBAL)
-    set_target_properties(TTMLIRStableHLOToTTIR PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_SHLO_LIBRARY_PATH})
-    add_dependencies(TTMLIRStableHLOToTTIR tt-mlir)
-
-    add_library(MLIRTTIRPipelines STATIC IMPORTED GLOBAL)
-    set_target_properties(MLIRTTIRPipelines PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_PIPELINES_LIBRARY_PATH})
-    add_dependencies(MLIRTTIRPipelines tt-mlir)
 
     install(FILES ${TT_MLIR_LIBRARY_PATH} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "4e5447d8ae8635c6b7e25f163f4576fe0cdda3fb")
+set(TT_MLIR_VERSION "62517e0e97a923809fb7eeaed6ae31e59501bfd7")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "c0ac6ded06b60b09262e72e1430fd210816efcf6")
+set(TT_MLIR_VERSION "4e5447d8ae8635c6b7e25f163f4576fe0cdda3fb")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
@@ -41,7 +41,8 @@ else()
     endif()
 
     include(ExternalProject)
-    set(TT_MLIR_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIR.so)
+    set(TT_MLIR_COMPILER_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIRCompiler.so)
+    set(TT_MLIR_RUNTIME_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIRRuntime.so)
     ExternalProject_Add(
         tt-mlir
         PREFIX ${TTTORCH_SOURCE_DIR}/third_party/tt-mlir
@@ -65,10 +66,14 @@ else()
         BUILD_BYPRODUCTS ${TT_MLIR_LIBRARY_PATH}
     )
 
-    add_library(TTMLIRShared SHARED IMPORTED GLOBAL)
-    set_target_properties(TTMLIRShared PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_LIBRARY_PATH})
-    add_dependencies(TTMLIRShared tt-mlir)
+    add_library(TTMLIRCompiler SHARED IMPORTED GLOBAL)
+    set_target_properties(TTMLIRCompiler PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_COMPILER_LIBRARY_PATH})
+    add_dependencies(TTMLIRCompiler tt-mlir)
+    add_library(TTMLIRRuntime SHARED IMPORTED GLOBAL)
+    set_target_properties(TTMLIRRuntime PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TT_MLIR_RUNTIME_LIBRARY_PATH})
+    add_dependencies(TTMLIRRuntime tt-mlir)
 
-    install(FILES ${TT_MLIR_LIBRARY_PATH} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+    install(FILES ${TT_MLIR_COMPILER_LIBRARY_PATH} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+    install(FILES ${TT_MLIR_RUNTIME_LIBRARY_PATH} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "6eda280f3160a63cbdf327ff7f1729ba52ff220a")
+set(TT_MLIR_VERSION "c0ac6ded06b60b09262e72e1430fd210816efcf6")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -63,7 +63,9 @@ else()
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON
-        BUILD_BYPRODUCTS ${TT_MLIR_LIBRARY_PATH}
+        BUILD_BYPRODUCTS 
+            ${TT_MLIR_COMPILER_LIBRARY_PATH} 
+            ${TT_MLIR_RUNTIME_LIBRARY_PATH}
     )
 
     add_library(TTMLIRCompiler SHARED IMPORTED GLOBAL)

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -27,73 +27,10 @@ target_include_directories(TT_TORCH_MLIR PUBLIC
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/include
 )
 
-set(STABLEHLO_LIBS
-    StablehloBase
-    StablehloReferenceIndex
-    StablehloReferenceErrors
-    StablehloReferenceElement
-    StablehloReferenceAxes
-    StablehloReferenceValue
-    StablehloReferenceTypes
-    StablehloReferenceToken
-    StablehloReferenceTensor
-    StablehloReferenceScope
-    StablehloReferenceProcessGrid
-    StablehloReferenceProcess
-    StablehloReferenceOps
-    StablehloPasses
-    ChloOps
-    VhloOps
-    VhloTypes
-    StablehloOps
-    StablehloRegister
-    StablehloReferenceToken
-    StablehloLinalgTransforms
-    StablehloReferenceValue
-    StablehloReferenceScope
-    StablehloPasses
-    StablehloReferenceOps
-    StablehloSerialization
-    InterpreterOps
-    StablehloPortableApi
-    StablehloPasses
-    StablehloAssemblyFormat
-    StablehloOps
-    StablehloReferenceElement
-    StablehloReferenceOps
-    StablehloReferenceTensor
-    StablehloRegister
-    StablehloBase
-    StablehloPasses
-    StablehloReferenceErrors
-    StablehloReferenceProcess
-    StablehloReferenceToken
-    StablehloSerialization
-    StablehloBroadcastUtils
-    StablehloPortableApi
-    StablehloReferenceIndex
-    StablehloReferenceProcessGrid
-    StablehloReferenceTypes
-    StablehloTypeInference
-    StablehloLinalgTransforms
-    StablehloReferenceAxes
-    StablehloReferenceNumPy
-    StablehloReferenceScope
-    StablehloReferenceValue
-    SdyDialect
-    SdyRegister
-)
-
 target_link_libraries(TT_TORCH_MLIR PUBLIC
     LLVM
     MLIR
     TTMLIRShared
-    TTMLIRStatic
-    TTMLIRTosaToTTIR
-    TTMLIRTTIRToLinalg
-    MLIRTTIRPipelines
-    TTMLIRStableHLOToTTIR
-    ${STABLEHLO_LIBS}
 )
 target_link_directories(TT_TORCH_MLIR PUBLIC
     ${TTMLIR_TOOLCHAIN_DIR}/lib

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(TT_TORCH_MLIR "tt-mlir-interface.cpp")
 
 add_dependencies(TT_TORCH_MLIR
     tt-mlir
-    TTMLIRShared
+    TTMLIRCompiler
+    TTMLIRRuntime
 )
 
 set_target_properties(TT_TORCH_MLIR PROPERTIES COMPILE_FLAGS "-fno-rtti")
@@ -30,7 +31,8 @@ target_include_directories(TT_TORCH_MLIR PUBLIC
 target_link_libraries(TT_TORCH_MLIR PUBLIC
     LLVM
     MLIR
-    TTMLIRShared
+    TTMLIRCompiler
+    TTMLIRRuntime
 )
 target_link_directories(TT_TORCH_MLIR PUBLIC
     ${TTMLIR_TOOLCHAIN_DIR}/lib


### PR DESCRIPTION
### Problem description
We want to change our linking strategy for tt-mlir to use dynamic linking.  For some reason, this breaks CI for this repo.  We fix by making stablehlo deps embedded in dylib, and also remove various static tt-mlir lib linking here (since components have been folded into the shared lib).

Related to: https://github.com/tenstorrent/tt-mlir/pull/1947

### What's changed
Simplifies how we import tt-mlir by folding everything into shared-lib target--remove links to all static tt-mlir libs, including stablehlo + shardy.

### Checklist
- [X] successful on-pr run
