### PR TITLE
Update capturing of runtime strck dump process

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -478,7 +478,6 @@ def process_json_files():
                 compiled_json,
             ]
             worksheet.write_row(row, 0, row_data)
-            worksheet.set_row(row, None, None, {"hidden": True})
             row += 1
             for shlo_op in ops:
                 row_data = ["", "", "", "", "", shlo_op[-1]]


### PR DESCRIPTION
### Ticket
#265 

### Problem description
Runtime stack dump is not captured for execution of model tests. 

### What's changed
Stack dump is captured during execution of the runtime instead of entire sub process which fails due to utilizing single/same process to execute multiple graphs to avoid process creation overhead.

### Checklist
- [ ] New/Existing tests provide coverage for changes
