### PR TITLE
Create bfloat16 tensor for boolean program inputs

### DIFF
--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -37,6 +37,10 @@ static tt::target::DataType torch_scalar_type_to_dt(torch::ScalarType st) {
   // case torch::ScalarType::Bool:
   case torch::ScalarType::BFloat16:
     return tt::target::DataType::BFloat16;
+  case torch::ScalarType::Bool:
+    // tt-metal does not support boolean data type; so bfloat16 data type is
+    // used instead.
+    return tt::target::DataType::BFloat16;
   default:
     break;
   }


### PR DESCRIPTION
closes #271 

### Ticket
#271 

### Problem description
subgraphs (generated for op by op execution) may require inputs of unsupported data types. which causes failure for op execution.

### What's changed
Add type conversion of inputs to supported data types for subgraph inputs for op by op execution.

### Checklist
- [ ] New/Existing tests provide coverage for changes
