### PR TITLE
Fix mamba test arguments

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -94,7 +94,7 @@ jobs:
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[op_by_op-swin_b]
               tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo
               tests/models/falcon/test_falcon.py::test_falcon
-              tests/models/mamba/test_mamba.py::test_mamba[state-spaces/mamba-790m-hf]
+              tests/models/mamba/test_mamba.py::test_mamba[op_by_op-state-spaces/mamba-790m-hf-eval]
               "
           },
         ]

--- a/tests/models/mamba/test_mamba.py
+++ b/tests/models/mamba/test_mamba.py
@@ -64,9 +64,7 @@ def test_mamba(record_property, model_name, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(
-        model_name, mode, assert_on_output_mismatch=False, compiler_config=cc
-    )
+    tester = ThisTester(model_name, mode, compiler_config=cc)
     results = tester.test_model()
 
     if mode == "eval":


### PR DESCRIPTION
### Problem description
Mamba test is invoked correctly in the nightly tests

### What's changed
tests/models/mamba/test_mamba.py - removed assert_on_output_mismatc
.github/workflows/run-op-by-op-model-tests.yml - fixed test arguments (now `tests/models/mamba/test_mamba.py[op_by_op-state-spaces/mamba-790m-hf]`)
