### PR TITLE
Enable timm tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@
 
 import pytest
 import torch
+import subprocess
+import sys
 
 
 @pytest.fixture(autouse=True)
@@ -11,6 +13,18 @@ def run_around_tests():
     torch.manual_seed(0)
     yield
     torch._dynamo.reset()
+
+
+@pytest.fixture(scope="module")
+def manage_dependencies(request):
+    dependencies = getattr(request.module, "dependencies", [])
+    # Install dependencies
+    subprocess.check_call([sys.executable, "-m", "pip", "install"] + dependencies)
+    yield
+    # Uninstall dependencies
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "uninstall", "-y"] + dependencies
+    )
 
 
 def pytest_addoption(parser):

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -31,7 +31,7 @@ class ThisTester(ModelTester):
             )
         )
         # get model specific transforms (normalization, resize)
-        data_config = timm.data.resolve_model_data_config(self.model)
+        data_config = timm.data.resolve_model_data_config(self.framework_model)
         transforms = timm.data.create_transform(**data_config, is_training=False)
         input_batch = transforms(img).unsqueeze(
             0
@@ -104,7 +104,6 @@ model_and_mode_list = [
 ]
 
 
-@pytest.mark.skip  # skipped due to missing manage_dependencies package
 @pytest.mark.usefixtures("manage_dependencies")
 @pytest.mark.parametrize("model_and_mode", model_and_mode_list)
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])


### PR DESCRIPTION

### Ticket
#267 

### Problem description
- timm image classification tests were previously disabled due to existing errors

### What's changed
- This test fixes the pytest-related errors and enables the test
  - Port manage_dependencies test fixture from the pytorch2.0_ttnn repo ([ref](https://github.com/tenstorrent/pytorch2.0_ttnn/blob/20f557b3bc5736c70c4eb85a6e77139f3e96b301/tests/conftest.py#L271-L278))
  - Change self.**model** field naming to use newer naming self.**framework_model**
- However, I note that these tests do not pass due to various tensor shape mismatches. This change only enables them to run.

### Checklist
- [x] New/Existing tests provide coverage for changes (This enables a test)
