### PR TITLE
Improve record_property usage (#256)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 import subprocess
 import sys
+from datetime import datetime, timezone
 
 
 @pytest.fixture(autouse=True)
@@ -66,3 +67,12 @@ def pytest_collection_modifyitems(config, items):
                 selected_items.append(item)
         # Replace the items with only the op_by_op tests
     items[:] = selected_items
+
+
+@pytest.fixture(scope="function", autouse=True)
+def record_test_timestamp(record_property):
+    start_timestamp = datetime.now(timezone.utc).isoformat()
+    record_property("start_timestamp", start_timestamp)
+    yield
+    end_timestamp = datetime.now(timezone.utc).isoformat()
+    record_property("end_timestamp", end_timestamp)

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -38,8 +38,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_MobileNetV2(record_property, mode, op_by_op):
     model_name = "MobileNetV2"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -47,7 +45,12 @@ def test_MobileNetV2(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -55,7 +58,7 @@ def test_MobileNetV2(record_property, mode, op_by_op):
         _, indices = torch.topk(results, 5)
         print(f"Top 5 predictions: {indices[0].tolist()}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()
 
 
 # Empty property record_property

--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -46,13 +46,13 @@ class ThisTester(ModelTester):
 def test_qwen2_casual_lm(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    record_property("model_name", model_name)
-    record_property("mode", mode)
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
@@ -66,4 +66,4 @@ def test_qwen2_casual_lm(record_property, model_name, mode, op_by_op):
             f"Model: {model_name} | Input: {tester.text} | Generated Text: {gen_text}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/Qwen/test_qwen2_token_classification.py
+++ b/tests/models/Qwen/test_qwen2_token_classification.py
@@ -39,15 +39,18 @@ class ThisTester(ModelTester):
 def test_qwen2_token_classification(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     with torch.no_grad():
         results = tester.test_model()
@@ -65,4 +68,4 @@ def test_qwen2_token_classification(record_property, model_name, mode, op_by_op)
             f"Model: {model_name} | Tokens: {tokens} | Predictions: {predicted_tokens_classes}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -45,8 +45,6 @@ def test_RMBG(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "RMBG"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -54,7 +52,9 @@ def test_RMBG(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
 
     with torch.no_grad():
         results = tester.test_model()
@@ -66,4 +66,4 @@ def test_RMBG(record_property, mode, op_by_op):
         tester.image.putalpha(mask)
         tester.image.save("no_bg_image.png")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -50,8 +50,6 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -60,7 +58,12 @@ def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -75,4 +78,4 @@ def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
 
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -33,8 +33,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["twmkn9/albert-base-v2-squad2"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_albert_question_answering(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -42,7 +40,13 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
 
     if mode == "eval":
@@ -60,4 +64,4 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
             f"Model: {model_name} | Question: {tester.question} | Text: {tester.text} | Answer: {answer}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -33,8 +33,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["textattack/albert-base-v2-imdb"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_albert_sequence_classification(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -43,7 +41,12 @@ def test_albert_sequence_classification(record_property, model_name, mode, op_by
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -56,4 +59,4 @@ def test_albert_sequence_classification(record_property, model_name, mode, op_by
             f"Model: {model_name} | Input: {tester.input_text} | Label: {predicted_label}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -36,7 +36,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_albert_token_classification(record_property, model_name, mode, op_by_op):
     record_property("model_name", f"{model_name}-classification")
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -45,7 +44,12 @@ def test_albert_token_classification(record_property, model_name, mode, op_by_op
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -67,4 +71,4 @@ def test_albert_token_classification(record_property, model_name, mode, op_by_op
             f"Model: {model_name} | Tokens: {tokens} | Predictions: {predicted_tokens_classes}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/autoencoder_conv/test_autoencoder_conv.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv.py
@@ -53,8 +53,6 @@ AutoencoderTiny(
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_autoencoder_conv(record_property, mode, op_by_op):
     model_name = "Autoencoder (convolutional)"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -62,10 +60,12 @@ def test_autoencoder_conv(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
         image = results.images[0]
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -78,8 +78,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_autoencoder_conv_v2(record_property, mode, op_by_op):
     model_name = f"Autoencoder (conv)"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -87,10 +85,12 @@ def test_autoencoder_conv_v2(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
         print("Output: ", results)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -89,8 +89,6 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "Autoencoder (linear)"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -98,10 +96,12 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
         print("Output: ", results)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -47,8 +47,6 @@ class ThisTester(ModelTester):
 def test_beit_image_classification(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -58,7 +56,11 @@ def test_beit_image_classification(record_property, model_name, mode, op_by_op):
 
     required_atol = 0.032 if model_name == "microsoft/beit-base-patch16-224" else 0.05
     tester = ThisTester(
-        model_name, mode, required_atol=required_atol, compiler_config=cc
+        model_name,
+        mode,
+        required_atol=required_atol,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -72,4 +74,4 @@ def test_beit_image_classification(record_property, model_name, mode, op_by_op):
             tester.framework_model.config.id2label[predicted_class_idx],
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -45,8 +45,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_bert(record_property, mode, op_by_op):
     model_name = "BERT"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -54,7 +52,13 @@ def test_bert(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.012, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.012,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
 
     if mode == "eval":
@@ -77,4 +81,4 @@ def test_bert(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -41,8 +41,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_bloom(record_property, mode, op_by_op):
     model_name = "Bloom"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -57,6 +55,7 @@ def test_bloom(record_property, mode, op_by_op):
         assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -77,4 +76,4 @@ def test_bloom(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -64,8 +64,6 @@ def test_clip(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "CLIP"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -74,8 +72,14 @@ def test_clip(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
+
     results = tester.test_model()
 
     if mode == "eval":
@@ -86,4 +90,4 @@ def test_clip(record_property, mode, op_by_op):
             dim=1
         )  # we can take the softmax to get the label probabilities
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -38,16 +38,16 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_codegen(record_property, mode, op_by_op):
     model_name = "codegen"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
         print(tester.tokenizer.decode(results[0]))
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/deepseek/test_deepseek_qwen.py
+++ b/tests/models/deepseek/test_deepseek_qwen.py
@@ -42,13 +42,14 @@ def test_deepseek_qwen(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     pytest.skip("#291")
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
 
-    results = tester.test_model()
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -51,8 +51,6 @@ class ThisTester(ModelTester):
 def test_deit(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -60,7 +58,13 @@ def test_deit(record_property, model_name, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
 
     if mode == "eval":
@@ -72,4 +76,4 @@ def test_deit(record_property, model_name, mode, op_by_op):
             tester.framework_model.config.id2label[predicted_class_idx],
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -47,8 +47,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_detr(record_property, mode, op_by_op):
     model_name = "DETR"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -57,7 +55,12 @@ def test_detr(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -65,4 +68,4 @@ def test_detr(record_property, mode, op_by_op):
         # Results
         print(results)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -29,8 +29,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_distilbert(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -39,11 +37,16 @@ def test_distilbert(record_property, model_name, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
     if mode == "eval":
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -37,8 +37,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_dpr(record_property, mode, op_by_op):
     model_name = "DPR"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -47,7 +45,12 @@ def test_dpr(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
@@ -57,4 +60,4 @@ def test_dpr(record_property, mode, op_by_op):
         relevance_logits = results.relevance_logits
         print(results)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -41,14 +41,14 @@ def test_falcon(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    results = tester = ThisTester(
+    tester = ThisTester(
         model_name,
         mode,
         relative_atol=0.013,
         compiler_config=cc,
         record_property_handle=record_property,
     )
-    tester.test_model()
+    results = tester.test_model()
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -34,8 +34,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_falcon(record_property, mode, op_by_op):
     model_name = "Falcon"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -43,8 +41,14 @@ def test_falcon(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.013, compiler_config=cc)
-    results = tester.test_model()
+    results = tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.013,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    tester.test_model()
 
     if mode == "eval":
         # Helper function to decode output to human-readable text
@@ -63,4 +67,4 @@ def test_falcon(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -38,8 +38,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_flan_t5(record_property, mode, op_by_op):
     model_name = "FLAN-T5"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -47,9 +45,11 @@ def test_flan_t5(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         results = tester.tokenizer.batch_decode(results, skip_special_tokens=True)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -35,8 +35,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_glpn_kitti(record_property, mode, op_by_op):
     model_name = "GLPN-KITTI"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -44,7 +42,13 @@ def test_glpn_kitti(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.013, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.013,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         predicted_depth = results.predicted_depth
@@ -62,4 +66,4 @@ def test_glpn_kitti(record_property, mode, op_by_op):
         formatted = (output * 255 / np.max(output)).astype("uint8")
         depth = Image.fromarray(formatted)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -36,8 +36,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_gpt2(record_property, mode, op_by_op):
     model_name = "GPT-2"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -45,7 +43,13 @@ def test_gpt2(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.013, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.013,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         # Helper function to decode output to human-readable text
@@ -63,4 +67,4 @@ def test_gpt2(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -46,8 +46,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_gpt_neo(record_property, mode, op_by_op):
     model_name = "GPTNeo"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -55,9 +53,11 @@ def test_gpt_neo(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         gen_text = tester.tokenizer.batch_decode(results)[0]
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -46,8 +46,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_hand_landmark(record_property, mode, op_by_op):
     model_name = "Hand Landmark"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     # Download required files unless they already exist
     urls = [
@@ -105,7 +103,6 @@ def test_hand_landmark(record_property, mode, op_by_op):
         ]
     )
 
-    tester = ThisTester(model_name, mode)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(model_name, mode, record_property_handle=record_property)
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -55,8 +55,6 @@ def test_hardnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "HardNet"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -64,7 +62,13 @@ def test_hardnet(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         # Tensor of shape 1000, with confidence scores over ImageNet's 1000 classes
@@ -73,4 +77,4 @@ def test_hardnet(record_property, mode, op_by_op):
         probabilities = torch.nn.functional.softmax(results[0], dim=0)
         print(probabilities)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -41,16 +41,17 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_llama_3b(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
-
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, assert_atol=False, assert_pcc=False
+        model_name,
+        mode,
+        compiler_config=cc,
+        assert_atol=False,
+        assert_pcc=False,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/llama/test_llama_7b.py
+++ b/tests/models/llama/test_llama_7b.py
@@ -47,15 +47,18 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_llama_7b(record_property, mode, op_by_op):
     model_name = "Llama"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -75,4 +78,4 @@ def test_llama_7b(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/mamba/test_mamba.py
+++ b/tests/models/mamba/test_mamba.py
@@ -57,18 +57,18 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_mamba(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
 
     if mode == "eval":
         gen_text = tester.tokenizer.batch_decode(results)
         print("Generated text: ", gen_text)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -42,8 +42,6 @@ def test_mgp_str_base(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "alibaba-damo/mgp-str-base"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -51,7 +49,13 @@ def test_mgp_str_base(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
 
     if mode == "eval":
@@ -60,4 +64,4 @@ def test_mgp_str_base(record_property, mode, op_by_op):
         print(f"Generated text: '{generated_text}'")
         assert generated_text[0] == "ticket"
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -39,8 +39,6 @@ def test_mlpmixer(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "MLPMixer"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -49,7 +47,12 @@ def test_mlpmixer(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
-    results = tester.test_model()
-    record_property("torch_ttnn", (tester, results))
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -65,18 +65,19 @@ def test_mnist_train(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "Mnist"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
-
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester.cleanup()

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -80,4 +80,4 @@ def test_mnist_train(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.cleanup()
+    tester.finalize()

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -79,5 +79,5 @@ def test_mnist_train(record_property, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
     )
-    results = tester.test_model()
+    tester.test_model()
     tester.cleanup()

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -42,8 +42,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_mobilenet_ssd(record_property, mode, op_by_op):
     model_name = "MobileNetSSD"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -51,7 +49,8 @@ def test_mobilenet_ssd(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -44,9 +44,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_musicgen_small(record_property, mode, op_by_op):
     model_name = "musicgen_small"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -54,8 +51,12 @@ def test_musicgen_small(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, assert_atol=False, assert_pcc=False
+        model_name,
+        mode,
+        compiler_config=cc,
+        assert_atol=False,
+        assert_pcc=False,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -38,8 +38,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_openpose(record_property, mode, op_by_op):
     model_name = "OpenPose"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -47,7 +45,8 @@ def test_openpose(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -55,8 +55,6 @@ def test_openpose_v2(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "OpenPose V2"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -65,10 +63,15 @@ def test_openpose_v2(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
         print(f"Output: {results}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -40,15 +40,15 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_opt(record_property, mode, op_by_op):
     model_name = "OPT"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         tester.tokenizer.batch_decode(results)[0]
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -42,8 +42,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_perceiver_io(record_property, mode, op_by_op):
     model_name = "Perceiver IO"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -52,7 +50,12 @@ def test_perceiver_io(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -60,4 +63,4 @@ def test_perceiver_io(record_property, mode, op_by_op):
         masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)
         print(tester.tokenizer.decode(masked_tokens_predictions))
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -29,8 +29,6 @@ def test_resnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "ResNet18"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -39,9 +37,13 @@ def test_resnet(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 
-    # Check inference result
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -42,8 +42,6 @@ def test_resnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "ResNet50"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -58,14 +56,16 @@ def test_resnet(record_property, mode, op_by_op):
         compiler_config=cc,
         assert_pcc=True,
         assert_atol=False,
+        record_property_handle=record_property,
     )
+
     results = tester.test_model()
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)
         print(f"Top 5 predictions: {indices[0].tolist()}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()
 
 
 # Empty property record_property

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -30,8 +30,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_roberta(record_property, mode, op_by_op):
     model_name = "RoBERTa"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -39,7 +37,13 @@ def test_roberta(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.012, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.012,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         logits = results.logits
@@ -51,4 +55,4 @@ def test_roberta(record_property, mode, op_by_op):
         predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
         output = tester.tokenizer.decode(predicted_token_id)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -50,8 +50,6 @@ def test_segformer(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "SegFormer"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -59,9 +57,15 @@ def test_segformer(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         logits = results.logits  # shape (batch_size, num_labels, height/4, width/4)
 
-    record_property("torch_ttnn", (tester, results))
+    results.finalize()

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -41,8 +41,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_segment_anything(record_property, mode, op_by_op):
     model_name = "segment-anything"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -50,7 +48,9 @@ def test_segment_anything(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -52,8 +52,6 @@ class ThisTester(ModelTester):
 def test_speecht5_tts(record_property, mode, op_by_op):
     pytest.skip()  # crashes in lowering to stable hlo
     model_name = "speecht5-tts"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -61,11 +59,13 @@ def test_speecht5_tts(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
     # if mode == "eval":
     #     # Uncomment below if you really want to hear the result.
     #     # import soundfile as sf
     #     sf.write("speech.wav", speech.numpy(), samplerate=16000)
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -32,8 +32,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_squeeze_bert(record_property, mode, op_by_op):
     model_name = "SqueezeBERT"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -41,10 +39,12 @@ def test_squeeze_bert(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         predicted_class_id = logits.argmax().item()
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -27,12 +27,10 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_stable_diffusion(record_property, mode, op_by_op):
     model_name = "Stable Diffusion"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, record_property_handle=record_property)
     results = tester.test_model()
     if mode == "eval":
         image = results.images[0]
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/stable_diffusion/test_stable_diffusion_v2.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_v2.py
@@ -67,8 +67,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_stable_diffusion_v2(record_property, mode, op_by_op):
     model_name = "Stable Diffusion V2"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -77,10 +75,15 @@ def test_stable_diffusion_v2(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
         noise_pred = results.sample
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -35,8 +35,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["t5-small", "t5-base", "t5-large"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_t5(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -44,7 +42,9 @@ def test_t5(record_property, model_name, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         output_text = tester.tokenizer.decode(results[0], skip_special_tokens=True)
@@ -52,4 +52,4 @@ def test_t5(record_property, model_name, mode, op_by_op):
             f"Model: {model_name} | Input: {tester.input_text} | Output: {output_text}"
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -76,7 +76,12 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, assert_pcc=False, assert_atol=False
+        model_name,
+        mode,
+        compiler_config=cc,
+        assert_pcc=False,
+        assert_atol=False,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -87,5 +92,4 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         print(
             f"Model: {model_name} | Predicted class ID: {top5_class_indices[0]} | Probabiliy: {top5_probabilities[0]}"
         )
-
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -96,9 +96,6 @@ model_info_list = [
 @pytest.mark.parametrize("mode", ["train", "eval"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_torchvision_image_classification(record_property, model_info, mode, op_by_op):
-    record_property("model_name", model_info[0])
-    record_property("mode", mode)
-
     if mode == "train":
         pytest.skip()
 
@@ -115,6 +112,7 @@ def test_torchvision_image_classification(record_property, model_info, mode, op_
         assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -122,4 +120,4 @@ def test_torchvision_image_classification(record_property, model_info, mode, op_
         _, indices = torch.topk(results, 5)
         print(f"Model: {model_info[0]} | Top 5 predictions: {indices[0].tolist()}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -56,8 +56,6 @@ model_info_list = [
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_torchvision_object_detection(record_property, model_info, mode, op_by_op):
     model_name, _ = model_info
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -66,10 +64,15 @@ def test_torchvision_object_detection(record_property, model_info, mode, op_by_o
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_info, mode, assert_pcc=True, assert_atol=False, compiler_config=cc
+        model_info,
+        mode,
+        assert_pcc=True,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
         print(f"Model: {model_name} | Output: {results}")
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -51,8 +51,6 @@ def test_unet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "U-Net"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -60,9 +58,11 @@ def test_unet(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         results = torch.round(results[0])
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -61,8 +61,6 @@ def test_unet_brain(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "Unet-brain"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -70,9 +68,11 @@ def test_unet_brain(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
     results = tester.test_model()
     if mode == "eval":
         print(torch.round(results[0]))
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -37,8 +37,6 @@ def test_unet_carvana(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "Unet-carvana"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -46,7 +44,8 @@ def test_unet_carvana(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -40,8 +40,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_vilt(record_property, mode, op_by_op):
     model_name = "ViLT"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -49,11 +47,17 @@ def test_vilt(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, relative_atol=0.01, compiler_config=cc)
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
     results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         idx = logits.argmax(-1).item()
         print("Predicted answer:", tester.framework_model.config.id2label[idx])
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -55,8 +55,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_whisper(record_property, mode, op_by_op):
     model_name = "Whisper"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -64,7 +62,8 @@ def test_whisper(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, record_property_handle=record_property
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -36,8 +36,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_xglm(record_property, mode, op_by_op):
     model_name = "XGLM"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -47,7 +45,12 @@ def test_xglm(record_property, mode, op_by_op):
     else:
         cc.compile_depth = CompileDepth.TTNN_IR
 
-    tester = ThisTester(model_name, mode, relative_atol=0.02, compiler_config=cc)
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name,
+        mode,
+        relative_atol=0.02,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -40,8 +40,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_yolos(record_property, mode, op_by_op):
     model_name = "YOLOS"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -50,7 +48,12 @@ def test_yolos(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":
@@ -85,4 +88,4 @@ def test_yolos(record_property, mode, op_by_op):
         """
         )
 
-    record_property("torch_ttnn", (tester, results))
+    tester.finalize()

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -60,8 +60,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_yolov3(record_property, mode, op_by_op):
     model_name = "YOLOv3"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -70,8 +68,12 @@ def test_yolov3(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     tester = ThisTester(
-        model_name, mode, assert_pcc=False, assert_atol=False, compiler_config=cc
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester.test_model()
+    tester.finalize()

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -111,8 +111,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_yolov5(record_property, mode, op_by_op):
     model_name = "YOLOv5"
-    record_property("model_name", model_name)
-    record_property("mode", mode)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -120,8 +118,12 @@ def test_yolov5(record_property, mode, op_by_op):
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
-    tester = ThisTester(model_name, mode, compiler_config=cc)
-    tester.required_atol = 12
-    results = tester.test_model()
-
-    record_property("torch_ttnn", (tester, results))
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        required_atol=12,
+        record_property_handle=record_property,
+    )
+    tester.test_model()
+    tester.finalize()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -237,7 +237,6 @@ class ModelTester:
             self.required_pcc,
             self.required_atol,
             self.relative_atol,
-            return_pccs_atols=True,
         )
         self.record_tag_cache["pccs"] = pccs
         self.record_tag_cache["atols"] = atols

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,6 @@ import json
 from onnx import version_converter
 from pathlib import Path
 from tt_torch.tools.verify import verify_against_golden
-from datetime import datetime, timezone
 
 
 class ModelTester:
@@ -267,23 +266,15 @@ class ModelTester:
         return outputs
 
     def test_model(self, on_device=True):
-        if self.mode not in ["train", "eval"]:
-            raise ValueError(f"Current mode is not supported: {self.mode}")
-
-        ret = None
-        self.record_property("start_timestamp", datetime.now(timezone.utc).isoformat())
-
         if self.mode == "train":
-            ret = self.test_model_train(on_device)
+            return self.test_model_train(on_device)
         elif self.mode == "eval":
-            ret = self.test_model_eval(on_device)
-
-        self.record_property("end_timestamp", datetime.now(timezone.utc).isoformat())
-
-        return ret
+            return self.test_model_eval(on_device)
+        else:
+            raise ValueError(f"Current mode is not supported: {self.mode}")
 
     def flush_tag_cache_to_record(self):
         self.record_property("tags", self.record_tag_cache)
 
-    def cleanup(self):
+    def finalize(self):
         self.flush_tag_cache_to_record()

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -305,6 +305,24 @@ class CompilerConfig:
         self.stablehlo_mlir_module = mlir_module
         # self.stable_hlo_ops, _ = parse_shlo_mlir(mlir_module)
 
+    def to_dict(self):
+        return {
+            "compile_depth": serialize_enum(self.compile_depth),
+            "profile_ops": self.profile_ops,
+            "torch_mlir_module": self.torch_mlir_module,
+            "stablehlo_mlir_module": self.stablehlo_mlir_module,
+            "unique_ops": self.unique_ops,
+            "stable_hlo_ops": self.stable_hlo_ops,
+            "model_name": self.model_name,
+            "results_path": self.results_path,
+            "single_op_timeout": self.single_op_timeout,
+            "enable_consteval": self.enable_consteval,
+            "remove_embedded_constants": self.remove_embedded_constants,
+            "_consteval_parameters": self._consteval_parameters,
+            "_enable_intermediate_verification": self._enable_intermediate_verification,
+            "_verify_op_by_op": self._verify_op_by_op,
+        }
+
 
 def extract_shape(shape_str):
     assert shape_str.startswith("tensor<")
@@ -536,3 +554,7 @@ def calculate_pcc(tensor, golden_tensor):
             )
         )
     )
+
+
+def serialize_enum(enum_value):
+    return f"{enum_value.__class__.__name__}.{enum_value.name}"

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -17,7 +17,6 @@ def verify_against_golden(
     required_pcc=0.99,
     required_atol=None,
     relative_atol=None,
-    return_pccs_atols=False,
 ):
     assert (required_atol is not None) != (
         relative_atol is not None
@@ -104,10 +103,7 @@ def verify_against_golden(
             )
             passed_atol = False
 
-    if return_pccs_atols:
-        return passed_pcc, passed_atol, msg, err_msg, pccs, atols
-
-    return passed_pcc, passed_atol, msg, err_msg
+    return passed_pcc, passed_atol, msg, err_msg, pccs, atols
 
 
 def _verify_torch_module(
@@ -159,7 +155,7 @@ def _verify_torch_module(
     golden = tuple(golden)
     ret = tuple(ret)
 
-    passed_pcc, passed_atol, msg, err_msg = verify_against_golden(
+    passed_pcc, passed_atol, msg, err_msg, _, _ = verify_against_golden(
         golden, ret, required_pcc, required_atol=required_atol
     )
     print(msg)
@@ -228,7 +224,7 @@ def _verify_onnx_module(
     golden = tuple(golden)
     ret = tuple(ret)
 
-    passed_pcc, passed_atol, msg, err_msg = verify_against_golden(
+    passed_pcc, passed_atol, msg, err_msg, _, _ = verify_against_golden(
         golden, ret, required_pcc, required_atol=required_atol
     )
     print(msg)

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -17,6 +17,7 @@ def verify_against_golden(
     required_pcc=0.99,
     required_atol=None,
     relative_atol=None,
+    return_pccs_atols=False,
 ):
     assert (required_atol is not None) != (
         relative_atol is not None
@@ -102,6 +103,9 @@ def verify_against_golden(
                 + f"ATOL of output {i}: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} {red_x}\n"
             )
             passed_atol = False
+
+    if return_pccs_atols:
+        return passed_pcc, passed_atol, msg, err_msg, pccs, atols
 
     return passed_pcc, passed_atol, msg, err_msg
 


### PR DESCRIPTION


### Ticket
#256 

### Problem description
Current Pytest **record_property** usage has a lot of code duplication and does not expose model evaluation results (PCC, ATOL). This populates some missing fields needed for compliance with the [Pydantic Test model spec](https://github.com/tenstorrent/tt-github-actions/blob/main/.github/actions/collect_data/src/pydantic_models.py).

### What's changed
- Create a tag cache to store "tag" records, and flush them with tester.finalize() at the end of each test
- Extract actual PCC and ATOLs from verify_against_golden
- Move record_property calls into ModelTester, as side effects of other internal class functions to reduce code duplication
  - This pattern is less functionally pure but reduces the overhead for creating new tests, and adds flexibility when adding or changing the telemetry schema (as defined in the Pydantic Test model spec)

### Checklist
- [ ] New/Existing tests provide coverage for changes (in progress)
