### PR TITLE
Enable tests

### DIFF
--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -375,10 +375,6 @@ for begin in torch.arange(0, 64, 32).tolist():
     "begin, end, dim", [*dim2_cases, *dim3_cases, *dim0_cases, *dim1_cases]
 )
 def test_slice(begin, end, dim):
-    # Slice test is only working for dim=3; skipping all other tests.
-    if dim != 3:
-        pytest.skip()
-
     class Basic(nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/torch/test_constant_fold.py
+++ b/tests/torch/test_constant_fold.py
@@ -11,7 +11,6 @@ from tt_torch.tools.verify import verify_module
 from tt_torch.tools.utils import CompilerConfig, CompileDepth
 
 
-@pytest.mark.xfail(reason="Fails due tt_torch not being able to pass in scalars")
 def test_multiple_ops():
     class ConstantFoldable(nn.Module):
         def __init__(self):


### PR DESCRIPTION
### Problem description
Following two tests are skipped/xfailed due to tt-mlir/tt-metal issues; these problems are resolved now.
1. `test_basic.py::test_slice` skips for dim=0,1,2
2. `test_constant_fold.py::test_multiple_ops()` is marked xfail

### What's changed
Enable `test_basic.py::test_slice` for all dims
Enable `test_constant_fold.py::test_multiple_ops`

### Checklist
- [x] Existing tests provide coverage for changes
