### PR TITLE
Add llama 3b [#289]

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -88,6 +88,7 @@ jobs:
       env:
         HF_HOME: /mnt/dockercache/huggingface
         TORCH_HOME: /mnt/dockercache/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
       shell: bash
       run: |
         source env/activate
@@ -107,6 +108,7 @@ jobs:
                   tests/models/whisper/test_whisper.py::test_whisper[full-eval] \
                   tests/models/yolos/test_yolos.py::test_yolos[full-eval] \
                   tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval] \
+                  tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval] \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }}
 
 

--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -61,6 +61,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
+              tests/models/llama/test_llama_7b.py::test_llama_7b
               tests/models/llama/test_llama_3b.py::test_llama_3b
               "
           },

--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -61,7 +61,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
-              tests/models/llama/test_llama.py::test_llama
+              tests/models/llama/test_llama_3b.py::test_llama_3b
               "
           },
           {
@@ -278,6 +278,7 @@ jobs:
       env:
         HF_HOME: /mnt/dockercache/huggingface
         TORCH_HOME: /mnt/dockercache/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
       shell: bash
       run: |
         source env/activate

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,6 +110,7 @@ jobs:
       env:
         HF_HOME: /mnt/dockercache/huggingface
         TORCH_HOME: /mnt/dockercache/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
       shell: bash
       run: |
         source env/activate
@@ -126,7 +127,7 @@ jobs:
                   tests/models/resnet50/test_resnet50.py::test_resnet[full-eval] \
                   tests/models/yolov3/test_yolov3.py::test_yolov3[full-eval] \
                   tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xxlarge-v2-eval] \
-                  tests/models/llama/test_llama.py::test_llama[full-eval] \
+                  tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval] \
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v2] \
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v3_small] \
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v3_large] \

--- a/docs/src/models/supported_models.md
+++ b/docs/src/models/supported_models.md
@@ -12,7 +12,7 @@ The following models can be currently run through tt-torch as of Feb 3rd, 2025. 
 | | Token Classification Base | tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[full-albert/albert-base-v2-eval] |
 | Autoencoder | (linear) | tests/models/autoencoder_linear/test_autoencoder_linear.py::test_autoencoder_linear[full-eval] |
 | DistilBert | base uncased | tests/models/distilbert/test_distilbert.py::test_distilbert[full-distilbert-base-uncased-eval] |
-| Llama | 7B | tests/models/llama/test_llama.py::test_llama[full-eval] |
+| Llama | 3B | tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval] |
 | MLPMixer || tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[full-eval] |
 | MNist || pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval] |
 | MobileNet V2 || tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2[full-eval] |

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_name, torch_dtype=torch.bfloat16
+        )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name, torch_dtype=torch.bfloat16
+        )
+        self.tokenizer.pad_token = self.tokenizer.eos_token
+        return model
+
+    def _load_inputs(self):
+        self.test_input = "This is a sample text from "
+        inputs = self.tokenizer.encode_plus(
+            self.test_input,
+            return_tensors="pt",
+            max_length=32,
+            padding="max_length",
+            truncation=True,
+        )
+        return inputs
+
+    def set_model_eval(self, model):
+        return model
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
+@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+def test_llama_3b(record_property, model_name, mode, op_by_op):
+    record_property("model_name", model_name)
+    record_property("mode", mode)
+
+    cc = CompilerConfig()
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+
+    tester = ThisTester(
+        model_name, mode, compiler_config=cc, assert_atol=False, assert_pcc=False
+    )
+    results = tester.test_model()
+
+    record_property("torch_ttnn", (tester, results))

--- a/tests/models/llama/test_llama_7b.py
+++ b/tests/models/llama/test_llama_7b.py
@@ -45,7 +45,7 @@ class ThisTester(ModelTester):
     reason="llama-7b is too large to fit on single device, but we can still generate a graph"
 )
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
-def test_llama(record_property, mode, op_by_op):
+def test_llama_7b(record_property, mode, op_by_op):
     model_name = "Llama"
     record_property("model_name", model_name)
     record_property("mode", mode)


### PR DESCRIPTION
Add meta-llama/Llama-3.2-3B from https://huggingface.co/meta-llama/Llama-3.2-3B

### Ticket
#289 

### Problem description
LLama 7b runs out of memory after recent tt-mlir changes. Therefore, we need a smaller llama test. 

### Checklist
- [DONE] `tests/models/llama/test_llama_3b.py` added
- [DONE] test_llama_3b added to `.github/workflows/run-e2e-tests.yml`
- [DONE] llama test updated in `.github/workflows/run-op-by-op-model-tests.yml` 
- [DONE] `docs/src/models/supported_models.md` updated to include llama 3b information
- [DONE] HuggingFace access token generated 
- [DONE] HuggingFace token added as github secret (`HF_TOKEN`) by @AleksKnezevic 
- [DONE] Tested if llama as standalone runs in [CI](https://github.com/tenstorrent/tt-torch/actions/runs/13218380283/job/36900528154) 
