### PR TITLE
Add preprocessing of list inputs for op by op execution

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -336,6 +336,16 @@ class Executor:
                 if not inp.is_contiguous():
                     inp = inp.contiguous()
                 processed_inputs.append(inp)
+            elif isinstance(inp, list):
+                for ele in inp:
+                    if isinstance(ele, torch.nn.Parameter):
+                        if not ele.data.is_contiguous():
+                            ele.data = ele.data.contiguous()
+                        processed_inputs.append(ele.data)
+                    elif isinstance(ele, torch.Tensor):
+                        if not ele.is_contiguous():
+                            ele = ele.contiguous()
+                        processed_inputs.append(ele)
 
         # Typecast the unsupported data types to hardware supported types.
         supported_inputs = ()


### PR DESCRIPTION
closes #301 

### Ticket
#301 

### Problem description
aten::cat (concatenate) operation is failing for op-by-op execution due to mismatch in numbers of inputs

### What's changed
Inputs preprocessing for op-by-op execution is updated to process inputs of type list.
Nightly tests (https://github.com/tenstorrent/tt-torch/actions/runs/13270505478) report shows the improvement.

### Checklist
- [ ] New/Existing tests provide coverage for changes
