### PR TITLE
Minor fixes to model e2e tests

### DIFF
--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -35,7 +35,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("model_name", ["albert/albert-base-v2"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_albert_token_classification(record_property, model_name, mode, op_by_op):
-    record_property("model_name", f"{model_name}-classification")
 
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -68,4 +68,4 @@ def test_segformer(record_property, mode, op_by_op):
     if mode == "eval":
         logits = results.logits  # shape (batch_size, num_labels, height/4, width/4)
 
-    results.finalize()
+    tester.finalize()

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -64,9 +64,6 @@ model_list = [
 @pytest.mark.parametrize("mode", ["train", "eval"])
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_timm_image_classification(record_property, model_name, mode, op_by_op):
-    record_property("model_name", model_name)
-    record_property("mode", mode)
-
     if mode == "train":
         pytest.skip()
     cc = CompilerConfig()


### PR DESCRIPTION
### Ticket
#256 

### Problem description
An error introduced in PR#283 breaks nightly model tests. Also, I noticed a few of the tests still have record_property calls.

### What's changed
- Fix segformer test typo breaking nightly tests
- Remove missed extraneous record_property calls

### Checklist
- [x] New/Existing tests provide coverage for changes
