### PR TITLE
New tt-mlir installation support

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "947aed03c54a92612c9e3bb2f172c252f867b13f")
+set(TT_MLIR_VERSION "bfb88ddfac2d3aaf2ab0525ff177bdeadb2d34e9")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "fa8c589842b557042f8c554120b24fdae11d5fd6")
+set(TT_MLIR_VERSION "947aed03c54a92612c9e3bb2f172c252f867b13f")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
@@ -41,8 +41,8 @@ else()
     endif()
 
     include(ExternalProject)
-    set(TT_MLIR_COMPILER_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIRCompiler.so)
-    set(TT_MLIR_RUNTIME_LIBRARY_PATH ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib/SharedLib/libTTMLIRRuntime.so)
+    set(TT_MLIR_COMPILER_LIBRARY_PATH ${TTTORCH_SOURCE_DIR}/install/lib/libTTMLIRCompiler.so)
+    set(TT_MLIR_RUNTIME_LIBRARY_PATH ${TTTORCH_SOURCE_DIR}/install/lib/libTTMLIRRuntime.so)
     ExternalProject_Add(
         tt-mlir
         PREFIX ${TTTORCH_SOURCE_DIR}/third_party/tt-mlir
@@ -56,8 +56,9 @@ else()
           -DTT_RUNTIME_ENABLE_TTMETAL=OFF
           -DTTMLIR_ENABLE_STABLEHLO=ON
           -DTTMLIR_ENABLE_RUNTIME=ON
+          -DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF
           -DTT_RUNTIME_DEBUG=${TT_RUNTIME_DEBUG}
-          -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+          -DCMAKE_INSTALL_PREFIX=${TTTORCH_SOURCE_DIR}/install
           -DTTMLIR_ENABLE_DEBUG_STRINGS=${TT_RUNTIME_DEBUG}
         BUILD_COMMAND ${BUILD_COMMAND}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -29,15 +29,12 @@ target_include_directories(TT_TORCH_MLIR PUBLIC
 )
 
 target_link_libraries(TT_TORCH_MLIR PUBLIC
-    LLVM
-    MLIR
     TTMLIRCompiler
     TTMLIRRuntime
 )
 target_link_directories(TT_TORCH_MLIR PUBLIC
     ${TTMLIR_TOOLCHAIN_DIR}/lib
     ${TTTORCH_SOURCE_DIR}/install/lib
-    ${TTTORCH_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/lib
 )
 
 set(TORCH_INSTALL_PREFIX ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.11/site-packages/torch)


### PR DESCRIPTION
Adopt the new way that tt-mlir builds and links:
- Packages all of tt-mlir + downstream tt-metal libs and files into installation prefix for easy deployment
- Statically links `libTTMLIRCompiler.so` and `libTTMLIRRuntime.so`, now FE's only need to link against these 2 binaries and no other deps.

See tt-mlir PR for more information:
https://github.com/tenstorrent/tt-mlir/pull/2108