### PR TITLE
Fix op_by_op override clunky

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,34 +39,24 @@ def pytest_addoption(parser):
 
 def pytest_collection_modifyitems(config, items):
     # If --op_by_op flag is set, filter out tests with op_by_op=False
+
     selected_items = []
+    using_op_by_op = config.getoption("--op_by_op")
+
     for item in items:
         # Check if the test has a parameter called 'op_by_op'
         # and whether it is set to True
 
-        if config.getoption("--op_by_op"):
+        if using_op_by_op:
             for param in item.iter_markers(name="parametrize"):
                 # Check if the parameter is 'op_by_op' and its value is True
                 if "op_by_op" in param.args[0] and item.callspec.params["op_by_op"]:
                     selected_items.append(item)
                     break
-        else:
-            # If the test does not have a 'op_by_op' parameter,
-            # add all tests without a op_by_op parameter, as well
-            # as all testst with a op_by_op parameter where op_by_op=False
-            has_op_by_op_param = False
-            for param in item.iter_markers(name="parametrize"):
-                if "op_by_op" in param.args[0]:
-                    has_op_by_op_param = True
-                    # Only add the test if op_by_op=False
-                    if not item.callspec.params["op_by_op"]:
-                        selected_items.append(item)
-                        break
-            # If theres no nigtly parameter, add the test
-            if not has_op_by_op_param:
-                selected_items.append(item)
+
+    if using_op_by_op:
         # Replace the items with only the op_by_op tests
-    items[:] = selected_items
+        items[:] = selected_items
 
 
 @pytest.fixture(scope="function", autouse=True)


### PR DESCRIPTION
### Ticket
#254

### Problem description
The --op_by_op override previously ran only op_by_op tests if present, and only full model (non op_by_op) tests if absent. 

### What's changed
Now, there will be no effect from omitting the op_by_op option instead of the previous implied behaviour, which would assume you wanted to run full models only and NOT run any op_by_op tests when the op_by_op option was absent.

### Checklist
- [x] New/Existing tests provide coverage for changes
