### PR TITLE
First pass - CICD testcase schema change preparation

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,9 @@ class ModelTester:
         self.record_property("model_name", model_name)
         self.record_property("frontend", "tt-torch")
 
+        self.record_tag_cache["model_name"] = model_name
+        self.record_tag_cache["frontend"] = "tt-torch"
+
         # configs should be set at test start, so they can be flushed immediately
         self.record_property("config", {"compiler_config": compiler_config.to_dict()})
 


### PR DESCRIPTION

### Ticket
#256 

### Problem description
CICD testcase schema will change and obscure model name and frontend values.

### What's changed
- Pack model/fe metadata into tags in preparation for CICD testcase schema change
- This retains record_property calls for model name and frontend for now. This will be 
removed in a future pass once the pydantic model and python pytest parser is amended.

### Checklist
- [x] New/Existing tests provide coverage for changes
