### PR TITLE
Remove ttrt build from third party components

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -26,7 +26,6 @@ RUN apt-get update && apt-get install -y \
     ccache \
     doxygen \
     graphviz \
-    patchelf \
     libyaml-cpp-dev \
     libboost-all-dev \
     jq \

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi
 black
 mdutils
 ninja
-patchelf
 pre-commit
 pybind11
 pytest

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -30,15 +30,6 @@ if (BUILD_TOOLCHAIN)
 else()
     set(TT_RUNTIME_DEBUG OFF CACHE BOOL "Enable runtime debugging")
     message(STATUS "TT_RUNTIME_DEBUG is set to: ${TT_RUNTIME_DEBUG}")
-    set(BUILD_TTRT ON CACHE BOOL "Build the ttrt target")
-    # Set the build command based on the BUILD_TTRT variable
-    if(BUILD_TTRT)
-        message(STATUS "Building ttrt")
-        set(BUILD_COMMAND "${CMAKE_COMMAND}" --build . -- ttrt)
-    else()
-        message(STATUS "Not building ttrt")
-        set(BUILD_COMMAND "")
-    endif()
 
     include(ExternalProject)
     set(TT_MLIR_COMPILER_LIBRARY_PATH ${CMAKE_INSTALL_PREFIX}/lib/libTTMLIRCompiler.so)
@@ -60,7 +51,6 @@ else()
           -DTT_RUNTIME_DEBUG=${TT_RUNTIME_DEBUG}
           -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
           -DTTMLIR_ENABLE_DEBUG_STRINGS=${TT_RUNTIME_DEBUG}
-        BUILD_COMMAND ${BUILD_COMMAND}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git
         GIT_TAG ${TT_MLIR_VERSION}
         GIT_PROGRESS ON


### PR DESCRIPTION
### Ticket
closes #324 

### Problem description
TTRT is build as part of third party components which is no more required.

### What's changed
Update cmake to not build ttrt.

### Checklist
- [ ] New/Existing tests provide coverage for changes
