### PR TITLE
Update cron job timing for nightly uplift

### DIFF
--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -5,7 +5,7 @@ name: Nightly Uplift
 
 on:
   schedule:
-    - cron: '0 8 * * *'  # Runs at 08:00 UTC every day
+    - cron: '0 1 * * *'  # Runs at 01:00 UTC every day
   workflow_dispatch:  # Manual trigger
 
 jobs:


### PR DESCRIPTION
### Problem description
Nightly tests are started before nightly uplift. So nightly tests results are delayed by a day.

### What's changed
Update cron job timing for nightly uplift to start before nightly tests.
If nightly uplift is successful then nightly tests will run on latest main.
