### PR TITLE
Only include numeric types in pcc/atol aggregate

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -284,6 +284,7 @@ class ModelTester:
         max_metric = default_value
 
         if metric_list:  # check null or empty list
+            metric_list = [x for x in metric_list if isinstance(x, (int, float))]
             avg_metric = sum(metric_list) / len(metric_list)
             min_metric = min(metric_list)
             max_metric = max(metric_list)


### PR DESCRIPTION
### Problem description
Nightly dpr test was [broken](https://github.com/tenstorrent/tt-torch/actions/runs/13469421394/artifacts/2634283031) due to pcc/atol aggregator since it was trying to add a None type to a floating point. 

### What's changed
Only include int/float values to aggregator. 

### Checklist
- [x] New/Existing tests provide coverage for changes
