### PR TITLE
Skip vilt test until tt-mlir uplift

### DIFF
--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -40,6 +40,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_vilt(record_property, mode, op_by_op):
     model_name = "ViLT"
+    pytest.skip()
 
     cc = CompilerConfig()
     cc.enable_consteval = True


### PR DESCRIPTION


### Ticket
#370 

### Problem description
ViLT test fails due to LLVM uplift in tt-mlir uplift. 

### What's changed
Skip ViLT test for now, it will be reenabled after successful tt-mlir uplift. 

### Checklist
- [x] New/Existing tests provide coverage for changes
