### PR TITLE
Support Int32 datatype

### DIFF
--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -22,8 +22,10 @@ static tt::target::DataType torch_scalar_type_to_dt(torch::ScalarType st) {
     return tt::target::DataType::UInt8;
   case torch::ScalarType::Short:
     return tt::target::DataType::UInt16;
-  case torch::ScalarType::Int:
+  case torch::ScalarType::UInt32:
     return tt::target::DataType::UInt32;
+  case torch::ScalarType::Int:
+    return tt::target::DataType::Int32;
   case torch::ScalarType::Long:
     return tt::target::DataType::UInt32;
   case torch::ScalarType::Half:
@@ -54,6 +56,8 @@ static torch::ScalarType dt_to_torch_scalar_type(tt::target::DataType df) {
   case tt::target::DataType::UInt16:
     return torch::ScalarType::Short;
   case tt::target::DataType::UInt32:
+    return torch::ScalarType::UInt32;
+  case tt::target::DataType::Int32:
     return torch::ScalarType::Int;
   case tt::target::DataType::Float16:
     return torch::ScalarType::Half;


### PR DESCRIPTION

### Problem description
Follow up of [tt-mlir Commit a1af497](https://github.com/tenstorrent/tt-mlir/commit/a1af497a744b6f6b1d154b2dd9bb19c40295c035)

After tt-mlir Commit a1af497 added support for Int32 dtype, tt-torch tests fail when it can't convert the new type to a pytorch dtype.

### What's changed
Added conversion support between TT::Int32 to Pytorch::Int cherry-picked from @jnie-TT's [fix branch](https://github.com/tenstorrent/tt-torch/compare/jnie/test_uplift)

### Checklist
- [-] New/Existing tests provide coverage for changes
- [ ] Wait for referenced commit to be uplifted
