### PR TITLE
Enable ViLT after tt-mlir negative constant fix uplifted

### DIFF
--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -40,7 +40,6 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_vilt(record_property, mode, op_by_op):
     model_name = "ViLT"
-    pytest.skip()
 
     cc = CompilerConfig()
     cc.enable_consteval = True


### PR DESCRIPTION
### Ticket
#370 

### Problem description
ViLT model tests were previously disabled due to LLVM 
uplift changing APInt constructor and assertion failure with
negative constants.

### What's changed
Fix to tt-mlir uplifted, so this test can be reenabled.

### Checklist
- [x] New/Existing tests provide coverage for changes
