### PR TITLE
Added OnnxModelTester, other onnx qol infra. Added onnx mobilenetv2 test

### DIFF
--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import onnx
+import requests
+import torchvision.models as models
+from torchvision import transforms
+from PIL import Image
+import os
+
+import pytest
+from tests.utils import OnnxModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth
+
+
+class ThisTester(OnnxModelTester):
+    def _load_model(self):
+        # Load the MobileNetV2 model with updated API
+        self.weights = models.MobileNet_V2_Weights.DEFAULT
+        model = models.mobilenet_v2(weights=self.weights)
+        torch.onnx.export(model, self._load_torch_inputs(), f"{self.model_name}.onnx")
+        model = onnx.load(f"{self.model_name}.onnx")
+        os.remove(f"{self.model_name}.onnx")
+        return model
+
+    def _load_torch_inputs(self):
+        # Define a transformation to preprocess the input image using the weights transforms
+        preprocess = self.weights.transforms()
+
+        # Load and preprocess the image
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        img_t = preprocess(image)
+        batch_t = torch.unsqueeze(img_t, 0)
+        return (batch_t,)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+def test_MobileNetV2(record_property, mode, op_by_op):
+    model_name = "MobileNetV2"
+    cc = CompilerConfig()
+    cc.compile_depth = CompileDepth.STABLEHLO
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    results = tester.test_model()
+    if mode == "eval":
+        # Print the top 5 predictions
+        _, indices = torch.topk(results[0], 5)
+        print(f"Top 5 predictions: {indices[0].tolist()}")
+
+    tester.finalize()
+
+
+# Empty property record_property
+def empty_record_property(a, b):
+    pass
+
+
+# Main
+if __name__ == "__main__":
+    test_MobileNetV2(empty_record_property)

--- a/tests/onnx/test_basic.py
+++ b/tests/onnx/test_basic.py
@@ -23,11 +23,10 @@ def test_abs():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_abs_model(), "abs.onnx")
     cc = CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("abs.onnx", compiler_config=cc)
+    verify_module(create_abs_model(), compiler_config=cc)
 
 
 def test_add():
@@ -50,11 +49,10 @@ def test_add():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_add_model(), "add.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("add.onnx", compiler_config=cc)
+    verify_module(create_add_model(), compiler_config=cc)
 
 
 def test_concat_dim0():
@@ -77,11 +75,10 @@ def test_concat_dim0():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_concat_model(), "concat_dim0.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("concat_dim0.onnx", compiler_config=cc)
+    verify_module(create_concat_model(), compiler_config=cc)
 
 
 def test_concat_dim1():
@@ -104,11 +101,10 @@ def test_concat_dim1():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_concat_model(), "concat_dim1.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("concat_dim1.onnx", compiler_config=cc)
+    verify_module(create_concat_model(), compiler_config=cc)
 
 
 def test_concat_dim2():
@@ -131,11 +127,10 @@ def test_concat_dim2():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_concat_model(), "concat_dim2.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("concat_dim2.onnx", compiler_config=cc)
+    verify_module(create_concat_model(), compiler_config=cc)
 
 
 def test_concat_dim3():
@@ -158,11 +153,10 @@ def test_concat_dim3():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_concat_model(), "concat_dim3.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("concat_dim3.onnx", compiler_config=cc)
+    verify_module(create_concat_model(), compiler_config=cc)
 
 
 @pytest.mark.parametrize(
@@ -193,11 +187,10 @@ def test_div(input_range, input_shapes, input_type):
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_div_model(), "div.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("div.onnx", compiler_config=cc)
+    verify_module(create_div_model(), compiler_config=cc)
 
 
 def test_div_zero():
@@ -214,11 +207,10 @@ def test_div_zero():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_div_zero_model(), "div_zero.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("div_zero.onnx", compiler_config=cc)
+    verify_module(create_div_zero_model(), compiler_config=cc)
 
 
 def test_exp():
@@ -230,11 +222,10 @@ def test_exp():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_exp_model(), "exp.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("exp.onnx", compiler_config=cc, required_atol=3e-2)
+    verify_module(create_exp_model(), compiler_config=cc, required_atol=3e-2)
 
 
 def test_linear_with_bias():
@@ -264,8 +255,7 @@ def test_linear_with_bias():
         model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
         return model
 
-    onnx.save(create_linear_with_bias_model(), "linear_with_bias.onnx")
     cc = tt_torch.tools.utils.CompilerConfig()
     cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE
     cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
-    verify_module("linear_with_bias.onnx", compiler_config=cc)
+    verify_module(create_linear_with_bias_model(), compiler_config=cc)

--- a/tt_torch/onnx_compile/__init__.py
+++ b/tt_torch/onnx_compile/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from .onnx_compile import onnx_to_stablehlo, compile_onnx
+from .onnx_compile import compile_onnx

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -16,6 +16,31 @@ import sys
 from tt_mlir import is_runtime_debug_enabled
 
 
+"""
+The CompileDepth's below represent the different stages of the compilation
+pipeline.
+
+tt-torch has two entrypoints it can compile from: PyTorch and ONNX. At the
+beginning of the compile flow these entrypoints follow different paths, but
+converge early in the compilation pipeline. The flow is as follows:
+
+                                 PyTorch nn.Module
+                                         |
+     ONNX ModelProto               Torch FX Graph
+            |                            |
+      Torch ONNX IR                Torch FX IR  <-----  (first MLIR modules)
+             \-----Torch Backend IR-----/
+                           |
+                       StableHLO
+                           |
+                      TTIR Dialect
+                           |
+                      TTNN Dialect
+                           |
+                 Flatbuffer Executable
+"""
+
+
 class CompileDepth(Enum):
     TORCH_FX = 1
     STABLEHLO = 2
@@ -443,8 +468,6 @@ def parse_shlo_mlir(mlir_code, verbose=False):
         if verbose:
             print(opString)
         output = opString.split(" = ")[0].strip()
-        # if output == "%21":
-        #   breakpoint()
         op_name = opString.split(" = ")[1].split(" ")[0]
         if op_name.startswith('"'):
             op_name = op_name.split('"')[1]


### PR DESCRIPTION
### Ticket
Mobilenetv2 onnx issue: https://github.com/tenstorrent/tt-torch/issues/346#issue-2869513608

### What's changed
- `verify_module` now accepts a `ModelProto` instead of a filename to a serialized onnx model. 
- Added an OnnxModelTester for making onnx model tests
- Added mobilenetv2 onnx test (SHLO depth)
- `verify_against_golden` now handles assertions on PCC/ATOL checks
    - Prints ❎ instead of ❌ if the check fails but we decided against asserting PCC/ATOL
