### PR TITLE
Shlo compiler

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -42,6 +42,7 @@ else
     cd $TT_TORCH_HOME
   fi
   pip install $TT_TORCH_HOME/dist/torchvision*.whl
+  pip install stablehlo -f https://github.com/openxla/stablehlo/releases/expanded_assets/v1.0.0
 fi
 export TTTORCH_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,18 @@ def pytest_addoption(parser):
         default=False,
         help="Run test in op-by-op mode",
     )
+    parser.addoption(
+        "--op_by_op_stablehlo",
+        action="store_true",
+        default=False,
+        help="Run test in stablehlo op-by-op mode",
+    )
+    parser.addoption(
+        "--op_by_op_torch",
+        action="store_true",
+        default=False,
+        help="Run test in torch op-by-op mode",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -35,7 +35,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_MobileNetV2(record_property, mode, op_by_op):
     model_name = "MobileNetV2"
     cc = CompilerConfig()
@@ -43,6 +47,8 @@ def test_MobileNetV2(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/Qwen/test_qwen2_token_classification.py
+++ b/tests/models/Qwen/test_qwen2_token_classification.py
@@ -5,7 +5,7 @@ from transformers import AutoTokenizer, Qwen2ForTokenClassification
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -35,7 +35,11 @@ class ThisTester(ModelTester):
         "Qwen/Qwen2-7B",
     ],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_qwen2_token_classification(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -43,6 +47,8 @@ def test_qwen2_token_classification(record_property, model_name, mode, op_by_op)
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -9,7 +9,7 @@ import requests
 from torchvision import transforms
 from transformers import AutoModelForImageSegmentation
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -40,7 +40,11 @@ class ThisTester(ModelTester):
     ["train", "eval"],
 )
 @pytest.mark.xfail(reason="Fails due pt2 compile issue, graph is traced")
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_RMBG(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -51,6 +55,8 @@ def test_RMBG(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, AlbertForMaskedLM
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -48,7 +48,11 @@ class ThisTester(ModelTester):
         "albert/albert-xxlarge-v2",
     ],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
@@ -56,6 +60,8 @@ def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, AlbertForQuestionAnswering
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -31,7 +31,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["twmkn9/albert-base-v2-squad2"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_albert_question_answering(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
@@ -39,6 +43,8 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 from tests.utils import ModelTester
 
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -31,7 +31,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["textattack/albert-base-v2-imdb"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_albert_sequence_classification(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
@@ -39,6 +43,8 @@ def test_albert_sequence_classification(record_property, model_name, mode, op_by
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -8,7 +8,7 @@ import torch
 import pytest
 from tests.utils import ModelTester
 
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -33,7 +33,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["albert/albert-base-v2"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_albert_token_classification(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
@@ -41,6 +45,8 @@ def test_albert_token_classification(record_property, model_name, mode, op_by_op
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -8,7 +8,7 @@ import torchvision.transforms as transforms
 from datasets import load_dataset
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class LinearAE(torch.nn.Module):
@@ -84,7 +84,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_autoencoder_linear(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -95,6 +99,8 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -7,7 +7,7 @@ import pytest
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForQuestionAnswering
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -42,7 +42,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_bert(record_property, mode, op_by_op):
     model_name = "BERT"
 
@@ -51,6 +55,8 @@ def test_bert(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -7,7 +7,7 @@ import pytest
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -38,7 +38,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_bloom(record_property, mode, op_by_op):
     model_name = "Bloom"
 
@@ -47,6 +51,8 @@ def test_bloom(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -7,7 +7,7 @@ import torch
 from transformers import CLIPProcessor, CLIPModel
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -59,7 +59,11 @@ class ThisTester(ModelTester):
         "eval",
     ],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_clip(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -70,6 +74,8 @@ def test_clip(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -35,12 +35,18 @@ class ThisTester(ModelTester):
 @pytest.mark.xfail(
     reason="Fails due to pt2 compile issue when finishing generation, but we can still generate a graph"
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_codegen(record_property, mode, op_by_op):
     model_name = "codegen"
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/deepseek/test_deepseek_qwen.py
+++ b/tests/models/deepseek/test_deepseek_qwen.py
@@ -5,7 +5,7 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,7 +37,11 @@ class ThisTester(ModelTester):
         "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
     ],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_deepseek_qwen(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -46,6 +50,8 @@ def test_deepseek_qwen(record_property, model_name, mode, op_by_op):
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -9,7 +9,7 @@ import requests
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -47,7 +47,11 @@ class ThisTester(ModelTester):
     ],
 )
 @pytest.mark.parametrize("model_name", ["facebook/deit-base-patch16-224"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_deit(record_property, model_name, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -57,6 +61,8 @@ def test_deit(record_property, model_name, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -8,7 +8,7 @@ import numpy as np
 from torchvision import transforms
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -44,7 +44,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_detr(record_property, mode, op_by_op):
     model_name = "DETR"
 
@@ -53,6 +57,8 @@ def test_detr(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -5,7 +5,7 @@ from transformers import DistilBertTokenizer, DistilBertModel
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -27,7 +27,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_distilbert(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
@@ -35,6 +39,8 @@ def test_distilbert(record_property, model_name, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -7,7 +7,7 @@ from transformers import DPRReader, DPRReaderTokenizer
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -34,7 +34,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_dpr(record_property, mode, op_by_op):
     model_name = "DPR"
 
@@ -43,6 +47,8 @@ def test_dpr(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -7,7 +7,7 @@ import pytest
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -31,7 +31,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_falcon(record_property, mode, op_by_op):
     model_name = "Falcon"
 
@@ -40,6 +44,8 @@ def test_falcon(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForSeq2SeqLM, AutoTokenizer, GenerationConfig
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -35,7 +35,11 @@ class ThisTester(ModelTester):
 @pytest.mark.xfail(
     reason="Fails due to pt2 compile issue when finishing generation, but we can still generate a graph"
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_flan_t5(record_property, mode, op_by_op):
     model_name = "FLAN-T5"
 
@@ -44,6 +48,8 @@ def test_flan_t5(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -8,7 +8,7 @@ import requests
 from transformers import GLPNImageProcessor, GLPNForDepthEstimation
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -32,7 +32,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_glpn_kitti(record_property, mode, op_by_op):
     model_name = "GLPN-KITTI"
 
@@ -41,6 +45,8 @@ def test_glpn_kitti(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -7,7 +7,7 @@ import pytest
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -33,7 +33,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_gpt2(record_property, mode, op_by_op):
     model_name = "GPT-2"
 
@@ -42,6 +46,8 @@ def test_gpt2(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -7,7 +7,7 @@ from transformers import GPTNeoForCausalLM, GPT2Tokenizer, GenerationConfig
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -43,7 +43,11 @@ class ThisTester(ModelTester):
 @pytest.mark.xfail(
     reason="Fails due to pt2 compile issue when finishing generation, but we can still generate a graph"
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_gpt_neo(record_property, mode, op_by_op):
     model_name = "GPTNeo"
 
@@ -52,6 +56,8 @@ def test_gpt_neo(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -43,7 +43,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.xfail(reason="Need to debud")
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_hand_landmark(record_property, mode, op_by_op):
     model_name = "Hand Landmark"
 

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -10,7 +10,7 @@ import requests
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -50,7 +50,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_hardnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -61,6 +65,8 @@ def test_hardnet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -4,7 +4,7 @@
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
 
 
@@ -39,11 +39,17 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_llama_3b(record_property, model_name, mode, op_by_op):
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -9,7 +9,7 @@ import torch
 from transformers import MgpstrProcessor, MgpstrForSceneTextRecognition
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,7 +37,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_mgp_str_base(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -48,6 +52,8 @@ def test_mgp_str_base(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader
 import torch.nn as nn
 import torch.nn.functional as F
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 # adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py
@@ -60,7 +60,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_mnist_train(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -71,6 +75,9 @@ def test_mnist_train(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from diffusers.utils import load_image
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 dependencies = ["controlnet_aux==0.0.9"]
 
@@ -35,7 +35,11 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.usefixtures("manage_dependencies")
 @pytest.mark.skip(reason="failing during torch run with bypass compilation")
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_openpose(record_property, mode, op_by_op):
     model_name = "OpenPose"
 
@@ -44,6 +48,8 @@ def test_openpose(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -10,7 +10,7 @@ from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 def get_image_tensor():
@@ -50,7 +50,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_openpose_v2(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -61,6 +65,8 @@ def test_openpose_v2(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -7,7 +7,7 @@ import torch
 from transformers import OPTForCausalLM, GPT2Tokenizer, GenerationConfig
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,13 +37,20 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.xfail(reason="Need to debug")
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_opt(record_property, mode, op_by_op):
     model_name = "OPT"
 
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property
     )

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -7,7 +7,7 @@ from transformers import PerceiverTokenizer, PerceiverForMaskedLM
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -39,7 +39,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_perceiver_io(record_property, mode, op_by_op):
     model_name = "Perceiver IO"
 
@@ -48,6 +52,8 @@ def test_perceiver_io(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -5,7 +5,7 @@ import torch
 import torchvision
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -24,7 +24,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_resnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -35,7 +39,8 @@ def test_resnet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
-
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -9,7 +9,7 @@ from PIL import Image
 
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,7 +37,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_resnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -48,6 +52,8 @@ def test_resnet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, XLMRobertaForMaskedLM
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -27,7 +27,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_roberta(record_property, mode, op_by_op):
     model_name = "RoBERTa"
 
@@ -36,6 +40,8 @@ def test_roberta(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -9,7 +9,7 @@ import requests
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -45,7 +45,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_segformer(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -56,6 +60,8 @@ def test_segformer(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -9,7 +9,7 @@ import requests
 from PIL import Image
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -38,7 +38,11 @@ class ThisTester(ModelTester):
 @pytest.mark.skip(
     reason="Failed to install sam2. sam2 requires Python >=3.10.0 but the default version on Ubuntu 20.04 is 3.8. We found no other pytorch implementation of segment-anything."
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_segment_anything(record_property, mode, op_by_op):
     model_name = "segment-anything"
 
@@ -47,6 +51,8 @@ def test_segment_anything(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, AutoModelForSequenceClassification
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -29,7 +29,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_squeeze_bert(record_property, mode, op_by_op):
     model_name = "SqueezeBERT"
 
@@ -38,6 +42,8 @@ def test_squeeze_bert(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -24,7 +24,11 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.skip(reason="Dynamo cannot support pipeline.")
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_stable_diffusion(record_property, mode, op_by_op):
     model_name = "Stable Diffusion"
 

--- a/tests/models/stable_diffusion/test_stable_diffusion_v2.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_v2.py
@@ -10,7 +10,7 @@ from diffusers import (
 from transformers import CLIPTextModel, CLIPTokenizer
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -64,7 +64,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_stable_diffusion_v2(record_property, mode, op_by_op):
     model_name = "Stable Diffusion V2"
 
@@ -73,6 +77,8 @@ def test_stable_diffusion_v2(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -7,7 +7,7 @@ import torch
 import requests
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -94,7 +94,11 @@ model_info_list = [
     "model_info", model_info_list, ids=[info[0] for info in model_info_list]
 )
 @pytest.mark.parametrize("mode", ["train", "eval"])
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_torchvision_image_classification(record_property, model_info, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -104,6 +108,8 @@ def test_torchvision_image_classification(record_property, model_info, mode, op_
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_info,

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -7,7 +7,7 @@ import torch
 import requests
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 # TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
@@ -53,7 +53,11 @@ model_info_list = [
     model_info_list,
     ids=[model_info[0] for model_info in model_info_list],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_torchvision_object_detection(record_property, model_info, mode, op_by_op):
     model_name, _ = model_info
 
@@ -62,6 +66,8 @@ def test_torchvision_object_detection(record_property, model_info, mode, op_by_o
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_info,

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -10,7 +10,7 @@ import requests
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -46,7 +46,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_unet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -57,6 +61,8 @@ def test_unet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -8,7 +8,7 @@ from PIL import Image
 from torchvision import transforms
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -56,7 +56,11 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_unet_brain(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
@@ -67,6 +71,8 @@ def test_unet_brain(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -9,7 +9,7 @@ from PIL import Image
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,7 +37,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_vilt(record_property, mode, op_by_op):
     model_name = "ViLT"
 
@@ -46,6 +50,8 @@ def test_vilt(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -6,7 +6,7 @@ from datasets import load_dataset
 import pytest
 from tests.utils import ModelTester
 import torch
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -52,7 +52,11 @@ class ThisTester(ModelTester):
 @pytest.mark.xfail(
     reason="Fails due to pt2 compile issue when finishing generation, but we can still generate a graph"
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_whisper(record_property, mode, op_by_op):
     model_name = "Whisper"
 
@@ -61,6 +65,8 @@ def test_whisper(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name, mode, compiler_config=cc, record_property_handle=record_property

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 from transformers import XGLMTokenizer, XGLMForCausalLM
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -33,7 +33,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_xglm(record_property, mode, op_by_op):
     model_name = "XGLM"
 
@@ -42,6 +46,9 @@ def test_xglm(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
     else:
         cc.compile_depth = CompileDepth.TTNN_IR
 

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -9,7 +9,7 @@ import requests
 # Load model directly
 from transformers import AutoImageProcessor, AutoModelForObjectDetection
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -37,7 +37,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_yolos(record_property, mode, op_by_op):
     model_name = "YOLOS"
 
@@ -46,6 +50,8 @@ def test_yolos(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.models.yolov3.holli_src.yolov3 import *
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
 class ThisTester(ModelTester):
@@ -57,7 +57,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_yolov3(record_property, mode, op_by_op):
     model_name = "YOLOv3"
 
@@ -66,6 +70,8 @@ def test_yolov3(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -10,7 +10,7 @@ import sys
 import os
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 dependencies = ["ultralytics==8.2.92", "ultralytics-thop==2.0.6"]
 
@@ -108,7 +108,11 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
 def test_yolov5(record_property, mode, op_by_op):
     model_name = "YOLOv5"
 
@@ -117,6 +121,8 @@ def test_yolov5(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
         model_name,

--- a/tests/onnx/test_basic.py
+++ b/tests/onnx/test_basic.py
@@ -4,21 +4,268 @@
 import torch
 from torch import nn
 import pytest
+import onnx
+from onnx import helper, TensorProto
 
+import tt_torch
 from tt_torch.tools.verify import verify_module
 from tt_torch.tools.utils import CompilerConfig
 
 
+def test_abs():
+    def create_abs_model():
+        input_info = helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 3])
+        output_info = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 3])
+        abs_node = helper.make_node(
+            "Abs", inputs=["input"], outputs=["output"]  # ONNX Abs operation
+        )
+        graph = helper.make_graph([abs_node], "AbsModel", [input_info], [output_info])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_abs_model(), "abs.onnx")
+    cc = CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("abs.onnx", compiler_config=cc)
+
+
 def test_add():
-    class Basic(nn.Module):
-        def __init__(self):
-            super().__init__()
+    def create_add_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", TensorProto.FLOAT, [256, 256]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", TensorProto.FLOAT, [256, 256]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [256, 256]
+        )
+        add_node = helper.make_node(
+            "Add", inputs=["input1", "input2"], outputs=["output"]
+        )
+        graph = helper.make_graph(
+            [add_node], "AddModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
 
-        def forward(self, x, y):
-            return torch.add(x, y)
+    onnx.save(create_add_model(), "add.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("add.onnx", compiler_config=cc)
 
-    torch_model = Basic()
-    torch_input = (torch.randn(256, 256), torch.randn(256, 256))
-    torch.onnx.export(torch_model, torch_input, "add.onnx")
 
-    verify_module("add.onnx")
+def test_concat_dim0():
+    def create_concat_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", TensorProto.FLOAT, [32, 32]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", TensorProto.FLOAT, [64, 32]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [96, 32]
+        )
+        concat_node = helper.make_node(
+            "Concat", inputs=["input1", "input2"], outputs=["output"], axis=0
+        )
+        graph = helper.make_graph(
+            [concat_node], "ConcatModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_concat_model(), "concat_dim0.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("concat_dim0.onnx", compiler_config=cc)
+
+
+def test_concat_dim1():
+    def create_concat_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", TensorProto.FLOAT, [32, 32]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", TensorProto.FLOAT, [32, 64]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [32, 96]
+        )
+        concat_node = helper.make_node(
+            "Concat", inputs=["input1", "input2"], outputs=["output"], axis=1
+        )
+        graph = helper.make_graph(
+            [concat_node], "ConcatModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_concat_model(), "concat_dim1.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("concat_dim1.onnx", compiler_config=cc)
+
+
+def test_concat_dim2():
+    def create_concat_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", TensorProto.FLOAT, [32, 32, 32]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", TensorProto.FLOAT, [32, 32, 64]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [32, 32, 96]
+        )
+        concat_node = helper.make_node(
+            "Concat", inputs=["input1", "input2"], outputs=["output"], axis=2
+        )
+        graph = helper.make_graph(
+            [concat_node], "ConcatModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_concat_model(), "concat_dim2.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("concat_dim2.onnx", compiler_config=cc)
+
+
+def test_concat_dim3():
+    def create_concat_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", TensorProto.FLOAT, [32, 32, 32, 32]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", TensorProto.FLOAT, [32, 32, 32, 64]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [32, 32, 32, 96]
+        )
+        concat_node = helper.make_node(
+            "Concat", inputs=["input1", "input2"], outputs=["output"], axis=3
+        )
+        graph = helper.make_graph(
+            [concat_node], "ConcatModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_concat_model(), "concat_dim3.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("concat_dim3.onnx", compiler_config=cc)
+
+
+@pytest.mark.parametrize(
+    ("input_range", "input_shapes", "input_type"),
+    [
+        ((-0.5, 0.5), [(2, 2), (2, 2)], TensorProto.FLOAT),
+        ((1, 10), [(32, 32), (32, 32)], TensorProto.FLOAT),
+        ((1, 10), [(32, 32), (32, 32)], TensorProto.FLOAT),
+    ],
+)
+def test_div(input_range, input_shapes, input_type):
+    def create_div_model():
+        input1_info = helper.make_tensor_value_info(
+            "input1", input_type, input_shapes[0]
+        )
+        input2_info = helper.make_tensor_value_info(
+            "input2", input_type, input_shapes[1]
+        )
+        output_info = helper.make_tensor_value_info(
+            "output", input_type, input_shapes[0]
+        )
+        div_node = helper.make_node(
+            "Div", inputs=["input1", "input2"], outputs=["output"]
+        )
+        graph = helper.make_graph(
+            [div_node], "DivModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_div_model(), "div.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("div.onnx", compiler_config=cc)
+
+
+def test_div_zero():
+    def create_div_zero_model():
+        input1_info = helper.make_tensor_value_info("input1", TensorProto.FLOAT, [8])
+        input2_info = helper.make_tensor_value_info("input2", TensorProto.FLOAT, [8])
+        output_info = helper.make_tensor_value_info("output", TensorProto.FLOAT, [8])
+        div_node = helper.make_node(
+            "Div", inputs=["input1", "input2"], outputs=["output"]
+        )
+        graph = helper.make_graph(
+            [div_node], "DivZeroModel", [input1_info, input2_info], [output_info]
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_div_zero_model(), "div_zero.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("div_zero.onnx", compiler_config=cc)
+
+
+def test_exp():
+    def create_exp_model():
+        input_info = helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 2])
+        output_info = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 2])
+        exp_node = helper.make_node("Exp", inputs=["input"], outputs=["output"])
+        graph = helper.make_graph([exp_node], "ExpModel", [input_info], [output_info])
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_exp_model(), "exp.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE_OP_BY_OP
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("exp.onnx", compiler_config=cc, required_atol=3e-2)
+
+
+def test_linear_with_bias():
+    def create_linear_with_bias_model():
+        input_info = helper.make_tensor_value_info("input", TensorProto.FLOAT, [32, 32])
+        output_info = helper.make_tensor_value_info(
+            "output", TensorProto.FLOAT, [32, 32]
+        )
+
+        weights_info = helper.make_tensor_value_info(
+            "weights", TensorProto.FLOAT, [32, 32]
+        )
+        bias_info = helper.make_tensor_value_info("bias", TensorProto.FLOAT, [32])
+        matmul_node = helper.make_node(
+            "MatMul", inputs=["input", "weights"], outputs=["matmul_output"]
+        )
+        add_node = helper.make_node(
+            "Add", inputs=["matmul_output", "bias"], outputs=["output"]
+        )
+
+        graph = helper.make_graph(
+            [matmul_node, add_node],
+            "LinearWithBiasModel",
+            [input_info, weights_info, bias_info],
+            [output_info],
+        )
+        model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 21)])
+        return model
+
+    onnx.save(create_linear_with_bias_model(), "linear_with_bias.onnx")
+    cc = tt_torch.tools.utils.CompilerConfig()
+    cc.compile_depth = tt_torch.tools.utils.CompileDepth.EXECUTE
+    cc.op_by_op_backend = tt_torch.tools.utils.OpByOpBackend.STABLEHLO
+    verify_module("linear_with_bias.onnx", compiler_config=cc)

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -2,567 +2,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
-
-from torch._dynamo.backends.common import aot_autograd
-from torch.fx.experimental.proxy_tensor import make_fx
-from torch._functorch.compile_utils import strip_overloads
-import operator
-
-from tt_torch.dynamo.passes import pass_pipeline
-from tt_torch.tools.utils import (
-    CompilerConfig,
-    CompileDepth,
-    Op,
-    Tensor,
-    OpCompilationStatus,
-    calculate_atol,
-    calculate_pcc,
-)
-
+import os
 import tt_mlir
-from tt_mlir import is_runtime_debug_enabled
+import sys
 import torch_mlir
-from torch_mlir.ir import Context, Location
-from torch_mlir.extras.fx_importer import FxImporter, ContextCache
 
-from torch_mlir.dialects import torch as torch_dialect
-
+from tt_torch.dynamo.torch_backend import (
+    TorchExecutor,
+    import_graph,
+    verify_ir,
+    lower_to_stable_hlo,
+)
+from tt_torch.dynamo.shlo_backend import (
+    generate_random_inputs_for_shlo,
+    parse_module_from_str,
+    StablehloExecutor,
+)
 from torch_mlir.compiler_utils import (
     OutputType,
     run_pipeline_with_repro_report,
     lower_mlir_module,
 )
-from typing import List, Tuple, Union, Optional
-import os
-import multiprocessing as mp
-import time
-import faulthandler
-from pathlib import Path
-import re
-import sys
-import tempfile
-
-
-def verify_ir(module):
-    def verify_op(op):
-        if hasattr(op, "verify"):
-            op.verify()
-        return torch_mlir.ir.WalkResult.ADVANCE
-
-    module.operation.walk(verify_op)
-
-
-class TTContextCache(ContextCache):
-    def get_node_location(self, node: torch.fx.Node) -> Optional[Location]:
-        return Location.name(node.name, context=self._c)
-
-
-def import_graph(graph: torch.fx.GraphModule):
-    context = Context()
-    torch_dialect.register_dialect(context)
-    importer = FxImporter(context=context)
-    importer._cc = TTContextCache(
-        importer._c, py_attr_tracker=importer._py_attr_tracker
-    )
-    importer.import_stateless_graph(graph)
-    return importer.module
-
-
-def lower_to_stable_hlo(module, op=None, enable_ir_printing=False):
-    run_pipeline_with_repro_report(
-        module,
-        f"builtin.module(torchdynamo-export-to-torch-backend-pipeline)",
-        "Lowering TorchFX IR -> Torch Backend IR",
-        enable_ir_printing,
-    )
-    if op is not None:
-        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_BACKEND_IR
-
-    lower_mlir_module(False, OutputType.STABLEHLO, module)
-    if op is not None:
-        op.compilation_status = OpCompilationStatus.CONVERTED_TO_STABLE_HLO
-
-
-def compile_process(receiver, sender, ttir_event, ttnn_event, json_event):
-    obj = receiver.get()
-    faulthandler.disable()
-    asm = obj["asm"]
-    ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
-    sender.put({"ttir": ttir})
-    ttir_event.wait()
-    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
-    sender.put({"binary": binary, "ttnn": ttnn})
-    ttnn_event.wait()
-    sender.put({"json": tt_mlir.bytestream_to_json(binary)})
-    json_event.wait()
-    sys.exit(0)
-
-
-def execute_process(receiver, sender, exec_event):
-    while 1:
-        obj = receiver.get()
-        faulthandler.disable()
-        binary = obj["binary"]
-        inputs = obj["inputs"]
-        file_name = obj["dump_file"]
-        file_stderr = open(file_name, "w")
-        old_stderr = sys.stderr
-        sys.stderr = file_stderr
-        old_stdout = sys.stdout
-        sys.stdout = file_stderr
-        outputs = tt_mlir.run(inputs, binary)
-        sys.stderr = old_stderr
-        sys.stdout = old_stdout
-        file_stderr.close()
-        sender.put({"outputs": outputs})
-        exec_event.wait()
-    sys.exit(0)
-
-
-class Executor:
-    def __init__(
-        self,
-        gm,
-        graph_constants,
-        compiler_config=None,
-        required_pcc=0.99,
-        required_atol=1e-2,
-    ):
-        self.gm = gm
-        self.binary = None
-        self.graph_constants = tuple(graph_constants)
-        if compiler_config is None:
-            compiler_config = CompilerConfig()
-        self.compiler_config = compiler_config
-        self.required_atol = required_atol
-        self.required_pcc = required_pcc
-        # Dictionary to keep track of the type conversion for unsupported hardware
-        # types and use it to convert the input arguments to supported types.
-        self.type_conversion = {
-            torch.bool: torch.bfloat16,
-            torch.int64: torch.int32,
-            torch.float64: torch.float32,
-        }
-        self.intermediate_callbacks = {}
-
-        # Opening a device in a new process is very slow as the pcie device needs to be initializes
-        # So we keep the process alive and reuse it. If the process dies, the next call will create a new process
-        self.execute_process = None
-        self.execute_sender = None
-        self.execute_receiver = None
-
-        # Create temp file at start of execution of first op and pass the name
-        # of temp file to subprocess which will be used to redirect the stderr
-        # to capture runtime stack dump.
-        self.stderror_redirected = False
-        self.file_stderr = None
-
-    def register_intermediate_callback(self, callback):
-        if not is_runtime_debug_enabled():
-            raise RuntimeError(
-                "Runtime debug is required to use intermediate callbacks. Please recompile this project with -DTT_RUNTIME_DEBUG=ON."
-            )
-        tt_mlir.DebugHooks.get_debug_hooks(callback)
-
-    def set_binary(self, binary):
-        self.binary = binary
-
-    def compile_op(self, node, *inputs, **kwargs):
-        input_shapes_and_constants = []
-        for inp in inputs:
-            if isinstance(inp, torch.Tensor):
-                input_shapes_and_constants.append(inp.shape)
-            elif isinstance(inp, (list, tuple)):
-                sub = []
-                for sub_inp in inp:
-                    if isinstance(sub_inp, torch.Tensor):
-                        sub.append(sub_inp.shape)
-                    else:
-                        sub.append(sub_inp)
-                input_shapes_and_constants.append(sub)
-            elif isinstance(inp, (int, float, bool)):
-                input_shapes_and_constants.append(inp)
-            elif isinstance(inp, torch.dtype):
-                input_shapes_and_constants.append(inp.__str__())
-            elif inp is None:
-                input_shapes_and_constants.append(None)
-            else:
-                raise ValueError(f"Unexpected input type: {type(inp)}")
-
-        name = node.target.name() if hasattr(node.target, "name") else node.name
-        if not isinstance(node.target, torch._ops.OpOverload):
-            if "getitem" not in name:
-                raise ValueError(f"Node target is not an OpOverload: {name}")
-            return None, None
-
-        op = Op(name, input_shapes_and_constants, self.compiler_config.model_name)
-        if op.unique_key() not in self.compiler_config.unique_ops:
-            self.compiler_config.unique_ops[op.unique_key()] = op
-        else:
-            self.compiler_config.unique_ops[op.unique_key()].num_ops += 1
-            return None, None
-
-        graph = torch.fx.Graph()
-        placeholders = []
-        for inp in inputs:
-            if isinstance(inp, torch.Tensor):
-                placeholders.append(graph.placeholder("input"))
-            elif isinstance(inp, (list, tuple)):
-                inps = torch.fx.immutable_collections.immutable_list(
-                    [
-                        graph.placeholder(f"input_{idx}")
-                        if isinstance(sub_inp, torch.Tensor)
-                        else sub_inp
-                        for idx, sub_inp in enumerate(inp)
-                    ]
-                )
-                placeholders.append(inps)
-            else:
-                placeholders.append(inp)
-
-        if len(placeholders) != len(node.args):
-            # are any of the args duplicates? If so, we need to duplicate the placeholders
-            for idx, arg in enumerate(node.args):
-                if arg in node.args[idx + 1 :]:
-                    placeholders.append(placeholders[idx])
-
-        placeholders = tuple(placeholders)
-        for placeholder, arg in zip(placeholders, node.args):
-            if isinstance(placeholder, torch.fx.node.Node):
-                placeholder.meta["tensor_meta"] = arg.meta["tensor_meta"]
-            elif isinstance(placeholder, (list, tuple)):
-                for sub_placeholder, sub_arg in zip(placeholder, arg):
-                    if isinstance(sub_placeholder, torch.fx.node.Node):
-                        sub_placeholder.meta["tensor_meta"] = sub_arg.meta[
-                            "tensor_meta"
-                        ]
-
-        graph_node = graph.call_function(node.target, placeholders, kwargs)
-        graph_node.meta["tensor_meta"] = node.meta["tensor_meta"]
-
-        # if the node has multiple outputs, add a getitem for each and append to graph
-        if not isinstance(
-            node.meta["tensor_meta"], torch.fx.passes.shape_prop.TensorMetadata
-        ):
-            getitem_nodes = []
-            graph_node.meta["val"] = node.meta["val"]
-
-            for idx, tensor_meta in enumerate(node.meta["tensor_meta"]):
-                # filter out unused outputs that do not exist in the reduced graph
-                users = self.gm.graph.find_nodes(
-                    op="call_function", target=operator.getitem
-                )
-                if not any(user_node.args == (node, idx) for user_node in users):
-                    continue
-
-                getitem_node = graph.call_function(
-                    operator.getitem, args=(graph_node, idx)
-                )
-                getitem_nodes.append(getitem_node)
-                getitem_node.meta["tensor_meta"] = tensor_meta
-            out = graph.output(tuple(getitem_nodes))
-            if len(node.users) != len(graph_node.users):
-                raise ValueError(
-                    f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
-                )
-        else:
-            out = graph.output((graph_node,))
-        if "tensor_meta" not in node.meta:
-            raise ValueError(f"Node {node} does not have tensor_meta")
-
-        op.compilation_status = OpCompilationStatus.CREATED_GRAPH
-        out.meta["tensor_meta"] = node.meta["tensor_meta"]
-
-        out_meta = out.meta["tensor_meta"]
-        if isinstance(out_meta, torch.fx.passes.shape_prop.TensorMetadata):
-            out_meta = (out_meta,)
-        for out in out_meta:
-            op.output_shapes.append([dim for dim in out.shape])
-
-        module = import_graph(graph)
-        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_IR
-        op.add_torch_ir_graph(module.operation.get_asm())
-        lower_to_stable_hlo(module, op=op)
-        op.add_stable_hlo_graph(module.operation.get_asm())
-
-        sender = mp.Queue()
-        receiver = mp.Queue()
-        ttir_event = mp.Event()
-        ttnn_event = mp.Event()
-        json_event = mp.Event()
-        obj = {"asm": module.operation.get_asm()}
-        process = mp.Process(
-            target=compile_process,
-            args=(sender, receiver, ttir_event, ttnn_event, json_event),
-        )
-        process.start()
-        sender.put(obj)
-        start = time.time()
-        binary = None
-        while True:
-            try:
-                result = receiver.get_nowait()
-                if "ttir" in result:
-                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTIR
-                    op.add_ttir_graph(result["ttir"])
-                    ttir_event.set()
-                if "binary" in result:
-                    binary = result["binary"]
-                    op.binary = binary
-                    op.add_ttnn_graph(result["ttnn"])
-                    ttnn_event.set()
-                if "json" in result:
-                    op.json = result["json"]
-                    json_event.set()
-                    op.parse_json()
-                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
-                    break
-            except mp.queues.Empty:
-                pass
-            except Exception as e:
-                process.terminate()
-                raise e
-            if time.time() - start > self.compiler_config.single_op_timeout:
-                process.terminate()
-                break
-            if not process.is_alive():
-                break
-            time.sleep(0.01)
-        process.join()
-        print(f"json len {len(op.json)}")
-        return binary, op
-
-    def transform_input(self, inp):
-        # Convert torch.nn.Parameter to torch.Tensor and convert non-contiguous
-        # data to contiguous.
-        if isinstance(inp, torch.nn.Parameter):
-            if not inp.data.is_contiguous():
-                inp.data = inp.data.contiguous()
-            return inp.data
-        elif isinstance(inp, torch.Tensor):
-            if not inp.is_contiguous():
-                inp = inp.contiguous()
-            return inp
-
-        return None
-
-    def pre_process_inputs(self, *inputs):
-        # Remove scalar constants as they're absorbed into the binary
-        processed_inputs = []
-        for input in inputs:
-            # If input is a list, iterate over its elements;
-            # otherwise, process it directly
-            input_items = input if isinstance(input, list) else [input]
-
-            for inp in input_items:
-                transformed_inp = self.transform_input(inp)
-                if transformed_inp is not None:
-                    processed_inputs.append(transformed_inp)
-
-        # Typecast the unsupported data types to hardware supported types.
-        supported_inputs = ()
-        for input in processed_inputs:
-            # Handle scalar inputs.
-            if not hasattr(input, "dtype"):
-                assert (
-                    type(input) is not bool
-                ), "Conversion for scalar boolean is not supported."
-                supported_inputs = supported_inputs + ((input),)
-                continue
-
-            # Apply type conversion if required.
-            input_type = input.dtype
-            if input_type in self.type_conversion.keys():
-                supported_inputs = supported_inputs + (
-                    (input.to(dtype=self.type_conversion[input_type])),
-                )
-                continue
-
-            # No conversion required.
-            supported_inputs = supported_inputs + ((input),)
-
-        return supported_inputs
-
-    def run_op(self, binary, *inputs):
-        inputs = self.pre_process_inputs(*inputs)
-        if not self.stderror_redirected:
-            self.file_stderr = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
-            self.stderror_redirected = True
-
-        obj = {"binary": binary, "inputs": inputs, "dump_file": self.file_stderr.name}
-
-        exec_event = mp.Event()
-        if self.execute_process is None:
-            self.execute_sender = mp.Queue()
-            self.execute_receiver = mp.Queue()
-            self.execute_process = mp.Process(
-                target=execute_process,
-                args=(self.execute_sender, self.execute_receiver, exec_event),
-            )
-            self.execute_process.start()
-        self.execute_sender.put(obj)
-        result = {}
-        start = time.time()
-        outputs = [None]
-        while True:
-            if not self.execute_process.is_alive():
-                self.execute_process = None
-                break
-            try:
-                result = self.execute_receiver.get_nowait()
-                outputs = result["outputs"]
-                exec_event.set()
-                break
-            except mp.queues.Empty:
-                pass
-            if time.time() - start > self.compiler_config.single_op_timeout:
-                self.execute_process.terminate()
-                self.execute_process = None
-                break
-
-        if len(outputs) == 1:
-            outputs = outputs[0]
-
-        stderr_data = ""
-        if outputs is None:
-            file_stderr = open(self.file_stderr.name, "r")
-            stderr_data = file_stderr.read()
-            stderr_data = stderr_data.replace("\n", "\\n")
-            stderr_data = re.sub(r"[^\x20-\x7E]", "", stderr_data)
-            file_stderr.close()
-
-        return outputs, stderr_data
-
-    def run_gm_op_by_op(self, *inputs):
-        node_to_tensor = {}
-        input_index = 0
-        outputs = []
-        num_nodes = len(self.gm.graph.nodes)
-        out_degree = {}
-        for idx, node in enumerate(self.gm.graph.nodes):
-            print(f"Compiling {idx}/{num_nodes}: {node.target}")
-            out_degree[node] = len(node.users)
-            if node.op == "placeholder":
-                node_to_tensor[node] = inputs[input_index]
-                input_index += 1
-            elif node.op == "get_attr":
-                for buffer in self.gm.named_buffers():
-                    if buffer[0] == node.target:
-                        node_to_tensor[node] = buffer[1]
-                        break
-            elif node.op == "call_function":
-                args = []
-                for arg in node.args:
-                    if isinstance(arg, torch.fx.node.Node):
-                        args.append(node_to_tensor[arg])
-                    elif isinstance(arg, list):
-                        args.append(
-                            [
-                                node_to_tensor[a]
-                                if isinstance(a, torch.fx.node.Node)
-                                else a
-                                for a in arg
-                            ]
-                        )
-                    else:
-                        args.append(arg)
-                try:
-                    binary, op = self.compile_op(node, *args, **node.kwargs)
-                except Exception as e:
-                    binary = None
-                    print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
-
-                if (
-                    self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
-                    and binary is not None
-                ):
-                    try:
-                        calculated, runtime_stack_dump = self.run_op(binary, *args)
-                        self.compiler_config.unique_ops[
-                            op.unique_key()
-                        ].runtime_stack_dump = runtime_stack_dump
-
-                        print(f"Ran: {idx}/{num_nodes}: {node.target}")
-                        if calculated is None:
-                            raise ValueError("Failed to execute")
-                        op.compilation_status = OpCompilationStatus.EXECUTED
-                        tensor = node.target(*args, **node.kwargs)
-                        if self.compiler_config.verify_op_by_op:
-                            atol = calculate_atol(calculated, tensor)
-                            op.atol = atol
-                            if atol > self.required_atol:
-                                print(f"atol too high for {idx}: {atol}")
-                            pcc = calculate_pcc(calculated, tensor)
-                            op.pcc = pcc
-                            if pcc < self.required_pcc:
-                                print(f"pcc too low for {idx}: {pcc}")
-                    except Exception as e:
-                        print(
-                            f"Failed to execute {idx}/{num_nodes}: {node.target}: {e}"
-                        )
-                        tensor = node.target(*args, **node.kwargs)
-                else:
-                    tensor = node.target(*args, **node.kwargs)
-                node_to_tensor[node] = tensor
-            elif node.op == "output":
-                args = node.args[0]
-                output_tensors = [node_to_tensor[arg] for arg in args]
-                outputs = output_tensors
-            args_set = set()
-            for arg in node.args:
-                if arg in args_set:
-                    continue
-                args_set.add(arg)
-                if isinstance(arg, torch.fx.node.Node):
-                    out_degree[arg] -= 1
-                    if out_degree[arg] == 0 and arg.op != "output":
-                        del node_to_tensor[arg]
-                        out_degree.pop(arg)
-
-        self.compiler_config.save_unique_ops()
-        if self.execute_process is not None:
-            self.execute_process.terminate()
-            self.execute_process = None
-        if self.stderror_redirected:
-            os.unlink(self.file_stderr.name)
-            self.stderror_redirected = False
-
-        return outputs
-
-    def __call__(self, *inputs):
-        new_inputs = ()
-        for input in inputs:
-            # Handle scalar inputs.
-            if not hasattr(input, "dtype"):
-                assert (
-                    type(input) is not bool
-                ), "Conversion for scalar boolean is not supported."
-                new_inputs = new_inputs + ((input),)
-                continue
-
-            # Apply type conversion if required.
-            input_type = input.dtype
-            if input_type in self.type_conversion.keys():
-                new_inputs = new_inputs + (
-                    (input.to(dtype=self.type_conversion[input_type])),
-                )
-                continue
-
-            # No conversion required.
-            new_inputs = new_inputs + ((input),)
-
-        inputs = new_inputs
-
-        if self.compiler_config.compile_depth == CompileDepth.EXECUTE:
-            assert self.binary is not None, "Binary must be set for EXECUTE mode"
-            return tt_mlir.run(inputs + self.graph_constants, self.binary)
-        elif self.compiler_config.compile_depth in (
-            CompileDepth.EXECUTE_OP_BY_OP,
-            CompileDepth.COMPILE_OP_BY_OP,
-        ):
-            return self.run_gm_op_by_op(*(inputs + self.graph_constants))
-        else:
-            return self.gm(*inputs)
+from tt_torch.dynamo.passes import pass_pipeline
+from tt_torch.dynamo.executor import Executor
+from tt_torch.tools.utils import (
+    OpByOpBackend,
+    CompilerConfig,
+    CompileDepth,
+)
 
 
 def verify_golden_callback(binary, callback_context, op_context):
@@ -575,92 +42,116 @@ def verify_golden_callback(binary, callback_context, op_context):
     # Those bindings will interact with the runtime API
 
 
-def _base_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
-    # Apply environment overrides at start of compilation to allow overriding what was set in the test
-    compiler_config.apply_environment_overrides()
+def dump_module(module, name, compiler_config):
+    if compiler_config.dump_info:
+        print(f"{name} module", file=sys.stderr)
+        module.dump(large_elements_limit=0)
+
+
+def _shlo_backend(shlo, example_inputs, compiler_config, gm=None, graph_constants=None):
+    executor = StablehloExecutor(module=shlo, compiler_config=compiler_config)
+    if gm is not None:
+        # original input is a torch graph
+        executor.add_gm(gm, graph_constants)
+    return executor
+
+
+def _torch_backend(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     with torch.no_grad():
         gm, graph_constants = pass_pipeline(gm, example_inputs, compiler_config)
-    executor = Executor(gm, graph_constants, compiler_config)
-    if compiler_config.compile_depth in (
-        CompileDepth.EXECUTE_OP_BY_OP,
-        CompileDepth.COMPILE_OP_BY_OP,
-        CompileDepth.TORCH_FX,
-    ):
-        return executor
+    executor = TorchExecutor(
+        gm=gm, graph_constants=graph_constants, compiler_config=compiler_config
+    )
+    return executor
 
-    dump_intermediates = os.environ.get("TT_TORCH_IR_LOG_LEVEL")
-    dump_info = False
-    dump_debug = False
-    if dump_intermediates:
-        dump_debug = dump_intermediates == "DEBUG"
-        dump_info = dump_debug or dump_intermediates == "INFO"
+
+def torch_to_shlo(gm: torch.fx.GraphModule, example_inputs, compiler_config):
+    with torch.no_grad():
+        gm, graph_constants = pass_pipeline(gm, example_inputs, compiler_config)
 
     module = import_graph(gm.graph)
     verify_ir(module)
 
-    if dump_info:
-        print("Torch FX module", file=sys.stderr)
-        module.dump()
+    dump_module(module=module, name="Torch FX module", compiler_config=compiler_config)
 
     if compiler_config.profile_ops:
         compiler_config.set_torch_mlir_module(module.operation.get_asm())
-    if compiler_config.compile_depth == CompileDepth.TORCH_MLIR:
-        return executor
 
     run_pipeline_with_repro_report(
         module,
         f"builtin.module(torchdynamo-export-to-torch-backend-pipeline)",
         "Lowering TorchFX IR -> Torch Backend IR",
-        dump_debug,
+        compiler_config.dump_debug,
     )
-
-    if dump_info:
-        print("Torch Backend module", file=sys.stderr)
-        module.dump()
+    dump_module(
+        module=module, name="Torch Backend module", compiler_config=compiler_config
+    )
 
     lower_mlir_module(False, OutputType.STABLEHLO, module)
 
-    if dump_info:
-        print("StableHLO module", file=sys.stderr)
-        module.dump()
+    dump_module(module=module, name="StableHLO module", compiler_config=compiler_config)
+
+    return module, gm, graph_constants
+
+
+def shlo_to_flatbuffer(executor, module, compiler_config):
 
     if compiler_config.profile_ops:
         compiler_config.set_stablehlo_mlir_module(module.operation.get_asm())
-    if compiler_config.compile_depth == CompileDepth.STABLEHLO:
-        return executor
 
-    # Need to set enable_debug_info=True to get the location information for the ops in the asm string
     ttir = tt_mlir.compile_stable_hlo_to_ttir(
         module.operation.get_asm(enable_debug_info=True)
     )
-    if dump_info:
-        print("TTIR module", file=sys.stderr)
-        print(ttir, file=sys.stderr)
+    dump_module(module=ttir, name="TTIR module", compiler_config=compiler_config)
 
     if compiler_config.enable_intermediate_verification:
         executor.register_intermediate_callback(verify_golden_callback)
 
     binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
-    if dump_info:
-        print("TTNN module", file=sys.stderr)
-        print(ttnn, file=sys.stderr)
+    dump_module(module=ttnn, name="TTNN module", compiler_config=compiler_config)
 
+    return binary
+
+
+def _base_backend(gm, example_inputs, compiler_config):
+    shlo, gm, graph_constants = torch_to_shlo(gm, example_inputs, compiler_config)
+    executor = Executor(gm, graph_constants, compiler_config)
+
+    if compiler_config.compile_depth == CompileDepth.STABLEHLO:
+        return executor
+
+    binary = shlo_to_flatbuffer(executor, shlo, compiler_config)
     executor.set_binary(binary)
     return executor
 
 
 def backend(gm, example_inputs, options=None):
+    assert isinstance(gm, torch.fx.GraphModule), "Backend only supports torch graphs"
+
     if options is None:
         options = CompilerConfig()
 
-    concrete_inputs = [
-        x.view(x.shape) if isinstance(x, torch.Tensor) else x for x in example_inputs
-    ]
-    # fake_tensor_mode = torch._dynamo.utils.detect_fake_mode(example_inputs)
-    # fake_tensor_mode.allow_non_fake_inputs = True
-    # aten = make_fx(gm, tracing_mode="symbolic", decomposition_table={}, _allow_non_fake_inputs=True)(*example_inputs)
-    # return _base_backend(aten, example_inputs)
+    # Apply environment overrides at start of compilation to allow overriding what was set in the test
+    options.apply_environment_overrides()
+
+    if (
+        options.compile_depth == CompileDepth.COMPILE_OP_BY_OP
+        or options.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+    ):
+        if options.op_by_op_backend == OpByOpBackend.TORCH:
+            # run torch graph op-by-op
+            return _torch_backend(gm, example_inputs, compiler_config=options)
+        else:
+            # op_by_op_backend == OpByOpBackend.STABLEHLO
+            # convert torch to stablehlo, then run stablehlo op-by-op
+            module, gm, graph_constants = torch_to_shlo(
+                gm, example_inputs, compiler_config=options
+            )
+            return _shlo_backend(
+                shlo=module,
+                example_inputs=example_inputs,
+                compiler_config=options,
+                gm=gm,
+                graph_constants=graph_constants,
+            )
     return _base_backend(gm, example_inputs, compiler_config=options)
-
-
-# backend = aot_autograd(fw_compiler=_base_backend)

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import tt_mlir
+import time
+import faulthandler
+import sys
+import re
+import tempfile
+import multiprocessing as mp
+from tt_torch.tools.utils import (
+    CompileDepth,
+    OpByOpBackend,
+    CompilerConfig,
+    Op,
+    OpCompilationStatus,
+)
+from typing import Union
+
+
+def compile_process(receiver, sender, ttir_event, ttnn_event, json_event):
+    obj = receiver.get()
+    faulthandler.disable()
+    asm = obj["asm"]
+    ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
+    sender.put({"ttir": ttir})
+    ttir_event.wait()
+    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
+    sender.put({"binary": binary, "ttnn": ttnn})
+    ttnn_event.wait()
+    sender.put({"json": tt_mlir.bytestream_to_json(binary)})
+    json_event.wait()
+    sys.exit(0)
+
+
+def execute_process(receiver, sender, exec_event):
+    while 1:
+        obj = receiver.get()
+        faulthandler.disable()
+        binary = obj["binary"]
+        inputs = obj["inputs"]
+        file_name = obj["dump_file"]
+        file_stderr = open(file_name, "w")
+        old_stderr = sys.stderr
+        sys.stderr = file_stderr
+        old_stdout = sys.stdout
+        sys.stdout = file_stderr
+        outputs = tt_mlir.run(inputs, binary)
+        sys.stderr = old_stderr
+        sys.stdout = old_stdout
+        file_stderr.close()
+        sender.put({"outputs": outputs})
+        exec_event.wait()
+    sys.exit(0)
+
+
+class Executor:
+    def __init__(
+        self,
+        gm: Union[torch.fx.GraphModule, None] = None,
+        graph_constants=None,
+        compiler_config=None,
+        required_pcc=0.99,
+        required_atol=1e-2,
+    ):
+        self.gm = gm
+        self.binary = None
+        if graph_constants is not None:
+            self.graph_constants = (
+                (graph_constants,)
+                if isinstance(graph_constants, (int, float))
+                else tuple(graph_constants)
+            )
+        else:
+            self.graph_constants = None
+        if compiler_config is None:
+            compiler_config = CompilerConfig()
+        self.compiler_config = compiler_config
+        self.required_atol = required_atol
+        self.required_pcc = required_pcc
+
+        # Dictionary to keep track of the type conversion for unsupported hardware
+        # types and use it to convert the input arguments to supported types.
+        self.type_conversion = {
+            torch.bool: torch.bfloat16,
+            torch.int64: torch.int32,
+            torch.float64: torch.float32,
+        }
+
+    def register_intermediate_callback(self, callback):
+        if not is_runtime_debug_enabled():
+            raise RuntimeError(
+                "Runtime debug is required to use intermediate callbacks. Please recompile this project with -DTT_RUNTIME_DEBUG=ON."
+            )
+        tt_mlir.DebugHooks.get_debug_hooks(callback)
+
+    def typecast_inputs(self, inputs):
+        new_inputs = ()
+        for input in inputs:
+            # Handle scalar inputs.
+            if not hasattr(input, "dtype"):
+                assert (
+                    type(input) is not bool
+                ), "Conversion for scalar boolean is not supported."
+                new_inputs = new_inputs + ((input),)
+                continue
+
+            # Apply type conversion if required.
+            input_type = input.dtype
+            if input_type in self.type_conversion.keys():
+                new_inputs = new_inputs + (
+                    (input.to(dtype=self.type_conversion[input_type])),
+                )
+                continue
+
+            # No conversion required.
+            new_inputs = new_inputs + ((input),)
+        return new_inputs
+
+    def set_binary(self, binary):
+        self.binary = binary
+
+    def __call__(self, *inputs):
+        if self.compiler_config.compile_depth != CompileDepth.EXECUTE:
+            assert self.gm != None, "Cannot run base executor without torch graph"
+            return self.gm(*inputs)
+
+        assert self.binary is not None
+        if self.compiler_config.typecast_inputs:
+            inputs = self.typecast_inputs(inputs)
+        if self.graph_constants is not None:
+            inputs = inputs + self.graph_constants
+        return tt_mlir.run(inputs, self.binary)
+
+
+class OpByOpExecutor(Executor):
+    def __init__(
+        self,
+        compiler_config=None,
+        required_pcc=0.99,
+        required_atol=1e-2,
+    ):
+        super().__init__(
+            gm=None,
+            graph_constants=None,
+            compiler_config=compiler_config,
+            required_pcc=required_pcc,
+            required_atol=required_atol,
+        )
+
+        # Opening a device in a new process is very slow as the pcie device needs to be initializes
+        # So we keep the process alive and reuse it. If the process dies, the next call will create a new process
+        self.execute_process = None
+        self.execute_sender = None
+        self.execute_receiver = None
+
+        # Create temp file at start of execution of first op and pass the name
+        # of temp file to subprocess which will be used to redirect the stderr
+        # to capture runtime stack dump.
+        self.stderror_redirected = False
+        self.file_stderr = None
+
+    def transform_input(self, inp):
+        # Convert torch.nn.Parameter to torch.Tensor and convert non-contiguous
+        # data to contiguous.
+        if isinstance(inp, torch.nn.Parameter):
+            if not inp.data.is_contiguous():
+                inp.data = inp.data.contiguous()
+            return inp.data
+        elif isinstance(inp, torch.Tensor):
+            if not inp.is_contiguous():
+                inp = inp.contiguous()
+            return inp
+
+        return None
+
+    def pre_process_inputs(self, *inputs):
+        # Remove scalar constants as they're absorbed into the binary
+        processed_inputs = []
+        for input in inputs:
+            # If input is a list, iterate over its elements;
+            # otherwise, process it directly
+            input_items = input if isinstance(input, list) else [input]
+
+            for inp in input_items:
+                transformed_inp = self.transform_input(inp)
+                if transformed_inp is not None:
+                    processed_inputs.append(transformed_inp)
+
+        # Typecast the unsupported data types to hardware supported types.
+        supported_inputs = ()
+        for input in processed_inputs:
+            # Handle scalar inputs.
+            if not hasattr(input, "dtype"):
+                assert (
+                    type(input) is not bool
+                ), "Conversion for scalar boolean is not supported."
+                supported_inputs = supported_inputs + ((input),)
+                continue
+
+            # Apply type conversion if required.
+            input_type = input.dtype
+            if input_type in self.type_conversion.keys():
+                supported_inputs = supported_inputs + (
+                    (input.to(dtype=self.type_conversion[input_type])),
+                )
+                continue
+
+            # No conversion required.
+            supported_inputs = supported_inputs + ((input),)
+
+        return supported_inputs
+
+    def get_input_shapes_and_constants(self, *inputs):
+        input_shapes_and_constants = []
+        for inp in inputs:
+            if isinstance(inp, torch.Tensor):
+                input_shapes_and_constants.append(inp.shape)
+            elif isinstance(inp, (list, tuple)):
+                sub = []
+                for sub_inp in inp:
+                    if isinstance(sub_inp, torch.Tensor):
+                        sub.append(sub_inp.shape)
+                    else:
+                        sub.append(sub_inp)
+                input_shapes_and_constants.append(sub)
+            elif isinstance(inp, (int, float, bool)):
+                input_shapes_and_constants.append(inp)
+            elif isinstance(inp, torch.dtype):
+                input_shapes_and_constants.append(inp.__str__())
+            elif inp is None:
+                input_shapes_and_constants.append(None)
+            else:
+                raise ValueError(f"Unexpected input type: {type(inp)}")
+        return input_shapes_and_constants
+
+    def compile_op(self, node, *inputs, **kwargs):
+        # get_stablehlo_graph is a method implemented in inheriting classes
+        module, op = self.get_stable_hlo_graph(node, inputs, **kwargs)
+
+        if module is None or op is None:
+            return None, None
+
+        sender = mp.Queue()
+        receiver = mp.Queue()
+        ttir_event = mp.Event()
+        ttnn_event = mp.Event()
+        json_event = mp.Event()
+        obj = {"asm": module.operation.get_asm()}
+        process = mp.Process(
+            target=compile_process,
+            args=(sender, receiver, ttir_event, ttnn_event, json_event),
+        )
+        process.start()
+        sender.put(obj)
+        start = time.time()
+        binary = None
+        while True:
+            try:
+                result = receiver.get_nowait()
+                if "ttir" in result:
+                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTIR
+                    op.add_ttir_graph(result["ttir"])
+                    ttir_event.set()
+                if "binary" in result:
+                    binary = result["binary"]
+                    op.binary = binary
+                    op.add_ttnn_graph(result["ttnn"])
+                    ttnn_event.set()
+                if "json" in result:
+                    op.json = result["json"]
+                    json_event.set()
+                    op.parse_json()
+                    op.compilation_status = OpCompilationStatus.CONVERTED_TO_TTNN
+                    break
+            except mp.queues.Empty:
+                pass
+            except Exception as e:
+                process.terminate()
+                raise e
+            if time.time() - start > self.compiler_config.single_op_timeout:
+                process.terminate()
+                break
+            if not process.is_alive():
+                break
+            time.sleep(0.01)
+        process.join()
+        print(f"json len {len(op.json)}")
+        return binary, op
+
+    def run_op(self, binary, *inputs):
+        inputs = self.pre_process_inputs(*inputs)
+        if not self.stderror_redirected:
+            self.file_stderr = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
+            self.stderror_redirected = True
+
+        obj = {"binary": binary, "inputs": inputs, "dump_file": self.file_stderr.name}
+
+        exec_event = mp.Event()
+        if self.execute_process is None:
+            self.execute_sender = mp.Queue()
+            self.execute_receiver = mp.Queue()
+            self.execute_process = mp.Process(
+                target=execute_process,
+                args=(self.execute_sender, self.execute_receiver, exec_event),
+            )
+            self.execute_process.start()
+        self.execute_sender.put(obj)
+        result = {}
+        start = time.time()
+        outputs = [None]
+        while True:
+            if not self.execute_process.is_alive():
+                self.execute_process = None
+                break
+            try:
+                result = self.execute_receiver.get_nowait()
+                outputs = result["outputs"]
+                exec_event.set()
+                break
+            except mp.queues.Empty:
+                pass
+            if time.time() - start > self.compiler_config.single_op_timeout:
+                self.execute_process.terminate()
+                self.execute_process = None
+                break
+
+        if len(outputs) == 1:
+            outputs = outputs[0]
+
+        stderr_data = ""
+        if outputs is None:
+            file_stderr = open(self.file_stderr.name, "r")
+            stderr_data = file_stderr.read()
+            stderr_data = stderr_data.replace("\n", "\\n")
+            stderr_data = re.sub(r"[^\x20-\x7E]", "", stderr_data)
+            file_stderr.close()
+
+        return outputs, stderr_data

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch_mlir
+import tt_mlir
+from mlir.ir import Context, Module
+from torch_mlir._mlir_libs._mlir import ir
+import mlir.dialects.stablehlo as stablehlo
+import re
+import os
+from typing import Union
+
+from tt_torch.tools.utils import (
+    CompilerConfig,
+    CompileDepth,
+    Op,
+    OpByOpBackend,
+    OpCompilationStatus,
+    calculate_atol,
+    calculate_pcc,
+)
+
+from tt_torch.dynamo.executor import OpByOpExecutor
+
+#########################################################
+# Helper functions
+#########################################################
+
+
+def generate_random_inputs_for_shlo(module_str):
+    func_match = re.search(r"func\.func @\w+\((.*?)\)", module_str)
+    if not func_match:
+        raise ValueError("Could not find function signature in StableHLO module")
+
+    args_str = func_match.group(1)
+
+    # Match the function arguments
+    args = re.findall(r"%arg\d+:\s+tensor<([^>]+)>", args_str)
+
+    inputs = []
+    for shape_str in args:
+        # Check if shape_str contains dimensions (e.g., 1x784x or f32)
+        shape_dtype_match = re.match(r"([\dx]+)x([^>]+)", shape_str)
+
+        if shape_dtype_match:
+            # If it matches the pattern of dimensions and data type (like 1x784xf32)
+            shape_str, dtype_str = shape_dtype_match.groups()
+
+            dims = [int(dim) for dim in shape_str.split("x")]
+
+            if dtype_str == "f32":
+                inputs.append(torch.randn(dims, dtype=torch.float32))
+            elif dtype_str == "f16":
+                inputs.append(torch.randn(dims, dtype=torch.float16))
+            elif dtype_str == "bf16":
+                inputs.append(torch.randn(dims, dtype=torch.bfloat16))
+            elif dtype_str == "f64":
+                inputs.append(torch.randn(dims, dtype=torch.float64))
+            elif dtype_str.startswith("i") or dtype_str.startswith("si"):
+                bit_width = int(
+                    re.search(r"i(\d+)|si(\d+)", dtype_str).group(1)
+                    or re.search(r"i(\d+)|si(\d+)", dtype_str).group(2)
+                )
+                max_val = min(
+                    100,
+                    2 ** (bit_width - 1) - 1
+                    if dtype_str.startswith("si")
+                    else 2**bit_width - 1,
+                )
+                inputs.append(
+                    torch.randint(
+                        -max_val if dtype_str.startswith("si") else 0, max_val, dims
+                    )
+                )
+            elif dtype_str.startswith("ui"):
+                bit_width = int(re.search(r"ui(\d+)", dtype_str).group(1))
+                max_val = min(100, 2**bit_width - 1)
+                inputs.append(torch.randint(0, max_val, dims))
+            else:
+                raise ValueError(f"Unsupported datatype: {dtype_str}")
+
+        else:
+            # If the shape_str is just a data type (e.g., "f32"), treat it as a scalar or unknown shape
+            if shape_str == "f32":
+                inputs.append(torch.randn((), dtype=torch.float32))
+            elif shape_str == "f16":
+                inputs.append(torch.randn((), dtype=torch.float16))
+            elif shape_str == "bf16":
+                inputs.append(torch.randn((), dtype=torch.bfloat16))
+            elif shape_str == "f64":
+                inputs.append(torch.randn((), dtype=torch.float64))
+            elif shape_str.startswith("i") or shape_str.startswith("si"):
+                bit_width = int(
+                    re.search(r"i(\d+)|si(\d+)", shape_str).group(1)
+                    or re.search(r"i(\d+)|si(\d+)", shape_str).group(2)
+                )
+                max_val = min(
+                    100,
+                    2 ** (bit_width - 1) - 1
+                    if shape_str.startswith("si")
+                    else 2**bit_width - 1,
+                )
+                inputs.append(
+                    torch.randint(
+                        -max_val if shape_str.startswith("si") else 0, max_val, ()
+                    )
+                )
+            elif shape_str.startswith("ui"):
+                bit_width = int(re.search(r"ui(\d+)", shape_str).group(1))
+                max_val = min(100, 2**bit_width - 1)
+                inputs.append(torch.randint(0, max_val, ()))
+            else:
+                raise ValueError(f"Unsupported dtype: {shape_str}")
+
+    return tuple(inputs)
+
+
+def parse_module_from_str(module_str):
+    module = None
+    with Context() as ctx:
+        stablehlo.register_dialect(ctx)
+        module = Module.parse(module_str)
+    return module
+
+
+def print_shape(shape):
+    return "x".join(str(s) for s in shape)
+
+
+#########################################################
+# StableHlo Op Class which inherits from Op Class
+#########################################################
+
+
+class StablehloOp(Op):
+    def __init__(
+        self,
+        model_name,
+        op_id,
+        original_shlo,
+    ):
+        super().__init__("", [], model_name)
+        self.op_id = op_id
+        self.compilation_status = OpCompilationStatus.CREATED_GRAPH
+        self.original_shlo = original_shlo
+        self.op_name = self._extract_op_name()
+        self.input_shapes = self._extract_input_shapes()
+        self.unique_key = ""
+        self.set_unique_key()
+
+    def _extract_op_name(self):
+        # Extract operation name from either stablehlo or arith
+        match = re.search(r"(stablehlo|arith)\.[a-zA-Z_]+", self.original_shlo)
+        return match.group(0) if match else "unknown_op"
+
+    def _extract_input_shapes(self):
+        # Extract shapes handling both f32 and i64 types
+        shapes = []
+        # Look for tensor patterns with various types
+        shape_patterns = re.findall(r"tensor<([0-9x]+)x[fi][0-9]+>", self.original_shlo)
+        for shape_str in shape_patterns:
+            # Convert each dimension to int, handling both single and multi-dimensional cases
+            shape = tuple(int(dim) for dim in shape_str.split("x"))
+            shapes.append(shape)
+        return shapes
+
+    def set_unique_key(self):
+        """Generate a unique key based on operation name and input shapes"""
+        key = self.op_name
+        for shape in self.input_shapes:
+            key += f"_{print_shape(shape)}"
+        self.unique_key = key
+
+    def to_dict(self):
+        def scrub_nan_inf(value):
+            if isinstance(value, float):
+                if math.isnan(value):
+                    ret = "NaN"
+                elif math.isinf(value):
+                    ret = "Inf"
+                else:
+                    ret = f"{value:.2f}"
+            else:
+                ret = ""
+            return ret
+
+        pcc = scrub_nan_inf(self.pcc)
+        atol = scrub_nan_inf(self.atol)
+
+        return {
+            "frontend": self.frontend,
+            "model_name": self.model_name,
+            "input_shapes": self.print_shapes(self.input_shapes),
+            "input_tensors": [tensor.to_dict() for tensor in self.input_tensors],
+            "output_shapes": self.print_shapes(self.output_shapes),
+            "output_tensors": [tensor.to_dict() for tensor in self.output_tensors],
+            "num_ops": self.num_ops,
+            "compilation_status": self.compilation_status,
+            # "parsed_stable_hlo_ops": self.parsed_stable_hlo_ops,
+            # "torch_ir_graph": self.torch_ir_graph,
+            "stable_hlo_graph": self.stable_hlo_graph,
+            # "stable_hlo_ops": self.stable_hlo_ops,
+            "ttir_graph": self.ttir_graph,
+            "ttnn_graph": self.ttnn_graph,
+            "runtime_stack_dump": self.runtime_stack_dump,
+            "pcc": pcc,
+            "atol": atol,
+            "compiled_json": self.json,
+        }
+
+
+#########################################################
+# StablehloExecutor covers op-by-op CompileDepth Options
+#########################################################
+
+
+class StablehloExecutor(OpByOpExecutor):
+    def __init__(
+        self,
+        module: Union[str, "torch_mlir._mlir_libs._mlir.ir.Module", None] = None,
+        compiler_config=None,
+        required_pcc=0.99,
+        required_atol=1e-2,
+    ):
+        super().__init__(
+            compiler_config=compiler_config,
+            required_pcc=required_pcc,
+            required_atol=required_atol,
+        )
+        self.parsed_module = None
+        if module is not None:
+            self.set_module(module)
+        self.sub_ops = []
+        self.get_ops_in_module(self.parsed_module)
+        self.gm = None
+        self.graph_constants = None
+
+    def set_module(
+        self, module: Union[str, "torch_mlir._mlir_libs._mlir.ir.Module"]
+    ) -> None:
+        if isinstance(module, str):
+            self.parsed_module = parse_module_from_str(module)
+        elif isinstance(module, (ir.Module, ir.Operation)):
+            self.parsed_module = module
+        else:
+            raise ValueError(f"Invalid module type: {type(module)}")
+
+    def add_gm(self, gm: torch.fx.GraphModule, graph_constants):
+        assert (
+            self.compiler_config.compile_depth == CompileDepth.COMPILE_OP_BY_OP
+            or self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+        ) and self.compiler_config.op_by_op_backend == OpByOpBackend.STABLEHLO, (
+            "gm can only be added in op by op mode"
+        )
+        self.gm = gm
+        self.graph_constants = (
+            (graph_constants,)
+            if isinstance(graph_constants, (int, float))
+            else tuple(graph_constants)
+        )
+
+    def get_stable_hlo_graph(self, op, inputs, **kwargs):
+        if op.unique_key not in self.compiler_config.unique_ops:
+            self.compiler_config.unique_ops[op.unique_key] = op
+        else:
+            self.compiler_config.unique_ops[op.unique_key].num_ops += 1
+            return None, None
+
+        module = parse_module_from_str(op.stable_hlo_graph)
+        asm = module.operation.get_asm()
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_STABLE_HLO
+        op.add_stable_hlo_graph(asm)
+        return module, op
+
+    def get_ops_in_module(self, module_or_op):
+        if hasattr(module_or_op, "body"):
+            # This is likely a Module object
+            module_body = module_or_op.body
+        elif hasattr(module_or_op, "operation") and hasattr(
+            module_or_op.operation, "regions"
+        ):
+            # This is likely an Operation that represents a module
+            # Get the first region's first block
+            module_body = module_or_op.operation.regions[0].blocks[0]
+        else:
+            raise TypeError(
+                "Input must be either a Module object or an Operation representing a module"
+            )
+
+        for func_op in module_body.operations:
+            for block in func_op.regions[0].blocks:
+                for op in block.operations:
+                    if op.name.startswith(("func.", "return")):
+                        continue
+
+                    inputs = {
+                        operand.get_name(): str(operand.type) for operand in op.operands
+                    }
+                    args_str = ", ".join(f"{key}: {typ}" for key, typ in inputs.items())
+
+                    # Handle multiple results in the operation
+                    result_names = [str(result.get_name()) for result in op.results]
+                    result_types = [str(result.type) for result in op.results]
+
+                    # Construct the function signature based on the number of results
+                    if len(result_names) == 1:
+                        result_str = f"{result_types[0]}"
+                        return_stmt = f"return {result_names[0]} : {result_types[0]}"
+                    else:
+                        result_str = f"({', '.join(result_types)})"
+                        return_stmt = f"return ({', '.join(result_names)}) : ({', '.join(result_types)})"
+                    # Build the new module string
+                    new_module_str = f"""module {{
+        func.func @main({args_str}) -> {result_str} {{
+            {str(op)}
+            {return_stmt}
+        }}
+    }}"""
+
+                    opObj = StablehloOp(
+                        model_name=self.compiler_config.model_name,
+                        op_id=", ".join(result_names),
+                        original_shlo=str(op),
+                    )
+                    opObj.add_stable_hlo_graph(new_module_str)
+                    self.sub_ops.append(opObj)
+
+    def shlo_op_by_op(self):
+        calculated = None
+        num_ops = len(self.sub_ops)
+        for idx, op in enumerate(self.sub_ops):
+            print(f"Compiling {idx}/{num_ops}: {op.op_name}")
+            try:
+                binary, op = self.compile_op(op, None, None)
+            except Exception as e:
+                binary = None
+                print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
+            if (
+                self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+                and binary is not None
+            ):
+                try:
+                    inputs = generate_random_inputs_for_shlo(op.stable_hlo_graph)
+                    inputs = self.typecast_inputs(inputs)
+                    calculated, runtime_stack_dump = self.run_op(binary, *inputs)
+                    self.compiler_config.unique_ops[
+                        op.unique_key
+                    ].runtime_stack_dump = runtime_stack_dump
+                    print(f"Ran: {idx}/{num_ops}: {op.op_name}")
+                    if calculated is None:
+                        raise ValueError("Failed to execute")
+                    op.compilation_status = OpCompilationStatus.EXECUTED
+                except Exception as e:
+                    print(f"Failed to execute {idx}/{num_ops}: {op.op_name}: {e}")
+        self.binary = binary
+        self.compiler_config.save_unique_ops()
+        if self.execute_process is not None:
+            self.execute_process.terminate()
+            self.execute_process = None
+        if self.stderror_redirected:
+            os.unlink(self.file_stderr.name)
+            self.stderror_redirected = False
+
+    def print_op(self, op):
+        print(op.op_id)
+        print(op.stable_hlo_graph)
+        print(op.ttir_graph)
+        print(op.ttnn_graph)
+        print(op.json)
+
+    def print_ops(self):
+        for op in self.sub_ops:
+            self.print_op(op)
+
+    def __call__(self, *inputs):
+
+        inputs = self.typecast_inputs(inputs)
+
+        if self.compiler_config.compile_depth in (
+            CompileDepth.EXECUTE_OP_BY_OP,
+            CompileDepth.COMPILE_OP_BY_OP,
+        ):
+            self.shlo_op_by_op()
+        else:
+            assert False, "Invalid compile depth"
+
+        if self.gm is not None:
+            return self.gm(*inputs)
+
+        if self.binary is not None:
+            return tt_mlir.run(inputs, self.binary)

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import operator
+import tt_mlir
+import torch_mlir
+import os
+from torch_mlir.dialects import torch as torch_dialect
+
+from typing import Optional
+from tt_torch.tools.utils import (
+    CompilerConfig,
+    CompileDepth,
+    Op,
+    OpCompilationStatus,
+    calculate_atol,
+    calculate_pcc,
+)
+from torch_mlir.compiler_utils import (
+    OutputType,
+    run_pipeline_with_repro_report,
+    lower_mlir_module,
+)
+from torch_mlir.extras.fx_importer import FxImporter, ContextCache
+from torch_mlir.ir import Context, Location
+from tt_torch.dynamo.executor import (
+    Executor,
+    OpByOpExecutor,
+)
+
+#########################################################
+# Helper functions
+#########################################################
+
+
+def verify_ir(module):
+    def verify_op(op):
+        if hasattr(op, "verify"):
+            op.verify()
+        return torch_mlir.ir.WalkResult.ADVANCE
+
+    module.operation.walk(verify_op)
+
+
+class TTContextCache(ContextCache):
+    def get_node_location(self, node: torch.fx.Node) -> Optional[Location]:
+        return Location.name(node.name, context=self._c)
+
+
+def import_graph(graph: torch.fx.GraphModule):
+    context = Context()
+    torch_dialect.register_dialect(context)
+    importer = FxImporter(context=context)
+    importer._cc = TTContextCache(
+        importer._c, py_attr_tracker=importer._py_attr_tracker
+    )
+    importer.import_stateless_graph(graph)
+    return importer.module
+
+
+def lower_to_stable_hlo(module, op=None, enable_ir_printing=False):
+    run_pipeline_with_repro_report(
+        module,
+        f"builtin.module(torchdynamo-export-to-torch-backend-pipeline)",
+        "Lowering TorchFX IR -> Torch Backend IR",
+        enable_ir_printing,
+    )
+    if op is not None:
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_BACKEND_IR
+
+    lower_mlir_module(False, OutputType.STABLEHLO, module)
+    if op is not None:
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_STABLE_HLO
+
+
+##################################################################
+# TorchExecutor covers all CompileDepth options except for EXECUTE
+##################################################################
+
+
+class TorchExecutor(OpByOpExecutor):
+    def __init__(
+        self,
+        gm,
+        graph_constants,
+        compiler_config=None,
+        required_pcc=0.99,
+        required_atol=1e-2,
+    ):
+        super().__init__(
+            compiler_config=compiler_config,
+            required_pcc=required_pcc,
+            required_atol=required_atol,
+        )
+        self.gm = gm
+        self.graph_constants = (
+            (graph_constants,)
+            if isinstance(graph_constants, (int, float))
+            else tuple(graph_constants)
+        )
+        if self.compiler_config is None:
+            compiler_config = CompilerConfig()
+        self.compiler_config = compiler_config
+
+    def is_node_valid(self, node):
+        if not isinstance(node.target, torch._ops.OpOverload):
+            if "getitem" not in name:
+                raise ValueError(f"Node target is not an OpOverload: {name}")
+            return False
+        return True
+
+    def get_node_name(self, node):
+        name = node.target.name() if hasattr(node.target, "name") else node.name
+        return name
+
+    def get_stable_hlo_graph(self, node, inputs, **kwargs):
+
+        input_shapes_and_constants = self.get_input_shapes_and_constants(inputs)
+
+        name = node.target.name() if hasattr(node.target, "name") else node.name
+        if not isinstance(node.target, torch._ops.OpOverload):
+            if "getitem" not in name:
+                raise ValueError(f"Node target is not an OpOverload: {name}")
+            return None, None
+
+        op = Op(name, input_shapes_and_constants, self.compiler_config.model_name)
+        if op.unique_key() not in self.compiler_config.unique_ops:
+            self.compiler_config.unique_ops[op.unique_key()] = op
+        else:
+            self.compiler_config.unique_ops[op.unique_key()].num_ops += 1
+            return None, None
+
+        graph = torch.fx.Graph()
+        placeholders = []
+        for inp in inputs:
+            if isinstance(inp, torch.Tensor):
+                placeholders.append(graph.placeholder("input"))
+            elif isinstance(inp, (list, tuple)):
+                inps = torch.fx.immutable_collections.immutable_list(
+                    [
+                        graph.placeholder(f"input_{idx}")
+                        if isinstance(sub_inp, torch.Tensor)
+                        else sub_inp
+                        for idx, sub_inp in enumerate(inp)
+                    ]
+                )
+                placeholders.append(inps)
+            else:
+                placeholders.append(inp)
+
+        if len(placeholders) != len(node.args):
+            # are any of the args duplicates? If so, we need to duplicate the placeholders
+            for idx, arg in enumerate(node.args):
+                if arg in node.args[idx + 1 :]:
+                    placeholders.append(placeholders[idx])
+
+        placeholders = tuple(placeholders)
+        for placeholder, arg in zip(placeholders, node.args):
+            if isinstance(placeholder, torch.fx.node.Node):
+                placeholder.meta["tensor_meta"] = arg.meta["tensor_meta"]
+            elif isinstance(placeholder, (list, tuple)):
+                for sub_placeholder, sub_arg in zip(placeholder, arg):
+                    if isinstance(sub_placeholder, torch.fx.node.Node):
+                        sub_placeholder.meta["tensor_meta"] = sub_arg.meta[
+                            "tensor_meta"
+                        ]
+
+        graph_node = graph.call_function(node.target, placeholders, kwargs)
+        graph_node.meta["tensor_meta"] = node.meta["tensor_meta"]
+
+        # if the node has multiple outputs, add a getitem for each and append to graph
+        if not isinstance(
+            node.meta["tensor_meta"], torch.fx.passes.shape_prop.TensorMetadata
+        ):
+            getitem_nodes = []
+            graph_node.meta["val"] = node.meta["val"]
+
+            for idx, tensor_meta in enumerate(node.meta["tensor_meta"]):
+                # filter out unused outputs that do not exist in the reduced graph
+                users = self.gm.graph.find_nodes(
+                    op="call_function", target=operator.getitem
+                )
+                if not any(user_node.args == (node, idx) for user_node in users):
+                    continue
+
+                getitem_node = graph.call_function(
+                    operator.getitem, args=(graph_node, idx)
+                )
+                getitem_nodes.append(getitem_node)
+                getitem_node.meta["tensor_meta"] = tensor_meta
+            out = graph.output(tuple(getitem_nodes))
+            if len(node.users) != len(graph_node.users):
+                raise ValueError(
+                    f"Op Node {node} has different number of users({len(graph_node.users)}) from global graph({len(node.users)})"
+                )
+        else:
+            out = graph.output((graph_node,))
+        if "tensor_meta" not in node.meta:
+            raise ValueError(f"Node {node} does not have tensor_meta")
+
+        op.compilation_status = OpCompilationStatus.CREATED_GRAPH
+        out.meta["tensor_meta"] = node.meta["tensor_meta"]
+
+        out_meta = out.meta["tensor_meta"]
+        if isinstance(out_meta, torch.fx.passes.shape_prop.TensorMetadata):
+            out_meta = (out_meta,)
+        for out in out_meta:
+            op.output_shapes.append([dim for dim in out.shape])
+
+        module = import_graph(graph)
+        op.compilation_status = OpCompilationStatus.CONVERTED_TO_TORCH_IR
+        op.add_torch_ir_graph(module.operation.get_asm())
+        lower_to_stable_hlo(module, op=op)
+        op.add_stable_hlo_graph(module.operation.get_asm())
+        return module, op
+
+    def run_gm_op_by_op(self, *inputs):
+        node_to_tensor = {}
+        input_index = 0
+        outputs = []
+        num_nodes = len(self.gm.graph.nodes)
+        out_degree = {}
+        for idx, node in enumerate(self.gm.graph.nodes):
+            print(f"Compiling {idx}/{num_nodes}: {node.target}")
+            out_degree[node] = len(node.users)
+            if node.op == "placeholder":
+                node_to_tensor[node] = inputs[input_index]
+                input_index += 1
+            elif node.op == "get_attr":
+                for buffer in self.gm.named_buffers():
+                    if buffer[0] == node.target:
+                        node_to_tensor[node] = buffer[1]
+                        break
+            elif node.op == "call_function":
+                args = []
+                for arg in node.args:
+                    if isinstance(arg, torch.fx.node.Node):
+                        args.append(node_to_tensor[arg])
+                    elif isinstance(arg, list):
+                        args.append(
+                            [
+                                node_to_tensor[a]
+                                if isinstance(a, torch.fx.node.Node)
+                                else a
+                                for a in arg
+                            ]
+                        )
+                    else:
+                        args.append(arg)
+                try:
+                    binary, op = self.compile_op(node, *args, **node.kwargs)
+                except Exception as e:
+                    binary = None
+                    print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
+
+                if (
+                    self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
+                    and binary is not None
+                ):
+                    try:
+                        calculated, runtime_stack_dump = self.run_op(binary, *args)
+                        self.compiler_config.unique_ops[
+                            op.unique_key()
+                        ].runtime_stack_dump = runtime_stack_dump
+
+                        print(f"Ran: {idx}/{num_nodes}: {node.target}")
+                        if calculated is None:
+                            raise ValueError("Failed to execute")
+                        op.compilation_status = OpCompilationStatus.EXECUTED
+                        tensor = node.target(*args, **node.kwargs)
+                        if self.compiler_config.verify_op_by_op:
+                            atol = calculate_atol(calculated, tensor)
+                            op.atol = atol
+                            if atol > self.required_atol:
+                                print(f"atol too high for {idx}: {atol}")
+                            pcc = calculate_pcc(calculated, tensor)
+                            op.pcc = pcc
+                            if pcc < self.required_pcc:
+                                print(f"pcc too low for {idx}: {pcc}")
+                    except Exception as e:
+                        print(
+                            f"Failed to execute {idx}/{num_nodes}: {node.target}: {e}"
+                        )
+                        tensor = node.target(*args, **node.kwargs)
+                else:
+                    tensor = node.target(*args, **node.kwargs)
+                node_to_tensor[node] = tensor
+            elif node.op == "output":
+                args = node.args[0]
+                output_tensors = [node_to_tensor[arg] for arg in args]
+                outputs = output_tensors
+            args_set = set()
+            for arg in node.args:
+                if arg in args_set:
+                    continue
+                args_set.add(arg)
+                if isinstance(arg, torch.fx.node.Node):
+                    out_degree[arg] -= 1
+                    if out_degree[arg] == 0 and arg.op != "output":
+                        del node_to_tensor[arg]
+                        out_degree.pop(arg)
+
+        self.compiler_config.save_unique_ops()
+        if self.execute_process is not None:
+            self.execute_process.terminate()
+            self.execute_process = None
+        if self.stderror_redirected:
+            os.unlink(self.file_stderr.name)
+            self.stderror_redirected = False
+
+        return outputs
+
+    def __call__(self, *inputs):
+        inputs = self.typecast_inputs(inputs)
+        if self.compiler_config.compile_depth in (
+            CompileDepth.EXECUTE_OP_BY_OP,
+            CompileDepth.COMPILE_OP_BY_OP,
+        ):
+            return self.run_gm_op_by_op(*(inputs + self.graph_constants))
+        else:
+            return self.gm(*inputs)

--- a/tt_torch/onnx_compile/__init__.py
+++ b/tt_torch/onnx_compile/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from .onnx_compile import compile_onnx
+from .onnx_compile import onnx_to_stablehlo, compile_onnx

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -206,11 +206,8 @@ def _verify_onnx_module(
 
     for i in range(len(golden)):
         golden[i] = torch.tensor(golden[i])
-
     mod = onnx.load(filename)
-    binary = compile_onnx(mod)
-
-    ret = tt_mlir.run(inputs, binary)
+    ret = compile_onnx(mod, inputs, compiler_config)
     assert len(golden) == len(
         ret
     ), f"Number of outputs mismatch between golden and compiled: {len(golden)} vs {len(ret)}"


### PR DESCRIPTION
**Backend**
- Entry point for torch graph
- Decided that if input is onnx, it should call _shlo_backend or the executors separately from `compile_onnx`

**Base vs Torch vs Stablehlo Backends:**
- Torch and Stablehlo Backends refer to `COMPILE_OP_BY_OP`/ `EXECUTE_OP_BY_OP` 
- Base backend refers to Compile Depths: `TORCH_FX`, `STABLEHLO`, `TTNN_IR`, `EXECUTE`

**Executor/ OpByOpExecutor/ StablehloExecutor/ TorchExecutor**
- `Executor` is the base class which runs the binary or the graph, depending on compile depth. 
- `OpByOpExecutor` inherits from base `Executor`. Allows op-by-op compilation/ execution of stablehlo or torch ops through `compile_op` / `run_op` functions. 
- `StablehloExecutor` inherits from `OpByOpExecutor`. It parses stablehlo module and creates a module for each op  in `get_ops_in_module` to allow op-by-op compilation/ execution. Implements `get_stable_hlo_graph` and `shlo_op_by_op`. 
- `TorchExecutor` inherits from `OpByOpExecutor`. Implements `get_stable_hlo_graph` and `gm_op_by_op`. 

**Shared Functions between StablehloExecutor and TorchExecutor**
- `transform_input` , `pre_process_inputs`: helper functions for input manipulation/ preparation 
- `compile_op`: lowers a node/ op to stablehlo, then passes through pybinded functions to lower to ttnn/ binary. 
- `run_op`: given a binary and inputs, runs the binary with the inputs
- `get_stable_hlo_graph`: this function is implemented differently in both backends. This is expected since the starting point of `TorchExecutor` is a torch node, whereas for `StablehloExecutor` is a Stablehlo module. They return an mlir stablehlo `module` object and an `op` element. 

**shlo_op_by_op/ gm_op_by_op**
- These functions are very similar to one another, but one runs a stablehlo graph op by op, the other runs a torch graph op by op. Both call `compile_op` and `run_op` commands. 
- For stablehlo, I implemented a random input generator to be able to run the op. `generate_random_inputs_for_shlo`

**onnx support**
- Created `onnx_to_stablehlo` function which can be used to pipe to stablehlo backend
- Restructured `_verify_onnx_module` to run with stablehlo backend
- Added many onnx tests to test_basic.py
- Restructured `compile_onnx` function:

```
def compile_onnx(module: onnx.ModelProto, example_inputs, options=None):

    if options is None:
        options = CompilerConfig()
    options.op_by_op_backend = OpByOpBackend.STABLEHLO
    options.typecast_inputs = False
    options.apply_environment_overrides()
    if (
        options.compile_depth == CompileDepth.COMPILE_OP_BY_OP
        or options.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
    ):
        module = onnx_to_stablehlo(module, options)
        executor = StablehloExecutor(module=module, compiler_config=options)
        return executor(*example_inputs)
    elif options.compile_depth == CompileDepth.EXECUTE:
        module = onnx_to_stablehlo(module, options)
        executor = Executor(gm=None, graph_constants=None, compiler_config=options)
        ttir = tt_mlir.compile_stable_hlo_to_ttir(
            module.operation.get_asm(enable_debug_info=True)
        )
        dump_module(module=ttir, name="TTIR module", compiler_config=options)
        binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
        dump_module(module=ttnn, name="TTNN module", compiler_config=options)
        executor.set_binary(binary)
        return executor(*example_inputs)
```