### PR TITLE
Extend op by op tests timeout from 180->360m

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   tests:
-    timeout-minutes: 180
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Ticket
#410 

### Problem description
Nightly op by op tests are timing out randomly, 
possibly due to a runtime perf regression. This causes
nondeterministic nightly test failures.

### What's changed
Increase the nightly test timeouts from 180 to 360m,
per job (i.e. each group of testcases that is run in series).

### Checklist
- [x] New/Existing tests provide coverage for changes
