### PR TITLE
Properly unpack inputs to get_input_shapes_and_constants

### DIFF
--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -116,7 +116,7 @@ class TorchExecutor(OpByOpExecutor):
 
     def get_stable_hlo_graph(self, node, inputs, **kwargs):
 
-        input_shapes_and_constants = self.get_input_shapes_and_constants(inputs)
+        input_shapes_and_constants = self.get_input_shapes_and_constants(*inputs)
 
         name = node.target.name() if hasattr(node.target, "name") else node.name
         if not isinstance(node.target, torch._ops.OpOverload):


### PR DESCRIPTION
### Ticket
#412 

### Problem description
Inputs are implicitly wrapped in a tuple when not using `*`
to pass them into get_input_shapes_and_constants.

### What's changed
Add `*` to unpack inputs as individual args, not as a single
element so the outer `for inp in inputs` loop runs multiple times.

### Checklist
- [x] New/Existing tests provide coverage for changes
