### PR TITLE
Runtime stitching bringup: Added granular runtime APIs e2e, added distilbert multi iteration test.

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -39,6 +39,7 @@ jobs:
                   tests/models/openpose/test_openpose_v2.py::test_openpose_v2[full-eval]
                   tests/models/resnet/test_resnet.py::test_resnet[full-eval]
                   tests/models/resnet50/test_resnet50.py::test_resnet[full-eval]
+                  tests/models/distilbert/test_distilbert.py::test_distilbert_multiloop[full-distilbert-base-uncased-eval-64]
             "
           },
           {

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -56,3 +56,50 @@ def test_distilbert(record_property, model_name, mode, op_by_op):
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")
 
     tester.finalize()
+
+
+@pytest.mark.parametrize(
+    "num_loops",
+    [64],
+)
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
+@pytest.mark.parametrize(
+    "op_by_op",
+    [None],
+    ids=["full"],
+)
+def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_loops):
+    import time
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.enable_async = True
+    cc.cache_preprocessed_constants = True
+    cc.initialize_device()
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    model = tester.compile_model(tester.get_framework_model(), tester.compiler_config)
+
+    with torch.no_grad():
+        start_time = time.time()
+        for _ in range(num_loops):
+            results = tester.run_model(model, tester.inputs)
+        end_time = time.time()
+
+        print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")
+        print(f"{num_loops} iterations took {(end_time - start_time)} seconds")
+
+    tester.finalize()
+    cc.cleanup_device()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -238,21 +238,25 @@ class ModelTester:
         self.record_tag_cache["pccs"] = pccs
         self.record_tag_cache["atols"] = atols
 
-    @torch.no_grad()
-    def test_model_eval(self, on_device=True):
+    def get_framework_model(self):
         model = (
             self.framework_model.eval()
             if hasattr(self.framework_model, "eval")
             else self.framework_model
         )
+        return model
+
+    @torch.no_grad()
+    def test_model_eval(self, on_device=True):
+        model = self.get_framework_model()
         golden = self.get_golden_outputs(model, self.inputs)
 
         if on_device == True:
             model = self.compile_model(model, self.compiler_config)
 
         outputs = self.run_model(model, self.inputs)
-        self.verify_outputs(golden, outputs)
 
+        self.verify_outputs(golden, outputs)
         return outputs
 
     def test_model(self, on_device=True):

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -389,4 +389,4 @@ class StablehloExecutor(OpByOpExecutor):
             return self.gm(*inputs)
 
         if self.binary is not None:
-            return tt_mlir.run(inputs, self.binary)
+            return tt_mlir.run_end_to_end(inputs, self.binary)


### PR DESCRIPTION
### Ticket
Closes #400 

### Problem description
As described in #400, we needed more granular APIs to be able to cache tensors on device between runs. 

### What's changed
Broke down the previous `tt_mlir.run` API to multiple APIs. Updated the base `Executor` class to use the granular flow, as well as various options in `CompilerConfig` to configure it. Added a `tt_mlir.run_end_to_end` API that functions the same way as the previous `tt_mlir.run`, which isolates all runtime details in one place. 

Added a multi-iteration distilbert test that runs on pre-cached inputs.

Tested perf on llama-3b, got a 1.5x perf improvement over 128 iterations, however consteval has some issues on llama-3b so adding distilbert as a sanity test instead.

### Checklist
- [X] New/Existing tests provide coverage for changes
