### PR TITLE
Use Torch ExportedModule to import initial MLIR module

### DIFF
--- a/docs/src/controlling.md
+++ b/docs/src/controlling.md
@@ -9,7 +9,7 @@ You can use the following environment variables to override default behaviour:
 | TT_TORCH_VERIFY_INTERMEDIATES | Sets whether to verify runtime intermediates during execution. | False |
 | TT_TORCH_CONSTEVAL | Enables evaluation of constant expressions (consteval) in the Torch FX graph prior to compilation. | False |
 | TT_TORCH_CONSTEVAL_PARAMETERS | Extends consteval to include parameters (e.g., model weights) as well as embedded constants. | False |
-| TT_TORCH_EMBEDDEDD_CONSTANTS | Remove embedded constants from the Torch FX graph and convert them to constant inputs | False |
+| TT_TORCH_INLINE_PARAMETERS | Inlines parameters in the MLIR module (and thus flatbuffer executable) rather than requiring them as inputs. NOTE: The maximum size of a flatbuffer is 2GB so this will cause compilation to fail for sufficiently large models | False |
 | TT_TORCH_IR_LOG_LEVEL | Enables printing MLIR from Torch to TTNN. It supports two modes; `INFO` and `DEBUG`. `INFO` prints MLIR for all conversions steps (Torch, StableHLO, TTIR and TTNN MLIR graphs). `DEBUG` prints intermediate MLIR for all passes (IR dump before and after each pass) additionally. Be warned, `DEBUG` IR printing forces single core compile, so it is much slower. | Disable |
 
 ### Controlling Compiler Behaviour Programatically

--- a/env/activate
+++ b/env/activate
@@ -34,7 +34,7 @@ else
     cd $TT_TORCH_HOME/third_party
     git clone https://github.com/pytorch/vision.git
     cd vision
-    git checkout v0.20.0
+    git checkout v0.21.0
     pip uninstall -y torchvision
     TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python setup.py bdist_wheel
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
+torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
 black
 mdutils
 ninja

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        "torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl",
+        "torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl",
         "numpy",
     ],
 )

--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -57,7 +57,11 @@ def test_qwen2_casual_lm(record_property, model_name, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_token_output=True,
     )
     results = tester.test_model()
 

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -39,7 +39,7 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.xfail(reason="Fails due pt2 compile issue, graph is traced")
+@pytest.mark.skip(reason="Python bus error at the end of torch op-by-op flow")
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -60,7 +60,7 @@ def test_beit_image_classification(record_property, model_name, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    required_atol = 0.032 if model_name == "microsoft/beit-base-patch16-224" else 0.05
+    required_atol = 0.032 if model_name == "microsoft/beit-base-patch16-224" else 0.065
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -46,7 +46,11 @@ def test_codegen(record_property, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_transformers_generation=True,
     )
     results = tester.test_model()
 

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -67,7 +67,7 @@ def test_deit(record_property, model_name, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        relative_atol=0.01,
+        relative_atol=0.015,
         compiler_config=cc,
         record_property_handle=record_property,
     )

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -50,7 +50,7 @@ def test_falcon(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        relative_atol=0.013,
+        relative_atol=0.015,
         compiler_config=cc,
         record_property_handle=record_property,
     )

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -55,6 +55,7 @@ def test_flan_t5(record_property, mode, op_by_op):
         record_property_handle=record_property,
         assert_pcc=False,
         assert_atol=False,
+        is_token_output=True,
     )
     results = tester.test_model()
     if mode == "eval":

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -63,6 +63,7 @@ def test_gpt_neo(record_property, mode, op_by_op):
         record_property_handle=record_property,
         assert_pcc=False,
         assert_atol=False,
+        is_token_output=True,
     )
     results = tester.test_model()
     if mode == "eval":

--- a/tests/models/mamba/test_mamba.py
+++ b/tests/models/mamba/test_mamba.py
@@ -69,7 +69,11 @@ def test_mamba(record_property, model_name, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_token_output=True,
     )
     results = tester.test_model()
 

--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -58,7 +58,7 @@ def test_mgp_str_base(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        relative_atol=0.01,
+        relative_atol=0.02,
         compiler_config=cc,
         record_property_handle=record_property,
     )

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -63,6 +63,7 @@ def test_musicgen_small(record_property, mode, op_by_op):
         assert_atol=False,
         assert_pcc=False,
         record_property_handle=record_property,
+        is_token_output=True,
     )
     results = tester.test_model()
     tester.finalize()

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -52,7 +52,11 @@ def test_opt(record_property, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_token_output=True,
     )
     results = tester.test_model()
     if mode == "eval":

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -66,7 +66,11 @@ def test_speecht5_tts(record_property, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_token_output=True,
     )
     tester.test_model()
     # if mode == "eval":

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -52,6 +52,7 @@ def test_t5(record_property, model_name, mode, op_by_op):
         record_property_handle=record_property,
         assert_pcc=False,
         assert_atol=False,
+        is_token_output=True,
     )
     results = tester.test_model()
     if mode == "eval":

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -69,7 +69,11 @@ def test_whisper(record_property, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        is_token_output=True,
     )
     tester.test_model()
     tester.finalize()

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -198,21 +198,6 @@ def test_linear_with_bias():
     verify_module(Basic(), input_shapes=[(32, 32)])
 
 
-def test_linear_with_bias_no_embedded_constants():
-    class Basic(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.linear_a = nn.Linear(32, 32)
-
-        def forward(self, x):
-            x = self.linear_a(x)
-            return x
-
-    cc = CompilerConfig()
-    cc.remove_embedded_constants = True
-    verify_module(Basic(), input_shapes=[(32, 32)], compiler_config=cc)
-
-
 @pytest.mark.parametrize(
     ("input_type"),
     [

--- a/tests/torch/test_constant_fold.py
+++ b/tests/torch/test_constant_fold.py
@@ -50,7 +50,6 @@ def test_interp():
     inH = 5
     inW = 5
     inC = 1
-    scale_factor = 3
 
     input_shape = (1, inC, inH, inW)
     small = (

--- a/tests/torch/test_interpolation.py
+++ b/tests/torch/test_interpolation.py
@@ -11,8 +11,39 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth
 import torch.nn.functional as F
 
 
-@pytest.mark.parametrize("inH", [50, 128, 224, 960])
 @pytest.mark.parametrize("inW", [50, 128, 224, 540])
+@pytest.mark.parametrize("scale_factor", [0.5, 2])
+@pytest.mark.parametrize("align_corners", [False, True])
+def test_linear_upsample(inW, scale_factor, align_corners):
+    pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/405
+
+    class Interpolate(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return F.interpolate(
+                x,
+                scale_factor=scale_factor,
+                mode="linear",
+                align_corners=align_corners,
+            )
+
+    input_shape = (1, 1, inW)
+    small = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=0.07,
+    )
+
+
+@pytest.mark.parametrize("inH", [128, 224, 960])
+@pytest.mark.parametrize("inW", [128, 224, 540])
 @pytest.mark.parametrize("scale_factor", [0.5, 2])
 @pytest.mark.parametrize("align_corners", [False, True])
 def test_bilinear_upsample(inH, inW, scale_factor, align_corners):
@@ -43,10 +74,12 @@ def test_bilinear_upsample(inH, inW, scale_factor, align_corners):
     )
 
 
-@pytest.mark.parametrize("inH", [50, 128, 224, 960])
-@pytest.mark.parametrize("inW", [50, 128, 224, 540])
+@pytest.mark.parametrize("inZ", [4, 8])
+@pytest.mark.parametrize("inH", [224, 960])
+@pytest.mark.parametrize("inW", [224, 540])
 @pytest.mark.parametrize("scale_factor", [0.5, 2])
-def test_nearest_upsample(inH, inW, scale_factor):
+@pytest.mark.parametrize("align_corners", [False, True])
+def test_trilinear_upsample(inZ, inH, inW, scale_factor, align_corners):
     pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/405
 
     class Interpolate(nn.Module):
@@ -57,6 +90,67 @@ def test_nearest_upsample(inH, inW, scale_factor):
             return F.interpolate(
                 x,
                 scale_factor=scale_factor,
+                mode="trilinear",
+                align_corners=align_corners,
+            )
+
+    input_shape = (1, 1, inZ, inH, inW)
+    small = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=0.08,
+    )
+
+
+@pytest.mark.parametrize("inW", [50, 128, 224, 540])
+@pytest.mark.parametrize("scale_factor", [0.5, 2])
+def test_nearest_upsample1d(inW, scale_factor):
+    pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/405
+
+    class Interpolate(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return F.interpolate(
+                x,
+                scale_factor=scale_factor,
+                mode="nearest",
+            )
+
+    input_shape = (1, 1, inW)
+    small = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=0.07,
+    )
+
+
+@pytest.mark.parametrize("inH", [128, 224, 960])
+@pytest.mark.parametrize("inW", [128, 224, 540])
+@pytest.mark.parametrize("scale_factor", [0.5, 2])
+def test_nearest_upsample2d(inH, inW, scale_factor):
+    pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/405
+
+    class Interpolate(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return F.interpolate(
+                x,
+                scale_factor=scale_factor,
+                mode="nearest",
             )
 
     input_shape = (1, 1, inH, inW)
@@ -64,4 +158,40 @@ def test_nearest_upsample(inH, inW, scale_factor):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    verify_module(Interpolate(), inputs=[small], compiler_config=cc, required_atol=0.02)
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=0.07,
+    )
+
+
+@pytest.mark.parametrize("inZ", [4, 8])
+@pytest.mark.parametrize("inH", [224, 960])
+@pytest.mark.parametrize("inW", [224, 540])
+@pytest.mark.parametrize("scale_factor", [0.5, 2])
+def test_nearest_upsample3d(inZ, inH, inW, scale_factor):
+    pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/405
+
+    class Interpolate(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return F.interpolate(
+                x,
+                scale_factor=scale_factor,
+                mode="nearest",
+            )
+
+    input_shape = (1, 1, inZ, inH, inW)
+    small = torch.randn(input_shape, dtype=torch.bfloat16)
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    verify_module(
+        Interpolate(),
+        inputs=[small],
+        compiler_config=cc,
+        required_atol=0.08,
+    )

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -8,10 +8,9 @@ from torch.fx.experimental import const_fold
 from torch._decomp import get_decompositions
 from torch.func import functionalize
 from typing import List, Optional, Union
+from torch.export.graph_signature import InputKind
 
 from .decompositions import (
-    DecompositionTable,
-    DEFAULT_DECOMPOSITION_TABLE,
     CUSTOM_DECOMPOSITION_TABLE,
 )
 
@@ -60,27 +59,6 @@ def reduce_graph(module_or_graph: Union[torch.fx.Graph, torch.fx.GraphModule]):
             graph.erase_node(node)
 
 
-def apply_decompositions(
-    gm: torch.fx.GraphModule,
-    example_inputs,
-    decompositions: Optional[DecompositionTable] = None,
-):
-    concrete_inputs = [
-        x.view(tuple(int(dim) for dim in x.shape)) if isinstance(x, torch.Tensor) else x
-        for x in example_inputs
-    ]
-    if decompositions is None:
-        return gm
-
-    with torch.no_grad():
-        gm = make_fx(
-            functionalize(gm),
-            decomposition_table=decompositions,
-        )(*example_inputs)
-
-    return gm
-
-
 def bypass_redundant_getitem(gm):
     for node in gm.graph.nodes:
         if node.op == "call_function" and "getitem" in node.name:
@@ -91,159 +69,51 @@ def bypass_redundant_getitem(gm):
     return gm
 
 
-def sanitize_floating_point_tensors(tensor):
-    if isinstance(tensor, torch.Tensor) and tensor.is_floating_point():
-        return tensor.to(torch.float32)
-    return tensor
-
-
-def run_folding(gm):
-    # If there's no const subgraph module or attr output names to use, return
-    # early as there is no const folding to perform.
-    if gm.const_subgraph_module is None or gm.fx_const_folded_attrs_name is None:
-        return
-
-    assert not gm.has_folding_been_run
-    gm.has_folding_been_run = True
-
-    # Actually run const folding subgraph. Note that single attr const fold
-    # subgraphs output a single Tensor while multiple outputs are returned as
-    # Tuple[Tensor,].
-    folded_attrs = gm.const_subgraph_module()
-
-    def _create_param(i):
-        return torch.nn.Parameter(
-            sanitize_floating_point_tensors(i.detach())
-            if not isinstance(i, int)
-            else torch.Tensor([i]).to(device=gm.device_for_folded_attrs),
-            requires_grad=i.requires_grad if isinstance(i, torch.Tensor) else False,
-        )
-
-    params = (
-        torch.nn.ParameterList([_create_param(i) for i in folded_attrs])
-        if isinstance(folded_attrs, tuple)
-        else _create_param(folded_attrs)
-    )
-    setattr(gm, gm.fx_const_folded_attrs_name, params)
-
-
-def constant_fold(gm, example_inputs):
+def constant_fold(gm):
     gm = const_fold.split_const_subgraphs(gm)
     gm.run_folding()
-    graph_constants = {}
-
-    for node in gm.graph.nodes:
-        if node.op == "get_attr" and node.name == "_fx_const_folded_attrs":
-            gm.graph.inserting_before(node)
-            if isinstance(gm._FX_CONST_FOLDED_ATTRS, torch.Tensor):
-                placeholder = gm.graph.placeholder(node.target)
-                node.replace_all_uses_with(placeholder)
-                tensor = gm._FX_CONST_FOLDED_ATTRS.data
-                graph_constants[node.target] = tensor
-            else:
-                # loop through the get_item nodes
-                for key in node.users.keys():
-                    assert "getitem" in key.name
-                    idx = key.args[-1]
-                    name = f"{node.name}_{idx}"
-                    placeholder = gm.graph.placeholder(name)
-                    key.replace_all_uses_with(placeholder)
-                    tensor = gm._FX_CONST_FOLDED_ATTRS[idx].data
-                    graph_constants[name] = tensor
 
     gm.graph.eliminate_dead_code()
-    return gm, graph_constants
-
-
-def inline_parameters(gm):
-    parameters = {}
-    placeholders = {}
-    for node in gm.graph.nodes:
-        if node.op == "get_attr":
-            assert hasattr(gm, node.target), f"Parameter {node.target} not found"
-            gm.graph.inserting_before(node)
-            if node.target not in placeholders:
-                placeholder = gm.graph.placeholder(node.target)
-                placeholders[node.target] = placeholder
-                parameters[node.target] = getattr(gm, node.target).data
-            else:
-                placeholder = placeholders[node.target]
-            node.replace_all_uses_with(placeholder)
-
-    gm.graph.eliminate_dead_code()
-    return gm, parameters
-
-
-def order_constant_inputs(gm, parameters, constants, embedded_constants):
-    constant_inputs = []
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            if node.target in parameters:
-                constant_inputs.append(parameters[node.target])
-            elif node.target in constants:
-                constant_inputs.append(constants[node.target])
-            elif node.target in embedded_constants:
-                constant_inputs.append(embedded_constants[node.target])
-    return constant_inputs
-
-
-def inline_constants(gm, example_inputs):
-    inlied_constats = {}
-    placeholders = {}
-
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            # start appending after last placeholder
-            gm.graph.inserting_after(node)
-
-        if node.op != "call_function" or node.target._overloadname != "Tensor":
-            continue
-
-        for idx, arg in enumerate(node.args):
-            if isinstance(arg, (int, float)):
-                if arg not in placeholders:
-                    name = f"const_{arg}"
-                    placeholder = gm.graph.placeholder(name)
-                    placeholders[arg] = placeholder
-                    new_arg = torch.tensor(arg)
-                    inlied_constats[name] = new_arg
-                else:
-                    placeholder = placeholders[arg]
-
-                args = list(node.args)
-                args[idx] = placeholder
-                node.args = tuple(args)
-
-    return gm, inlied_constats
+    return gm
 
 
 def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
-    decompositions = DEFAULT_DECOMPOSITION_TABLE
+    decompositions = torch.export.default_decompositions()
     decompositions.update(CUSTOM_DECOMPOSITION_TABLE)
-    gm = apply_decompositions(gm, example_inputs, decompositions)  # type: ignore
-    if compiler_config.enable_consteval:
-        gm, constants = constant_fold(gm, example_inputs)
-    elif compiler_config.consteval_parameters:
-        raise Exception("consteval_parameters is enabled but enable_consteval is not")
-    else:
-        constants = {}
-    gm = bypass_redundant_getitem(gm)
-    gm, parameters = inline_parameters(gm)
-    if compiler_config.remove_embedded_constants:
-        gm, embedded_constants = inline_constants(gm, example_inputs)
-    else:
-        embedded_constants = {}
 
-    constant_inputs = order_constant_inputs(
-        gm, parameters, constants, embedded_constants
+    # we use the export API to run the decompositions, as this maintains the
+    # soruce locations in stack_trace
+    gm = (
+        torch.export.export_for_training(gm, tuple(example_inputs), strict=False)
+        .run_decompositions(decompositions)
+        .module()
     )
 
-    # some constant folding operations are preformed by changing tensor strides, we
-    # want all the strides to be 1, so make them contiguous
-    for (i, t) in enumerate(constant_inputs):
-        if not t.is_contiguous():
-            constant_inputs[i] = t.contiguous()
+    if compiler_config.enable_consteval:
+        gm = constant_fold(gm)
+    elif compiler_config.consteval_parameters:
+        raise Exception("consteval_parameters is enabled but enable_consteval is not")
+
+    gm = bypass_redundant_getitem(gm)
 
     reduce_graph(gm)
-    run_shape_prop(gm, example_inputs + constant_inputs)
-    return gm, constant_inputs
+    program = torch.export.export(gm, tuple(example_inputs), strict=False)
+    # The proper order of inputs when outlining everything is constants + parameters + buffers + example_inputs
+    if not compiler_config.inline_parameters:
+        constant_inputs = (
+            list(program.tensor_constants.values())
+            + [
+                param.contiguous() if not param.is_contiguous() else param
+                for param in program.parameters()
+            ]
+            + list(program.buffers())
+        )
+        for i in range(len(program._graph_signature.input_specs)):
+            if program._graph_signature.input_specs[i].kind != InputKind.USER_INPUT:
+                program._graph_signature.input_specs[i].kind = InputKind.USER_INPUT
+    else:
+        constant_inputs = []
+
+    # Need to run shape_prop again to populate tensor_meta
+    run_shape_prop(program.graph_module, constant_inputs + example_inputs)
+    return program, constant_inputs

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -257,7 +257,6 @@ class CompilerConfig:
         self.single_op_timeout = 30
         self.op_by_op_backend = OpByOpBackend.TORCH
         self.enable_consteval = False
-        self.remove_embedded_constants = False
         self._consteval_parameters = False
         self._enable_intermediate_verification = False
         self.dump_debug = False
@@ -267,6 +266,7 @@ class CompilerConfig:
         self.runtime_device = None
         self.enable_async = False
         self.cache_preprocessed_constants = False
+        self.inline_parameters = False
 
         self.apply_environment_overrides()
         self.post_init()
@@ -328,9 +328,9 @@ class CompilerConfig:
         consteval_parameters = os.environ.get("TT_TORCH_CONSTEVAL_PARAMETERS")
         if consteval_parameters and int(consteval_parameters):
             self.consteval_parameters = True
-        remove_embedded_constants = os.environ.get("TT_TORCH_EMBEDDEDD_CONSTANTS")
-        if remove_embedded_constants and int(remove_embedded_constants):
-            self.remove_embedded_constants = True
+        inline_parameters = os.environ.get("TT_TORCH_INLINE_PARAMETERS")
+        if inline_parameters and int(inline_parameters):
+            self.inline_parameters = True
         dump_intermediates = os.environ.get("TT_TORCH_IR_LOG_LEVEL")
         if dump_intermediates:
             self.dump_debug = dump_intermediates == "DEBUG"
@@ -400,7 +400,6 @@ class CompilerConfig:
             "results_path": self.results_path,
             "single_op_timeout": self.single_op_timeout,
             "enable_consteval": self.enable_consteval,
-            "remove_embedded_constants": self.remove_embedded_constants,
             "_consteval_parameters": self._consteval_parameters,
             "_enable_intermediate_verification": self._enable_intermediate_verification,
             "_verify_op_by_op": self._verify_op_by_op,


### PR DESCRIPTION
Use a `torch.export.ExportedProgram` to generate the initial MLIR module.

This requires us to create an `ExportedProgram` from the initial `GraphModule`.

Benefits:
- We can use the torch-mlir's official entrypoint
    - This handles in-place ops for us
- We can run decompositions and **keep** location data
    - This location data will stick around throughout the compile process

Issues:
- `aten.clamp` is decomposed by torch-mlir to `maximum(minimum(input, max), min)`. `ttnn.maximum` requires that the operand which needs to be broadcasted is on the RHS. Currently, in tt-mlir the `PartiallyBroadcastable` op trait only enforces that the broadcasted operand is on the LHS
    - tt-torch issue: https://github.com/tenstorrent/tt-torch/issues/431
    - tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/2458
- Graph parameters are inlined as constants in the graph. To have the `FxImporter` treat them as graph inputs we need to edit the `ExportedModule`s `ExportedGraphSignature` and force all "parameter" types to "user inputs"
    - This is a hack as the `ExportedGraphSignature` is meant to be a private member of `ExportedProgram`
    - Ideally we can configure the `FxImporter` to _not_ inline the parameters if we pass a flag of some sort. Perhaps a future contribution to torch-mlir.

Other Info:
- We need to upgrade to PyTorch 2.6.0 as it contains crucial changes which allow us to use custom decompositions (necessary to support interpolation)
    - AdaptiveAvgPool2d is lowered AvgPool2d and eventually to `stablehlo.reduce_window **even in the case where the op is equivalent to a global average**. Since we do not have support for lowering a sum_pool in `StablehloToTTIRPatterns.cpp` (sum because the division is afterward), I've temporarily added a custom decomposition of `aten.avg_pool2d` which will convert to a mean over the spatial dimensions when the `avg_pool2d` is equivalent to it.
    - `aten.split` is no longer lowered to a series of `narrow` ops. Instead it is now lowered to a series of `as_strided` ops.
        - `narrow` is lowered to `slice`, which can be lowered to `stablehlo.slice`. `as_strided` cannot be lowered from Torch Backend IR to Stablehlo. I've temporarily added back the old decomposition from PyTorch 2.5.0 which uses narrow as a custom decomposition.
        - I've made a PR which adds a lowering of `AtenAsStridedOp` to `stablehlo::SliceOp` in our fork of torch-mlir: https://github.com/tenstorrent/llvm-torch-mlir/pull/4
     - The tracer which generates the `GraphModule` which is passed to `backend` does not account for control flow, I believe in PyTorch 2.5.0 a graph break would be triggered during `.generate` methods in `transformers` LLMs. It does not anymore and so `.generate` will run until the max length is reached.
         - **this means that the entire generation becomes  one program**
         - Once the first EOS token is generated, the rest of the length is filled with padding. We cannot compare the golden output to the result from the `GraphModule` as the output shapes are different.
             - Since the output of `.generate` graphs are integers PCC/atol verification is not quite useful but does return `True` when the outputs are _identical_
             - The tokenizer can decode the outputs and strip padding.
             - I've added a flag to `ModelTester` that informs the `ModelTester` it is testing a `.generate` call. It will decode the output tokens and we compare the resulting strings.
         - PyTorch has an experimental `torch.cond` which they seem to intend to use to trace data-dependent control-flow. There's a note in the `transformers` source that says they intend to use it when it is no longer experimental
- When the graph is compiled, the user inputs are placed **at the end** of the arguments passed to the program rather than the front. That is graph constants first, then inputs.
- I needed to implement an `FxImporter` hook for importing literals to the graph. By default it will make all non-scalars `DenseElementsResourceAttr`s, however, this causes the process to hang upon cleanup whether the test fails or not. So the hook just uses `DenseElementsAttr` for all literals.
    - Someone has mentioned this problem in an IREE issue as well: https://github.com/iree-org/iree/issues/20102
    - They've traced it down to this PR in llvm that adds a GIL acquire when destroying the `DenseElementsResourceAttr`: https://github.com/llvm/llvm-project/pull/124832