### PR TITLE
Add model report file name check to op by op parser

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -29,10 +29,8 @@ def generate_status_report():
     model_names = []
 
     for json_file in json_files:
-
-        if (
-            "_unique_ops.json" not in json_file
-        ):  # indicator that the JSON is a model report, not an op report
+        # indicator that the JSON is a model report, not an op report
+        if "_unique_ops.json" not in json_file:
             continue
 
         # Get model name from the parent directory of the json file
@@ -192,6 +190,10 @@ def process_json_files():
     workbook = xlsxwriter.Workbook("results/models_op_per_op.xlsx")
     bold = workbook.add_format({"bold": True})
     for json_file in json_files:
+        # indicator that the JSON is a model report, not an op report
+        if "_unique_ops.json" not in json_file:
+            continue
+
         with open(json_file, "r") as f:
             data = json.load(f)
 

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -29,6 +29,12 @@ def generate_status_report():
     model_names = []
 
     for json_file in json_files:
+
+        if (
+            "_unique_ops.json" not in json_file
+        ):  # indicator that the JSON is a model report, not an op report
+            continue
+
         # Get model name from the parent directory of the json file
         model_name = (
             json_file.strip("_unique_ops.json")


### PR DESCRIPTION
### Ticket
#418 

### Problem description
Op by op parser may fail to parse a JSON on CI rerun
because it is malformed. This occurs when reingesting
data from JSON generating jobs in the old run during 
a CI rerun that are not model test data.

### What's changed
Add tighter check to ensure we only parse model op
report JSONs.

### Checklist
- [x] New/Existing tests provide coverage for changes
