### PR TITLE
Minor fix for module IR dump

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -45,7 +45,7 @@ def verify_golden_callback(binary, callback_context, op_context):
 def dump_module(module, name, compiler_config):
     if compiler_config.dump_info:
         print(f"{name} module", file=sys.stderr)
-        module.dump(large_elements_limit=0)
+        print(module, file=sys.stderr)
 
 
 def _shlo_backend(shlo, example_inputs, compiler_config, gm=None, graph_constants=None):


### PR DESCRIPTION
### Ticket
closes #421 

### Problem description
Module is represented by different types during the compilation process
- torch-mlir generated modules are stored as Module object.
- tt-mlir generated modules are stored as strings.
- Onnx generated modules are stored as Operation object. 
Not all of these support dump function

### What's changed
Use python standard print function to dump modules during compilation (if enabled)
