### PR TITLE
Add compile depth summary to models_op_per_op spreadsheet

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -185,6 +185,8 @@ def process_json_files():
     stable_hlo_ops_per_torch_op = {}
     workbook = xlsxwriter.Workbook("results/models_op_per_op.xlsx")
     bold = workbook.add_format({"bold": True})
+
+    worksheet = workbook.add_worksheet("Per Model Compile Depths")
     for json_file in json_files:
         with open(json_file, "r") as f:
             data = json.load(f)
@@ -558,6 +560,21 @@ def process_json_files():
         worksheet.write_row(row, 0, data)
         row += 1
 
+    # Summarize Models / Compile Depths in the first sheet
+    worksheet = workbook.get_worksheet_by_name("Per Model Compile Depths")
+    worksheet.write_row(0, 0, ["", 0, 1, 2, 3, 4, 5, 6, 7])
+    worksheet.write_column(1, 0, model_names)
+
+    row = 1
+    for model_name in model_names:
+        for compile_depth in range(0, 8):
+            # baking dynamic references
+            compile_depth_formula = (
+                f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!E:E"), {compile_depth})'
+            )
+            worksheet.write(row, 1 + compile_depth, compile_depth_formula)
+        row += 1
+
     workbook.close()
 
     op_mappings = {
@@ -839,12 +856,6 @@ def process_json_files():
             f.write(text)
 
         worksheet.autofit()
-
-    # model_ops_compile_depth_summary_worksheet
-    worksheet = workbook.add_worksheet("Per Model Compile Depths")
-    header = ["", 0, 1, 2, 3, 4, 5, 6, 7]
-    worksheet.write_row(0, 0, header)
-
     workbook.close()
 
 

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -839,6 +839,12 @@ def process_json_files():
             f.write(text)
 
         worksheet.autofit()
+
+    # model_ops_compile_depth_summary_worksheet
+    worksheet = workbook.add_worksheet("Per Model Compile Depths")
+    header = ["", 0, 1, 2, 3, 4, 5, 6, 7]
+    worksheet.write_row(0, 0, header)
+
     workbook.close()
 
 


### PR DESCRIPTION
### Ticket
#426 

### Problem description
There is no model / compile depth summary view
in the current excel spreadsheet

### What's changed
Add a Per Model Compile Depths sheet to the front
of the existing excel spreadsheet and populate it from
other info in the worksheet.

### Checklist
- [x] New/Existing tests provide coverage for changes
