### PR TITLE
Second pass for schema change - stop recording frontend info

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,11 +64,8 @@ class ModelTester:
         self.record_property = record_property_handle
         self.record_tag_cache = {}  # Holds for tags to be written out at finalize()
 
-        self.record_property("model_name", model_name)
-        self.record_property("frontend", "tt-torch")
         self.record_property("owner", "tt-torch")
         self.record_property("group", model_group)
-
         self.record_tag_cache["model_name"] = model_name
         self.record_tag_cache["frontend"] = "tt-torch"
 


### PR DESCRIPTION
### Ticket
#256 

### Problem description
Redundant model_name and frontend fields are recorded into the XML; which the Pytest result pydantic model was recently changed to omit.

### What's changed
Remove redundant reporting of the model name and frontend now that it won't break the pydantic model ingestion

### Checklist
- [x] New/Existing tests provide coverage for changes
