### PR TITLE
Crash Safe JunitXML Writer

### DIFF
--- a/.github/workflows/depth-benchmarks.yml
+++ b/.github/workflows/depth-benchmarks.yml
@@ -1,0 +1,31 @@
+# This workflow automates running model depth benchmarks
+
+name: Depth Benchmarks
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # Runs at 04:00 UTC every day
+  workflow_dispatch:  # Manual trigger
+
+jobs:
+  pre-commit:
+    uses: ./.github/workflows/pre-commit.yml
+    secrets: inherit
+  spdx:
+    uses: ./.github/workflows/spdx.yml
+    secrets: inherit
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+  build:
+    needs: [pre-commit, spdx, docker-build]
+    uses: ./.github/workflows/run-build.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  run_benchmark:
+    needs: [docker-build, build]
+    uses: ./.github/workflows/run-depth-benchmark-tests.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -24,31 +24,10 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_op_by_op:
-    needs: [docker-build, build]
-    uses: ./.github/workflows/run-op-by-op-model-tests.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_e2e:
-    needs: [docker-build, build]
-    uses: ./.github/workflows/run-e2e-tests.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_full_model:
-    needs: [docker-build, build]
-    uses: ./.github/workflows/run-full-model-execution-tests.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  download-report:
-    if: success() || failure()
-    needs: test_op_by_op
-    uses: ./.github/workflows/generate-model-report.yml
-    secrets: inherit
-  generate-ttnn-md:
-    if: success() || failure()
-    needs: download-report
-    uses: ./.github/workflows/generate-ttnn-md.yml
-    secrets: inherit
+  # I do not think this should run in nightly
+  run_benchmark:
+      needs: [docker-build, build]
+      uses: ./.github/workflows/run-depth-benchmark-tests.yml
+      secrets: inherit
+      with:
+        docker-image: ${{ needs.docker-build.outputs.docker-image }}

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -8,11 +8,6 @@ on:
         description: 'Docker image to use for build'
         required: true
         type: string
-      run-codecov:
-        description: 'Run code coverage reports'
-        required: false
-        type: string # properly a boolean but autocast to string when passed in using 'with' inputs
-        default: 'true'
   workflow_run:
     workflows: [Build] # backref to run-build as dependency
     types: [completed]
@@ -115,7 +110,6 @@ jobs:
       run: |
         source env/activate
         python -m tt-torch/tt_torch/tools/postprocess_crashsafe_reports.py ${{ steps.strings.outputs.test_report_path_models }}_subtest*_crashsafe.xml ${{ steps.strings.outputs.test_report_path_models }}
-
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -102,7 +102,7 @@ jobs:
 
             pytest -v "$test" \
                 --junit-xml=${{ steps.strings.outputs.test_report_path_models }}_subtest${test_name}_crashsafe.xml \
-                --crashsafe \
+                --crashsafe
         done
 
     - name: Postprocess and Join Test Reports

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -1,0 +1,135 @@
+name: Run Model Compile Depth Benchmark Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
+      run-codecov:
+        description: 'Run code coverage reports'
+        required: false
+        type: string # properly a boolean but autocast to string when passed in using 'with' inputs
+        default: 'true'
+  workflow_run:
+    workflows: [Build] # backref to run-build as dependency
+    types: [completed]
+
+jobs:
+  tests:
+    timeout-minutes: 60 # current onPR time runs ~60m
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [
+          # {runs-on: 'wormhole_b0', name: 'benchmark_1', tests: ['tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2[full-eval]', 'tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2[full-eval]', 'tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]', 'tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]', 'tests/models/RMBG/test_RMBG.py::test_RMBG[full-eval]', 'tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-base-v2-eval]', 'tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-large-v2-eval]', 'tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xlarge-v2-eval]', 'tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xxlarge-v2-eval]', 'tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[full-twmkn9/albert-base-v2-squad2-eval]', 'tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[full-textattack/albert-base-v2-imdb-eval]', 'tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[full-albert/albert-base-v2-eval]', 'tests/models/autoencoder_conv/test_autoencoder_conv.py::test_autoencoder_conv[full-eval]', 'tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[full-eval]', 'tests/models/autoencoder_linear/test_autoencoder_linear.py::test_autoencoder_linear[full-eval]', 'tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval]', 'tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_2', tests: ['tests/models/bert/test_bert.py::test_bert[full-eval]', 'tests/models/bloom/test_bloom.py::test_bloom[full-eval]', 'tests/models/clip/test_clip.py::test_clip[full-eval]', 'tests/models/codegen/test_codegen.py::test_codegen[full-eval]', 'tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]', 'tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval]', 'tests/models/detr/test_detr.py::test_detr[full-eval]', 'tests/models/distilbert/test_distilbert.py::test_distilbert[full-distilbert-base-uncased-eval]', 'tests/models/distilbert/test_distilbert.py::test_distilbert_multiloop[full-distilbert-base-uncased-eval-64]', 'tests/models/dpr/test_dpr.py::test_dpr[full-eval]', 'tests/models/falcon/test_falcon.py::test_falcon[full-eval]', 'tests/models/flan_t5/test_flan_t5.py::test_flan_t5[full-eval]', 'tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]', 'tests/models/gpt2/test_gpt2.py::test_gpt2[full-eval]', 'tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[full-eval]', 'tests/models/hand_landmark/test_hand_landmark.py::test_hand_landmark[full-eval]', 'tests/models/hardnet/test_hardnet.py::test_hardnet[full-eval]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_3', tests: ['tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval]', 'tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]', 'tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-790m-hf-eval]', 'tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-2.8b-hf-eval]', 'tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-1.4b-hf-eval]', 'tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-370m-hf-eval]', 'tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval]', 'tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[full-eval]', 'tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]', 'tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd[full-eval]', 'tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small[full-eval]', 'tests/models/openpose/test_openpose.py::test_openpose[full-eval]', 'tests/models/openpose/test_openpose_v2.py::test_openpose_v2[full-eval]', 'tests/models/opt/test_opt.py::test_opt[full-eval]', 'tests/models/perceiver_io/test_perceiver_io.py::test_perceiver_io[full-eval]', 'tests/models/resnet/test_resnet.py::test_resnet[full-eval]', 'tests/models/resnet50/test_resnet50.py::test_resnet[full-eval]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_4', tests: ['tests/models/roberta/test_roberta.py::test_roberta[full-eval]', 'tests/models/segformer/test_segformer.py::test_segformer[full-eval]', 'tests/models/segment_anything/test_segment_anything.py::test_segment_anything[full-eval]', 'tests/models/speecht5_tts/test_speecht5_tts.py::test_speecht5_tts[full-eval]', 'tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[full-eval]', 'tests/models/stable_diffusion/test_stable_diffusion.py::test_stable_diffusion[full-eval]', 'tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]', 'tests/models/t5/test_t5.py::test_t5[full-t5-small-eval]', 'tests/models/t5/test_t5.py::test_t5[full-t5-base-eval]', 'tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite0.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite1.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite2.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite3.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite4.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ghostnet_100.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ghostnetv2_100.in1k]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_5', tests: ['tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-inception_v4.tf_in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mixer_b16_224.goog_in21k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mobilenetv1_100.ra4_e3600_r224_in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ese_vovnet19b_dw.ra_in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-xception71.tf_in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-dla34.in1k]', 'tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-googlenet]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet121]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet161]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet169]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet201]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v2]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v3_small]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-mobilenet_v3_large]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnet18]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnet34]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_6', tests: ['tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnet50]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnet101]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnet152]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnext50_32x4d]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnext101_32x8d]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-resnext101_64x4d]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg11]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg11_bn]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg13]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg13_bn]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg16]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg16_bn]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19_bn]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_b_16]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_b_32]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_l_16]']},
+          # {runs-on: 'wormhole_b0', name: 'benchmark_7', tests: ['tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_l_32]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_h_14]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-wide_resnet50_2]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-wide_resnet101_2]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_400mf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_800mf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_1_6gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_3_2gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_8gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_16gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_32gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_128gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_400mf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_800mf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_1_6gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_3_2gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_8gf]']},{runs-on: 'wormhole_b0', name: 'benchmark_8', tests: ['tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_16gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_32gf]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_t]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_s]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_b]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_t]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_s]', 'tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_b]', 'tests/models/torchvision/test_torchvision_object_detection.py::test_torchvision_object_detection[full-ssd300_vgg16-eval]', 'tests/models/torchvision/test_torchvision_object_detection.py::test_torchvision_object_detection[full-ssdlite320_mobilenet_v3_large-eval]', 'tests/models/torchvision/test_torchvision_object_detection.py::test_torchvision_object_detection[full-retinanet_resnet50_fpn-eval]', 'tests/models/torchvision/test_torchvision_object_detection.py::test_torchvision_object_detection[full-retinanet_resnet50_fpn_v2-eval]', 'tests/models/unet/test_unet.py::test_unet[full-eval]', 'tests/models/unet_brain/test_unet_brain.py::test_unet_brain[full-eval]', 'tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[full-eval]', 'tests/models/vilt/test_vilt.py::test_vilt[full-eval]', 'tests/models/whisper/test_whisper.py::test_whisper[full-eval]']},
+          {runs-on: 'wormhole_b0', name: 'benchmark_9', tests: ['tests/models/xglm/test_xglm.py::test_xglm[full-eval]', 'tests/models/yolos/test_yolos.py::test_yolos[full-eval]', 'tests/models/yolov3/test_yolov3.py::test_yolov3[full-eval]', 'tests/models/yolov4/test_yolov4.py::test_yolov4[full-eval]', 'tests/models/yolov5/test_yolov5.py::test_yolov5[full-eval]']}
+        ]
+    runs-on:
+      - ${{ matrix.build.runs-on }}
+
+    name: "test benchmark (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+
+    container:
+      image: ${{ inputs.docker-image }}
+      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: true
+
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "test benchmark (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      env:
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
+        echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+    - name: Use build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: install-artifacts
+        path: ${{ steps.strings.outputs.install-dir }}
+
+    - name: 'Untar install directory'
+      shell: bash
+      working-directory: ${{ steps.strings.outputs.install-dir }}
+      run: |
+        tar xvf artifact.tar
+        mkdir -p ${{ steps.strings.outputs.dist-dir }}
+        mv wheels/* ${{ steps.strings.outputs.dist-dir }}
+
+    - name: install tt-torch
+      shell: bash
+      run: |
+        source env/activate
+        pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
+
+    - name: Run Full Model Execution Tests
+      env:
+        HF_HOME: /mnt/dockercache/huggingface
+        TORCH_HOME: /mnt/dockercache/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      shell: bash
+      run: |
+        source env/activate
+        apt-get update
+        apt install -y libgl1 libglx-mesa0
+
+        for test in $(echo '${{ toJSON(matrix.build.tests) }}' | jq -r '.[]'); do
+          pytest -v "$test" \
+            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
+            --crashsafe \
+            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+        done
+
+    - name: Upload Test Report Models
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.test_report_path_models }}
+
+    - name: Upload coverage reports to Codecov
+      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.info,.coverage,coverage.xml
+        # disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
+      continue-on-error: true
+      uses: codecov/test-results-action@v1
+      with:
+        files: ${{ steps.strings.outputs.test_report_path_models }}
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -91,7 +91,7 @@ jobs:
         source env/activate
         pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
 
-    - name: Run Full Model Execution Tests
+    - name: Run Execution Benchmark Tests
       env:
         HF_HOME: /mnt/dockercache/huggingface
         TORCH_HOME: /mnt/dockercache/torch
@@ -103,11 +103,19 @@ jobs:
         apt install -y libgl1 libglx-mesa0
 
         for test in $(echo '${{ toJSON(matrix.build.tests) }}' | jq -r '.[]'); do
-          pytest -v "$test" \
-            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
-            --crashsafe \
-            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+            test_name=$(echo "$test" | sed 's/[^a-zA-Z0-9]/_/g')  # Sanitize test name for filename
+
+            pytest -v "$test" \
+                --junit-xml=${{ steps.strings.outputs.test_report_path_models }}_subtest${test_name}_crashsafe.xml \
+                --crashsafe \
         done
+
+    - name: Postprocess and Join Test Reports
+      shell: bash
+      run: |
+        source env/activate
+        python -m tt-torch/tt_torch/tools/postprocess_crashsafe_reports.py ${{ steps.strings.outputs.test_report_path_models }}_subtest*_crashsafe.xml ${{ steps.strings.outputs.test_report_path_models }}
+
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4
@@ -115,21 +123,3 @@ jobs:
       with:
         name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path_models }}
-
-    - name: Upload coverage reports to Codecov
-      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
-      continue-on-error: true
-      uses: codecov/codecov-action@v5
-      with:
-        files: coverage.info,.coverage,coverage.xml
-        # disable_search: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Upload test results to Codecov
-      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
-      continue-on-error: true
-      uses: codecov/test-results-action@v1
-      with:
-        files: ${{ steps.strings.outputs.test_report_path_models }}
-        disable_search: true
-        token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def pytest_configure(config):
 
     # Check if the --crashsafe option is enabled
     if config.getoption("--crashsafe"):
-        print(f"Running in crashsafe mode - logging data to crashsafe log")
+        print(f"Running in crashsafe mode - logging data to crashsafe log.")
         junitxml_path = config.getoption("--junit-xml")
         property_file = f"{junitxml_path}{crashsafe_suffix}"
         print(f"Writing to {property_file}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import os
 import json
 import shutil
 
-global junitxml_path 
+global junitxml_path
 junitxml_path = None
 
 
@@ -96,7 +96,7 @@ def record_property(request):
     def _original_record_property(name, value):
         # Copied from https://docs.pytest.org/en/7.1.x/_modules/_pytest/junitxml.html
         request.node.user_properties.append((name, value))
-    
+
     # config options not in scope at this point, so using this global as indicator
     if not junitxml_path:
         return _original_record_property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,11 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from tt_torch.tools.utils import OpByOpBackend
+import os
+import json
+import shutil
+
+global junitxml_path
 
 
 @pytest.fixture(autouse=True)
@@ -41,6 +46,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run test in torch op-by-op mode",
     )
+    parser.addoption(
+        "--crashsafe",
+        action="store_true",
+        default=False,
+        help="Create transacted output logs",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -72,3 +83,48 @@ def record_test_timestamp(record_property):
     yield
     end_timestamp = datetime.now(timezone.utc).isoformat()
     record_property("end_timestamp", end_timestamp)
+
+
+@pytest.fixture
+def crashsafe_record_property(request):
+    """Override the built-in record_property fixture with transactional writes."""
+    global junitxml_path
+
+    property_file = f"{junitxml_path}_crashsafe.json"
+    with open(property_file, "w+") as f:
+        json.dump({}, f)
+
+    def _record_property(name, value):
+        # Add to the standard pytest user_properties
+        request.node.user_properties.append((name, value))
+
+        # Also write to disk immediately for durability
+        properties = {}
+        if os.path.exists(property_file):
+            with open(property_file, "r") as f:
+                try:
+                    properties = json.load(f)
+                except json.JSONDecodeError:
+                    properties = {}
+
+        properties[name] = value
+
+        # Write atomically to avoid corruption
+        temp_file = f"{property_file}.tmp"
+        with open(temp_file, "w") as f:
+            json.dump(properties, f)
+        os.replace(temp_file, property_file)
+
+    return _record_property
+
+
+def pytest_configure(config):
+    global junitxml_path
+    junitxml_path = config.getoption("--junit-xml")
+
+    # Check if the --crashsafe option is enabled
+    if config.getoption("--crashsafe"):
+        # Override the `record_property` fixture with the crash-safe version
+        pytest.record_property = pytest.fixture(scope="function")(
+            crashsafe_record_property
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,14 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from tt_torch.tools.utils import OpByOpBackend
+from tt_torch.tools.crashsafe_utils import crashsafe_suffix
+
 import os
 import json
 import shutil
 
-global junitxml_path
+global junitxml_path 
+junitxml_path = None
 
 
 @pytest.fixture(autouse=True)
@@ -86,15 +89,24 @@ def record_test_timestamp(record_property):
 
 
 @pytest.fixture
-def crashsafe_record_property(request):
+def record_property(request):
     """Override the built-in record_property fixture with transactional writes."""
     global junitxml_path
 
-    property_file = f"{junitxml_path}_crashsafe.json"
+    def _original_record_property(name, value):
+        # Copied from https://docs.pytest.org/en/7.1.x/_modules/_pytest/junitxml.html
+        request.node.user_properties.append((name, value))
+    
+    # config options not in scope at this point, so using this global as indicator
+    if not junitxml_path:
+        return _original_record_property
+
+    property_file = f"{junitxml_path}{crashsafe_suffix}"
+    print(f"Writing to {property_file}")
     with open(property_file, "w+") as f:
         json.dump({}, f)
 
-    def _record_property(name, value):
+    def _crashsafe_record_property(name, value):
         # Add to the standard pytest user_properties
         request.node.user_properties.append((name, value))
 
@@ -115,16 +127,13 @@ def crashsafe_record_property(request):
             json.dump(properties, f)
         os.replace(temp_file, property_file)
 
-    return _record_property
+    return _crashsafe_record_property
 
 
 def pytest_configure(config):
     global junitxml_path
-    junitxml_path = config.getoption("--junit-xml")
 
     # Check if the --crashsafe option is enabled
     if config.getoption("--crashsafe"):
-        # Override the `record_property` fixture with the crash-safe version
-        pytest.record_property = pytest.fixture(scope="function")(
-            crashsafe_record_property
-        )
+        print(f"Running in crashsafe mode - logging data to crashsafe log")
+        junitxml_path = config.getoption("--junit-xml")

--- a/tests/torch/rhetor/test_enumerate_tests.py
+++ b/tests/torch/rhetor/test_enumerate_tests.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from tt_torch.tools.crashsafe_utils import *
+
+
+def test_enumerate_all_model_tests():
+    test_list = enumerate_all_tests()
+
+    # prune list to filter out full eval
+    test_list = [test for test in test_list if ("full" in test and "eval" in test)]
+    # for test in test_list:
+    #     print(test)
+
+    matrix = generate_test_matrix(test_list)
+    for m in matrix:
+        print(repr(m) + ",\n")
+    assert len(test_list) > 0

--- a/tests/torch/rhetor/test_rewrite.py
+++ b/tests/torch/rhetor/test_rewrite.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from tt_torch.tools.crashsafe_utils import *
+import xml.etree.ElementTree as ET
+import ast
+
+
+def test_rewrite():
+    rewrite_crashsafe_xml("mnist.xml_crashsafe.xml")
+
+    tree = ET.parse("mnist.xml_crashsafe.xml")
+    root = tree.getroot()
+
+    # Find the <property> element with name="tags"
+    tags_property = root.find(".//property[@name='tags']")
+    tags_dict = ast.literal_eval(tags_property.attrib["value"])
+    assert (
+        "max_achieved_compile_depth" in tags_dict
+    ), "Key 'max_achieved_compile_depth' does not exist in tags_dict"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,7 +67,10 @@ class ModelTester:
             compiler_config = CompilerConfig()
         self.compiler_config = compiler_config
         self.compiler_config.model_name = model_name
+
         self.record_property = record_property_handle
+        self.compiler_config.record_property = record_property_handle
+
         self.record_tag_cache = {}  # Holds for tags to be written out at finalize()
 
         self.record_property("model_name", model_name)
@@ -255,7 +258,7 @@ class ModelTester:
             golden_tensors = self._extract_outputs(golden)
             output_tensors = self._extract_outputs(outputs)
 
-        pccs, atols = verify_against_golden(
+        pccs, atols, passed_pcc, passed_atol = verify_against_golden(
             golden_tensors,
             output_tensors,
             self.assert_pcc,
@@ -266,6 +269,8 @@ class ModelTester:
         )
         self.record_tag_cache["pccs"] = pccs
         self.record_tag_cache["atols"] = atols
+        if passed_pcc and passed_atol:
+            self.record_property("achieved_compile_depth", "PASSED")
 
     def get_framework_model(self):
         model = (
@@ -284,6 +289,8 @@ class ModelTester:
             model = self.compile_model(model, self.compiler_config)
 
         outputs = self.run_model(model, self.inputs)
+        self.record_property("achieved_compile_depth", "EXECUTE")
+
         if self.is_token_output:
             decoded_outputs = self.tokenizer.batch_decode(
                 outputs, skip_special_tokens=True

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -121,12 +121,15 @@ def shlo_to_flatbuffer(executor, module, compiler_config):
 def _base_backend(gm, example_inputs, compiler_config):
     shlo, program, graph_constants = torch_to_shlo(gm, example_inputs, compiler_config)
     executor = Executor(program, graph_constants, compiler_config)
+    compiler_config.record_property("achieved_compile_depth", "STABLEHLO")
 
     if compiler_config.compile_depth == CompileDepth.STABLEHLO:
         return executor
 
     binary = shlo_to_flatbuffer(executor, shlo, compiler_config)
     executor.set_binary(binary)
+    compiler_config.record_property("achieved_compile_depth", "TTNN_IR")
+
     return executor
 
 

--- a/tt_torch/tools/crashsafe_utils.py
+++ b/tt_torch/tools/crashsafe_utils.py
@@ -1,4 +1,102 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+import xml.etree.ElementTree as ET
+import ast
+
 crashsafe_suffix = "_crashsafe.xml"
+
+
+def get_achieved_compile_depths(xml_file):
+    try:
+        # Parse the XML file
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        # Find all <property> elements with name="achieved_compile_depth"
+        compile_depths = [
+            prop.attrib["value"]
+            for prop in root.findall(".//property[@name='achieved_compile_depth']")
+        ]
+
+        # Return the list of values or "UNKNOWN" if none are found
+        return compile_depths if compile_depths else ["UNKNOWN"]
+    except ET.ParseError as e:
+        print(f"Error parsing XML: {e}")
+        return ["UNKNOWN"]
+
+
+def get_max_achieved_compile_depth(xml_file):
+    achieved_depth_mapping = {
+        "UNKNOWN": 0,
+        "STABLEHLO": 1,
+        "TTNN_IR": 2,
+        "EXECUTE": 3,
+        "PASSED": 4,
+    }
+    reverse_compile_depth_mapping = {v: k for k, v in achieved_depth_mapping.items()}
+    compile_depths = get_achieved_compile_depths(xml_file)
+    numeric_depths = [achieved_depth_mapping.get(depth, 0) for depth in compile_depths]
+    max_numeric_depth = max(numeric_depths)
+    max_achieved_depth = reverse_compile_depth_mapping[max_numeric_depth]
+
+    return max_achieved_depth
+
+
+def check_valid_xml(xml_file):
+    required_property_names = ["frontend", "model_name", "owner", "group"]
+
+    try:
+        # Parse the XML file
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        # Check if each required property exists
+        for property_name in required_property_names:
+            xpath = f".//property[@name='{property_name}']"
+            if root.find(xpath) is None:
+                raise AssertionError(
+                    f"Property with name='{property_name}' does not exist in the XML."
+                )
+
+    except ET.ParseError as e:
+        print(f"Error parsing XML: {e}")
+    except AssertionError as e:
+        print(f"Assertion failed: {e}")
+
+
+def inject_param_into_tags(xml_file, tag_name, tag_value):
+    tree = ET.parse(xml_file)
+    root = tree.getroot()
+
+    # Find the <property> element with name="tags"
+    tags_property = root.find(".//property[@name='tags']")
+    if tags_property is not None:
+        # Parse the existing tags value as a dictionary
+        tags_dict = ast.literal_eval(tags_property.attrib["value"])
+    else:
+        # Create a new tags dictionary if it doesn't exist
+        tags_dict = {}
+
+    # Inject the max achieved compile depth into the tags dictionary
+    tags_dict[tag_name] = tag_value
+
+    # Update or create the <property> element for tags
+    if tags_property is not None:
+        tags_property.set("value", str(tags_dict))
+    else:
+        # Find the <properties> element to add the new <property>
+        properties_element = root.find(".//properties")
+        ET.SubElement(properties_element, "property", name="tags", value=str(tags_dict))
+
+    # Write the updated XML back to the file
+    tree.write(xml_file, encoding="utf-8", xml_declaration=True)
+
+
+def rewrite_crashsafe_xml(xml_file):
+    check_valid_xml(xml_file)
+    max_achieved_compile_depth = get_max_achieved_compile_depth(xml_file)
+    inject_param_into_tags(
+        xml_file, "max_achieved_compile_depth", max_achieved_compile_depth
+    )

--- a/tt_torch/tools/crashsafe_utils.py
+++ b/tt_torch/tools/crashsafe_utils.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
 crashsafe_suffix = "_crashsafe.json"
 
 from json2xml import json2xml
@@ -7,11 +10,10 @@ import sys
 # Convert a JSON file to XML
 
 
-
-def reconstruct_junitxml_from_crashsafe(junitxml_path:str):
+def reconstruct_junitxml_from_crashsafe(junitxml_path: str):
     # from here, how can the name of the file be determined?
     # assume it's passed in from the runner / eg. using the shared strings
-    
+
     crashsafe_path = f"{junitxml_path}{crashsafe_suffix}"
     junitxml_path = f"{junitxml_path}_regenerated.xml"
     data = readfromjson(crashsafe_path)

--- a/tt_torch/tools/crashsafe_utils.py
+++ b/tt_torch/tools/crashsafe_utils.py
@@ -1,25 +1,4 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-crashsafe_suffix = "_crashsafe.json"
-
-from json2xml import json2xml
-from json2xml.utils import readfromurl, readfromstring, readfromjson
-import sys
-
-# Convert a JSON file to XML
-
-
-def reconstruct_junitxml_from_crashsafe(junitxml_path: str):
-    # from here, how can the name of the file be determined?
-    # assume it's passed in from the runner / eg. using the shared strings
-
-    crashsafe_path = f"{junitxml_path}{crashsafe_suffix}"
-    junitxml_path = f"{junitxml_path}_regenerated.xml"
-    data = readfromjson(crashsafe_path)
-
-    with open(junitxml_path, "w+") as f:
-        f.write(json2xml.Json2xml(data).to_xml())
-
-
-reconstruct_junitxml_from_crashsafe(sys.argv[1])
+crashsafe_suffix = "_crashsafe.xml"

--- a/tt_torch/tools/crashsafe_utils.py
+++ b/tt_torch/tools/crashsafe_utils.py
@@ -1,0 +1,23 @@
+crashsafe_suffix = "_crashsafe.json"
+
+from json2xml import json2xml
+from json2xml.utils import readfromurl, readfromstring, readfromjson
+import sys
+
+# Convert a JSON file to XML
+
+
+
+def reconstruct_junitxml_from_crashsafe(junitxml_path:str):
+    # from here, how can the name of the file be determined?
+    # assume it's passed in from the runner / eg. using the shared strings
+    
+    crashsafe_path = f"{junitxml_path}{crashsafe_suffix}"
+    junitxml_path = f"{junitxml_path}_regenerated.xml"
+    data = readfromjson(crashsafe_path)
+
+    with open(junitxml_path, "w+") as f:
+        f.write(json2xml.Json2xml(data).to_xml())
+
+
+reconstruct_junitxml_from_crashsafe(sys.argv[1])

--- a/tt_torch/tools/postprocess_crashsafe_reports.py
+++ b/tt_torch/tools/postprocess_crashsafe_reports.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import glob
+import os
+from xml.etree.ElementTree import ElementTree, Element, parse
+from tt_torch.tools.crashsafe_utils import rewrite_crashsafe_xml
+
+
+def merge_junit_reports(input_files, output_file):
+    """
+    Merge multiple JUnit XML files into a single JUnit XML file.
+
+    Args:
+        input_files (list): List of paths to JUnit XML files to merge.
+        output_file (str): Path to the output merged JUnit XML file.
+    """
+    if not input_files:
+        print("No input files found to merge.")
+        return
+
+    # Parse the first file as the base
+    base_tree = parse(input_files[0])
+    base_root = base_tree.getroot()
+
+    # Merge the rest of the files into the base
+    for file in input_files[1:]:
+        tree = parse(file)
+        root = tree.getroot()
+
+        # Append all <testcase> elements from the current file to the base
+        for testcase in root.findall(".//testcase"):
+            base_root.append(testcase)
+
+    # Write the merged XML to the output file
+    base_tree.write(output_file, encoding="utf-8", xml_declaration=True)
+    print(f"Merged {len(input_files)} files into {output_file}")
+
+
+def process_and_merge_reports(search_pattern, output_file):
+    """
+    Process and merge JUnit XML reports.
+
+    Args:
+        search_pattern (str): Glob pattern to match JUnit XML files.
+        output_file (str): Path to the output merged JUnit XML file.
+    """
+    # Find all files matching the search pattern
+    input_files = glob.glob(search_pattern)
+    if not input_files:
+        print(f"No files found matching pattern: {search_pattern}")
+        return
+
+    print(f"Found {len(input_files)} files to process.")
+
+    # Process each file with rewrite_crashsafe_xml
+    for file in input_files:
+        print(f"Processing file: {file}")
+        rewrite_crashsafe_xml(file)
+
+    # Merge all processed files into a single output file
+    merge_junit_reports(input_files, output_file)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python -m tt_torch.tests.postprocess_test_reports <search_pattern> <output_file>"
+        )
+        sys.exit(1)
+
+    search_pattern = sys.argv[1]
+    output_file = sys.argv[2]
+
+    process_and_merge_reports(search_pattern, output_file)

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -267,6 +267,7 @@ class CompilerConfig:
         self.enable_async = False
         self.cache_preprocessed_constants = False
         self.inline_parameters = False
+        self.record_property = None
 
         self.apply_environment_overrides()
         self.post_init()

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -128,7 +128,7 @@ def verify_against_golden(
         else:
             print(msg)
 
-    return pccs, atols
+    return pccs, atols, passed_pcc, passed_atol
 
 
 def _verify_torch_module(


### PR DESCRIPTION
### Ticket
#443 

### Problem description
We only run model tests as a regression test, and we lack a way to run a benchmark on a models, and capture their actual achieved compile depth.

### What's changed
- Create a crashsafe, transactional XML logger that creates an XML to mirror the output of junitxml and optionally overload record_property when passing --crashsafe to the pytest as a CLI option
- Create utils to extract all pytests under tests/models that are full-eval related and write them to a parallel build matrix
- Create utils to rewrite the crashsafe XML into a pydantic model compliant format and pack max compile depth regardless of the termination mode of the original test

### Checklist
- [x] New/Existing tests provide coverage for changes
