### PR TITLE
Few op-by-op flow improvements (xfail output shown, better tar-results error) and fixes (use self.tokenizer) to models

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -313,7 +313,7 @@ jobs:
 
           pytest_log="test_${counter}.log"
 
-          pytest -svv "$test_case" --op_by_op_torch > "$pytest_log" 2>&1
+          pytest -svv --runxfail "$test_case" --op_by_op_torch > "$pytest_log" 2>&1
           exit_code=$?
 
           echo "====== BEGIN LOG: $test_case ======" >> full_job_output.log
@@ -340,9 +340,17 @@ jobs:
     - name: Tar results
       if: success() || failure()
       shell: bash
-      working-directory: ${{ steps.strings.outputs.test-output-dir }}
       run: |
-        tar cvf ${{ matrix.build.name }}_${{ steps.fetch-job-id.outputs.job_id }}.tar .
+        TEST_DIR="${{ steps.strings.outputs.test-output-dir }}"
+        OUTPUT_TAR="${{ matrix.build.name }}_${{ steps.fetch-job-id.outputs.job_id }}.tar"
+
+        if [ ! -d "$TEST_DIR" ]; then
+          echo "ERROR: Test output dir '$TEST_DIR' does not exist. Please check if test ran properly."
+          exit 1
+        fi
+
+        cd "$TEST_DIR"
+        tar cvf "$OUTPUT_TAR" .
 
     - name: Upload test folder to archive
       if: success() || failure()

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -50,7 +50,7 @@ def test_codegen(record_property, mode, op_by_op):
         mode,
         compiler_config=cc,
         record_property_handle=record_property,
-        is_transformers_generation=True,
+        is_token_output=True,
     )
     results = tester.test_model()
 

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -11,14 +11,14 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        self.processor = AutoProcessor.from_pretrained("facebook/musicgen-small")
+        self.tokenizer = AutoProcessor.from_pretrained("facebook/musicgen-small")
         model = MusicgenForConditionalGeneration.from_pretrained(
             "facebook/musicgen-small"
         )
         return model.generate
 
     def _load_inputs(self):
-        inputs = self.processor(
+        inputs = self.tokenizer(
             text=[
                 "80s pop track with bassy drums and synth",
                 "90s rock song with loud guitars and heavy drums",

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -12,7 +12,7 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 class ThisTester(ModelTester):
     def _load_model(self):
         # load model and processor
-        self.processor = WhisperProcessor.from_pretrained(
+        self.tokenizer = WhisperProcessor.from_pretrained(
             "openai/whisper-small", torch_dtype=torch.bfloat16
         )
         model = WhisperForConditionalGeneration.from_pretrained(
@@ -27,7 +27,7 @@ class ThisTester(ModelTester):
             "hf-internal-testing/librispeech_asr_dummy", "clean", split="validation"
         )
         sample = ds[0]["audio"]
-        input_features = self.processor(
+        input_features = self.tokenizer(
             sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt"
         ).input_features
         return input_features.to(torch.bfloat16)
@@ -36,7 +36,7 @@ class ThisTester(ModelTester):
         # generate token ids
         predicted_ids = model(input_features)
         # decode token ids to text
-        transcription = self.processor.batch_decode(
+        transcription = self.tokenizer.batch_decode(
             predicted_ids, skip_special_tokens=True
         )
         return transcription


### PR DESCRIPTION
### Ticket
See #451 for details - Closes #451

### Problem description
Address a few concerns from this ticket.

 - A couple categories of test fixes after Lewis' change at 0decda6 that prevented models from running (use self.tokenizer, and is_token_output). There are other issues exposed by whisper, musicgen that will require followup debug/fixes.
 - Add better error message in "Tar results" when $pwd (test output dir) used as working-directory doesn't exist (was occuring in these xfail tests that failed to run)
  - Add `--runxfail` arg to op-by-op flow so we can at least see xfail test output in log files instead of nothing (useful for when signature changes, but we don't know, happened today)
  
### Checklist
- [x] New/Existing tests provide coverage for changes

codegen model is back to passing in op-by-op flow with these changes.
