### PR TITLE
Add perf building to onPush workflow

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -21,6 +21,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      setup-args: "--build_perf" #TODO - This should be toggleable?
   test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-tests.yml


### PR DESCRIPTION
### Ticket
#257 

### Problem description
OnPush fails because it can't find tracy binaries, because they aren't built in the OnPush workflow

### What's changed
Add tracy binary building to OnPush workflow

### Checklist
- [x] New/Existing tests provide coverage for changes
