### PR TITLE
Change the way unused outputs are calculated in op_by_op_mode

### DIFF
--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -376,6 +376,14 @@ class CompilerConfig:
         with open(output_file, "w") as f:
             json.dump(unique_op_dict, f)
 
+        total_ops = len(unique_op_dict)
+        num_executed_ops = 0
+        for op in unique_op_dict.values():
+            if op["compilation_status"] == OpCompilationStatus.EXECUTED:
+                num_executed_ops += 1
+
+        print(f"{num_executed_ops}/{total_ops} ops executed")
+
     def set_compile_depth(self, compile_depth: CompileDepth):
         self.compile_depth = compile_depth
 


### PR DESCRIPTION
### Problem description
Unused outputs were not being detected correctly in op-by-op mode causing many ops to fail needlessly. The issue is that torch.export (introduces by @LPanosTT several days ago) places getitem nodes on node outputs whether they're needed or not.

### What's changed
Checking whether the user get_items have users restores original behaviour. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
