### PR TITLE
Remove --runxfail replace with pytest_runtest_logreport hook to print xfail/skip reason/output (#451)

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -313,7 +313,7 @@ jobs:
 
           pytest_log="test_${counter}.log"
 
-          pytest -svv --runxfail "$test_case" --op_by_op_torch > "$pytest_log" 2>&1
+          pytest -svv "$test_case" --op_by_op_torch > "$pytest_log" 2>&1
           exit_code=$?
 
           echo "====== BEGIN LOG: $test_case ======" >> full_job_output.log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,13 @@ def pytest_addoption(parser):
     )
 
 
+# Print more details for skipped and xfailed tests
+def pytest_runtest_logreport(report):
+    if report.outcome in ("xfailed", "skipped") or hasattr(report, "wasxfail"):
+        if report.longrepr:
+            print(f"\n{report.longreprtext}")
+
+
 def pytest_collection_modifyitems(config, items):
     # Filter tests based on which op_by_op flag is set
     selected_items = []

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -366,8 +366,10 @@ class CompilerConfig:
         # with python command; use 'sys.argv[0]' instead.
         if pytest_test is None:
             pytest_test = sys.argv[0]
-        pytest_test = pytest_test.replace("::", "_").replace(".", "_")
-        pytest_test = pytest_test.replace("[", "_").replace("]", "_")
+
+        # Keep slashes, replace all non-alphanumeric characters with underscore.
+        pytest_test = re.sub(r"[^A-Za-z0-9_/]", "_", pytest_test)
+
         for key, op in self.unique_ops.items():
             unique_op_dict[key] = op.to_dict()
         output_file = Path(f"{self.results_path}{pytest_test}_unique_ops.json")


### PR DESCRIPTION
### Ticket
#451 follow up

### Problem description
Fix an issue with previous change and improve unique_ops.json generation

 - Turns out --runxfail was causing pytest to ignore xfail attribute and return as failing
 - This is better, will preserve xfail attribute, but now for xfailed and skipped tests, will print their output/reason. This hook is automatically called by pytests
 - Also, sanitize pytest name better in _unique_ops.json creation to avoid spaces, brackets

Tested these on a seperate branch with reduced testlist before creating PR.

### Checklist
- [ ] New/Existing tests provide coverage for changes
