### PR TITLE
Fix nightly test failure March 20, 2025 [#465]

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,7 @@ jobs:
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
         echo "test_report_path_torch=report_torch_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_mnist=report_mnist_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_onnx=report_onnx_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
 
@@ -120,6 +121,22 @@ jobs:
         name: test-reports-onnx-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path_onnx }}
 
+    - name: Run Mnist Op-By-Op and Check All Ops Execute
+      shell: bash
+      run: |
+        source env/activate
+        TT_TORCH_CHECK_ALL_OPS_RUN=1 pytest -svv tests/models/mnist/test_mnist.py --op_by_op_torch \
+            --junit-xml=${{ steps.strings.outputs.test_report_path_mnist }} \
+            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+
+    - name: Upload Test Report Mnist
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: test-reports-mnist-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.test_report_path_mnist }}
+
+
     - name: Show Test Report
       uses: mikepenz/action-junit-report@v5
       if: success() || failure()
@@ -145,6 +162,6 @@ jobs:
       continue-on-error: true
       uses: codecov/test-results-action@v1
       with:
-        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}
+        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}, ${{ steps.strings.outputs.test_report_path_mnist }}
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -451,7 +451,7 @@ class OpByOpExecutor(Executor):
 
         inputs_size = get_inputs_size(inputs)
 
-        large_input = inputs_size > self.op_memory_limit
+        large_input = inputs_size >= self.op_memory_limit
 
         obj = {
             "binary": binary,
@@ -512,7 +512,7 @@ class OpByOpExecutor(Executor):
                 self.execute_process = None
                 break
 
-        if os.path.isfile(inputs_file_path):
+        if inputs_file_path and os.path.isfile(inputs_file_path):
             try:
                 os.remove(inputs_file_path)
             except OSError:

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -379,7 +379,6 @@ class TorchExecutor(OpByOpExecutor):
         if self.stderror_redirected:
             os.unlink(self.file_stderr.name)
             self.stderror_redirected = False
-
         return outputs
 
     def __call__(self, *inputs):

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -262,6 +262,7 @@ class CompilerConfig:
         self._enable_intermediate_verification = False
         self.dump_debug = False
         self.dump_info = False
+        self.check_all_ops_execute = False
         self._verify_op_by_op = False
         self.typecast_inputs = True
         self.runtime_device = None
@@ -320,6 +321,9 @@ class CompilerConfig:
         verify_op_by_op = os.environ.get("TT_TORCH_VERIFY_OP_BY_OP")
         if verify_op_by_op and int(verify_op_by_op):
             self.verify_op_by_op = True
+        check_all_ops_execute = os.environ.get("TT_TORCH_CHECK_ALL_OPS_EXECUTE")
+        if check_all_ops_execute:
+            self.check_all_ops_execute = True
         verify_intermediates = os.environ.get("TT_TORCH_VERIFY_INTERMEDIATES")
         if verify_intermediates and int(verify_intermediates):
             self.enable_intermediate_verification = True
@@ -385,6 +389,9 @@ class CompilerConfig:
                 num_executed_ops += 1
 
         print(f"{num_executed_ops}/{total_ops} ops executed")
+        if self.check_all_ops_execute:
+            assert num_executed_ops == total_ops
+            print(f"Verified all ops ran in {self.model_name}")
 
     def set_compile_depth(self, compile_depth: CompileDepth):
         self.compile_depth = compile_depth


### PR DESCRIPTION
Fix "stat: path should be string, bytes, os.PathLike or integer, not NoneType" error. Check all mnist ops execute on PR.

### Ticket
#465 

### Problem description
Issue arose from 
`if os.path.isfile(inputs_file_path):`
when inputs_file_path is None, this gives an "stat: path should be string, bytes, os.PathLike or integer, not NoneType" error.
This was replaced with
`if inputs_file_path and os.path.isfile(inputs_file_path):`

+ added a workflow job that checks all mnist ops run on PR. 