### PR TITLE
Move tag flush to happen before the verify_against_golden asserts

### DIFF
--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -64,8 +64,6 @@ def test_MobileNetV2(record_property, mode, op_by_op):
         _, indices = torch.topk(results, 5)
         print(f"Top 5 predictions: {indices[0].tolist()}")
 
-    tester.finalize()
-
 
 # Empty property record_property
 def empty_record_property(a, b):

--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -62,8 +62,6 @@ def test_MobileNetV2(record_property, mode, op_by_op):
         _, indices = torch.topk(results[0], 5)
         print(f"Top 5 predictions: {indices[0].tolist()}")
 
-    tester.finalize()
-
 
 # Empty property record_property
 def empty_record_property(a, b):

--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -75,5 +75,3 @@ def test_qwen2_casual_lm(record_property, model_name, mode, op_by_op):
         print(
             f"Model: {model_name} | Input: {tester.text} | Generated Text: {gen_text}"
         )
-
-    tester.finalize()

--- a/tests/models/Qwen/test_qwen2_token_classification.py
+++ b/tests/models/Qwen/test_qwen2_token_classification.py
@@ -73,5 +73,3 @@ def test_qwen2_token_classification(record_property, model_name, mode, op_by_op)
         print(
             f"Model: {model_name} | Tokens: {tokens} | Predictions: {predicted_tokens_classes}"
         )
-
-    tester.finalize()

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -71,5 +71,3 @@ def test_RMBG(record_property, mode, op_by_op):
         mask = pred_pil.resize(tester.image.size)
         tester.image.putalpha(mask)
         tester.image.save("no_bg_image.png")
-
-    tester.finalize()

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -83,5 +83,3 @@ def test_albert_masked_lm(record_property, model_name, mode, op_by_op):
         predicted_tokens = tester.tokenizer.decode(predicted_token_id)
 
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
-
-    tester.finalize()

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -69,5 +69,3 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
         print(
             f"Model: {model_name} | Question: {tester.question} | Text: {tester.text} | Answer: {answer}"
         )
-
-    tester.finalize()

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -64,5 +64,3 @@ def test_albert_sequence_classification(record_property, model_name, mode, op_by
         print(
             f"Model: {model_name} | Input: {tester.input_text} | Label: {predicted_label}"
         )
-
-    tester.finalize()

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -75,5 +75,3 @@ def test_albert_token_classification(record_property, model_name, mode, op_by_op
         print(
             f"Model: {model_name} | Tokens: {tokens} | Predictions: {predicted_tokens_classes}"
         )
-
-    tester.finalize()

--- a/tests/models/autoencoder_conv/test_autoencoder_conv.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv.py
@@ -73,5 +73,3 @@ def test_autoencoder_conv(record_property, mode, op_by_op):
 
     if mode == "eval":
         image = results.images[0]
-
-    tester.finalize()

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -98,5 +98,3 @@ def test_autoencoder_conv_v2(record_property, mode, op_by_op):
 
     if mode == "eval":
         print("Output: ", results)
-
-    tester.finalize()

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -109,5 +109,3 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
 
     if mode == "eval":
         print("Output: ", results)
-
-    tester.finalize()

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -79,5 +79,3 @@ def test_beit_image_classification(record_property, model_name, mode, op_by_op):
             "Predicted class:",
             tester.framework_model.config.id2label[predicted_class_idx],
         )
-
-    tester.finalize()

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -86,5 +86,3 @@ def test_bert(record_property, mode, op_by_op):
         answer: {answer}
         """
         )
-
-    tester.finalize()

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -81,5 +81,3 @@ def test_bloom(record_property, mode, op_by_op):
         output: {decoded_output}
         """
         )
-
-    tester.finalize()

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -95,5 +95,3 @@ def test_clip(record_property, mode, op_by_op):
         probs = logits_per_image.softmax(
             dim=1
         )  # we can take the softmax to get the label probabilities
-
-    tester.finalize()

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -56,5 +56,3 @@ def test_codegen(record_property, mode, op_by_op):
 
     if mode == "eval":
         print(tester.tokenizer.decode(results[0]))
-
-    tester.finalize()

--- a/tests/models/deepseek/test_deepseek_qwen.py
+++ b/tests/models/deepseek/test_deepseek_qwen.py
@@ -61,4 +61,3 @@ def test_deepseek_qwen(record_property, model_name, mode, op_by_op):
     )
 
     tester.test_model()
-    tester.finalize()

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -81,5 +81,3 @@ def test_deit(record_property, model_name, mode, op_by_op):
             "Predicted class:",
             tester.framework_model.config.id2label[predicted_class_idx],
         )
-
-    tester.finalize()

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -73,5 +73,3 @@ def test_detr(record_property, mode, op_by_op):
     if mode == "eval":
         # Results
         print(results)
-
-    tester.finalize()

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -55,8 +55,6 @@ def test_distilbert(record_property, model_name, mode, op_by_op):
     if mode == "eval":
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")
 
-    tester.finalize()
-
 
 @pytest.mark.parametrize(
     "num_loops",
@@ -101,5 +99,4 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")
         print(f"{num_loops} iterations took {(end_time - start_time)} seconds")
 
-    tester.finalize()
     cc.cleanup_device()

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -65,5 +65,3 @@ def test_dpr(record_property, mode, op_by_op):
         end_logits = results.end_logits
         relevance_logits = results.relevance_logits
         print(results)
-
-    tester.finalize()

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -72,5 +72,3 @@ def test_falcon(record_property, mode, op_by_op):
         output before: {decoded_output}
         """
         )
-
-    tester.finalize()

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -60,5 +60,3 @@ def test_flan_t5(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         results = tester.tokenizer.batch_decode(results, skip_special_tokens=True)
-
-    tester.finalize()

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -71,5 +71,3 @@ def test_glpn_kitti(record_property, mode, op_by_op):
         output = prediction.squeeze().cpu().to(float).numpy()
         formatted = (output * 255 / np.max(output)).astype("uint8")
         depth = Image.fromarray(formatted)
-
-    tester.finalize()

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -72,5 +72,3 @@ def test_gpt2(record_property, mode, op_by_op):
         output before: {decoded_output}
         """
         )
-
-    tester.finalize()

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -68,5 +68,3 @@ def test_gpt_neo(record_property, mode, op_by_op):
     results = tester.test_model(assert_eval_token_mismatch=False)
     if mode == "eval":
         gen_text = tester.tokenizer.batch_decode(results)[0]
-
-    tester.finalize()

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -110,4 +110,3 @@ def test_hand_landmark(record_property, mode, op_by_op):
 
     tester = ThisTester(model_name, mode, record_property_handle=record_property)
     tester.test_model()
-    tester.finalize()

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -82,5 +82,3 @@ def test_hardnet(record_property, mode, op_by_op):
         # The output has unnormalized scores. To get probabilities, you can run a softmax on it.
         probabilities = torch.nn.functional.softmax(results[0], dim=0)
         print(probabilities)
-
-    tester.finalize()

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -60,4 +60,3 @@ def test_llama_3b(record_property, model_name, mode, op_by_op):
         record_property_handle=record_property,
     )
     results = tester.test_model()
-    tester.finalize()

--- a/tests/models/llama/test_llama_7b.py
+++ b/tests/models/llama/test_llama_7b.py
@@ -83,5 +83,3 @@ def test_llama_7b(record_property, mode, op_by_op):
         output before: {decoded_output}
         """
         )
-
-    tester.finalize()

--- a/tests/models/mamba/test_mamba.py
+++ b/tests/models/mamba/test_mamba.py
@@ -80,5 +80,3 @@ def test_mamba(record_property, model_name, mode, op_by_op):
     if mode == "eval":
         gen_text = tester.tokenizer.batch_decode(results)
         print("Generated text: ", gen_text)
-
-    tester.finalize()

--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -69,5 +69,3 @@ def test_mgp_str_base(record_property, mode, op_by_op):
         generated_text = tester.processor.batch_decode(logits)["generated_text"]
         print(f"Generated text: '{generated_text}'")
         assert generated_text[0] == "ticket"
-
-    tester.finalize()

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -61,4 +61,3 @@ def test_mlpmixer(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -87,4 +87,3 @@ def test_mnist_train(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -59,4 +59,3 @@ def test_mobilenet_ssd(record_property, mode, op_by_op):
         model_name, mode, compiler_config=cc, record_property_handle=record_property
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -66,4 +66,3 @@ def test_musicgen_small(record_property, mode, op_by_op):
         is_token_output=True,
     )
     results = tester.test_model()
-    tester.finalize()

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -55,4 +55,3 @@ def test_openpose(record_property, mode, op_by_op):
         model_name, mode, compiler_config=cc, record_property_handle=record_property
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -79,5 +79,3 @@ def test_openpose_v2(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         print(f"Output: {results}")
-
-    tester.finalize()

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -61,5 +61,3 @@ def test_opt(record_property, mode, op_by_op):
     results = tester.test_model(assert_eval_token_mismatch=False)
     if mode == "eval":
         tester.tokenizer.batch_decode(results)[0]
-
-    tester.finalize()

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -68,5 +68,3 @@ def test_perceiver_io(record_property, mode, op_by_op):
         logits = results.logits
         masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)
         print(tester.tokenizer.decode(masked_tokens_predictions))
-
-    tester.finalize()

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -50,5 +50,3 @@ def test_resnet(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     results = tester.test_model()
-
-    tester.finalize()

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -71,8 +71,6 @@ def test_resnet(record_property, mode, op_by_op):
         _, indices = torch.topk(results, 5)
         print(f"Top 5 predictions: {indices[0].tolist()}")
 
-    tester.finalize()
-
 
 # Empty property record_property
 def empty_record_property(a, b):

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -60,5 +60,3 @@ def test_roberta(record_property, mode, op_by_op):
 
         predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
         output = tester.tokenizer.decode(predicted_token_id)
-
-    tester.finalize()

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -73,5 +73,3 @@ def test_segformer(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         logits = results.logits  # shape (batch_size, num_labels, height/4, width/4)
-
-    tester.finalize()

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -58,5 +58,3 @@ def test_segment_anything(record_property, mode, op_by_op):
         model_name, mode, compiler_config=cc, record_property_handle=record_property
     )
     tester.test_model()
-
-    tester.finalize()

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -77,5 +77,3 @@ def test_speecht5_tts(record_property, mode, op_by_op):
     #     # Uncomment below if you really want to hear the result.
     #     # import soundfile as sf
     #     sf.write("speech.wav", speech.numpy(), samplerate=16000)
-
-    tester.finalize()

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -52,5 +52,3 @@ def test_squeeze_bert(record_property, mode, op_by_op):
     if mode == "eval":
         logits = results.logits
         predicted_class_id = logits.argmax().item()
-
-    tester.finalize()

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -50,5 +50,3 @@ def test_stable_diffusion(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         image = results.images[0]
-
-    tester.finalize()

--- a/tests/models/stable_diffusion/test_stable_diffusion_unet.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_unet.py
@@ -91,5 +91,3 @@ def test_stable_diffusion_unet(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         noise_pred = results.sample
-
-    tester.finalize()

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -60,5 +60,3 @@ def test_t5(record_property, model_name, mode, op_by_op):
         print(
             f"Model: {model_name} | Input: {tester.input_text} | Output: {output_text}"
         )
-
-    tester.finalize()

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -95,4 +95,3 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         print(
             f"Model: {model_name} | Predicted class ID: {top5_class_indices[0]} | Probabiliy: {top5_probabilities[0]}"
         )
-    tester.finalize()

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -125,5 +125,3 @@ def test_torchvision_image_classification(record_property, model_info, mode, op_
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)
         print(f"Model: {model_info[0]} | Top 5 predictions: {indices[0].tolist()}")
-
-    tester.finalize()

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -80,5 +80,3 @@ def test_torchvision_object_detection(record_property, model_info, mode, op_by_o
     results = tester.test_model()
     if mode == "eval":
         print(f"Model: {model_name} | Output: {results}")
-
-    tester.finalize()

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -70,5 +70,3 @@ def test_unet(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         results = torch.round(results[0])
-
-    tester.finalize()

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -80,5 +80,3 @@ def test_unet_brain(record_property, mode, op_by_op):
     results = tester.test_model()
     if mode == "eval":
         print(torch.round(results[0]))
-
-    tester.finalize()

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -54,4 +54,3 @@ def test_unet_carvana(record_property, mode, op_by_op):
         model_name, mode, compiler_config=cc, record_property_handle=record_property
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -65,5 +65,3 @@ def test_vilt(record_property, mode, op_by_op):
         logits = results.logits
         idx = logits.argmax(-1).item()
         print("Predicted answer:", tester.framework_model.config.id2label[idx])
-
-    tester.finalize()

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -76,4 +76,3 @@ def test_whisper(record_property, mode, op_by_op):
         is_token_output=True,
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -60,4 +60,3 @@ def test_xglm(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -93,5 +93,3 @@ def test_yolos(record_property, mode, op_by_op):
         answer before: {interpret_results(decoded_output)}
         """
         )
-
-    tester.finalize()

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -82,4 +82,3 @@ def test_yolov3(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.finalize()

--- a/tests/models/yolov4/test_yolov4.py
+++ b/tests/models/yolov4/test_yolov4.py
@@ -62,4 +62,3 @@ def test_yolov4(record_property, mode, op_by_op):
     )
     with torch.no_grad():
         tester.test_model()
-    tester.finalize()

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -132,4 +132,3 @@ def test_yolov5(record_property, mode, op_by_op):
         record_property_handle=record_property,
     )
     tester.test_model()
-    tester.finalize()

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -20,6 +20,7 @@ def verify_against_golden(
     required_pcc=0.99,
     required_atol=None,
     relative_atol=None,
+    preflush_tags=None,
 ):
     assert (required_atol is not None) != (
         relative_atol is not None
@@ -107,6 +108,9 @@ def verify_against_golden(
                 + f"ATOL of output {i}: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} {red_x if assert_atol else atol_warning}\n"
             )
             passed_atol = False
+
+        if preflush_tags is not None:
+            preflush_tags(pccs, atols)
 
         if assert_pcc and assert_atol:
             if passed_pcc and passed_atol:


### PR DESCRIPTION
### Ticket
Part of #443 

### Problem description
Tags are not flushed since the PCC / ATOL verification check happens as an assert and prevents tester finalization if the check fails and we are asserting PCC / ATOL

### What's changed
- Move the tag flushing to happen as soon as PCC and ATOLs are generated. This is the last thing to record into tags anyways (at this point) so it is valid to write out tags at this point.
- Remove tester.finalize() from every step since it happens inside golden verification

### Checklist
- [x] New/Existing tests provide coverage for changes
