### PR TITLE
Add tests for mistral 8B model #263

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -224,6 +224,11 @@ jobs:
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[op_by_op_torch-eval-regnet_x_32gf]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[op_by_op_torch-eval-swin_b]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "mistral", tests: "
+              tests/models/mistral/test_mistral_8b.py::test_mistral_8b
+              "
           }
         ]
     runs-on:

--- a/tests/models/mistral/test_mistral_8b.py
+++ b/tests/models/mistral/test_mistral_8b.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+# Load model directly
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model_name = "mistralai/Ministral-8B-Instruct-2410"
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, padding_side="left", torch_dtype=torch.bfloat16
+        )
+        m = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+        return m
+
+    def _load_inputs(self):
+        # Set up sample input
+        self.test_input = "How often does the letter r occur in Mistral?"
+        inputs = self.tokenizer.encode_plus(self.test_input, return_tensors="pt")
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.xfail(reason="Mistral-8B is too large to fit on a single device")
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_mistral_8b(record_property, mode, op_by_op):
+    model_name = "Mistral-8B"
+
+    cc = CompilerConfig()
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        assert_atol=False,
+        assert_pcc=False,
+    )
+    results = tester.test_model()
+    if mode == "eval":
+        decoded_output = tester.tokenizer.decode(
+            torch.argmax(results["logits"], dim=-1)[0], skip_special_tokens=True
+        )
+
+        print(
+            f"""
+        model_name: {model_name}
+        input: {tester.test_input}
+        output: {decoded_output}
+        """
+        )
+
+    tester.finalize()


### PR DESCRIPTION
### Ticket
#263 

### Problem description
We need to add mistral 8B model to our test cases

### What's changed
Added mistral 8B model, we needed to add a xfail due to the model not fitting on single device. Running op by op fails due to ATOL mismatch.

### Checklist
- [x] Tested model locally op_by_op-eval
