### PR TITLE
Reduce input size limit to 512MB, eanble RMBG test

### DIFF
--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -39,7 +39,6 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.skip(reason="Python bus error at the end of torch op-by-op flow")
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -313,7 +313,7 @@ class OpByOpExecutor(Executor):
         # to capture runtime stack dump.
         self.stderror_redirected = False
         self.file_stderr = None
-        self.op_memory_limit = gb_to_bytes(1)  # 1GB limit
+        self.op_memory_limit = gb_to_bytes(0.5)  # 512MB limit
 
     def transform_input(self, inp):
         # Convert torch.nn.Parameter to torch.Tensor and convert non-contiguous


### PR DESCRIPTION
### Problem description
RMBG was failing with a seg fault. 

### What's changed
Decreased input size req to dump inputs to disk to 512MB. 

### Checklist
- [x] New/Existing tests provide coverage for changes
