### PR TITLE
Few op-by-op flow improvements/tidyup/bugfix, and upload markdown report as artifact

### DIFF
--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -111,12 +111,22 @@ jobs:
         echo "commit=$commit" >> "$GITHUB_OUTPUT"
         echo "date=$date" >> "$GITHUB_OUTPUT"
         spreadsheet_name="models_op_per_op_${date}_${branch}_${commit}.xlsx"
+        markdown_name="models_${date}_${branch}_${commit}.md"
         echo "spreadsheet_name=$spreadsheet_name" >> "$GITHUB_OUTPUT"
+        echo "markdown_name=$markdown_name" >> "$GITHUB_OUTPUT"
         echo "Renaming spreadsheet from ${{ steps.strings.outputs.work-dir }}/results/models_op_per_op.xlsx to ${{ steps.strings.outputs.work-dir }}/results/$spreadsheet_name"
         mv ${{ steps.strings.outputs.work-dir }}/results/models_op_per_op.xlsx ${{ steps.strings.outputs.work-dir }}/results/$spreadsheet_name
+        echo "Renaming markdown from ${{ steps.strings.outputs.work-dir }}/results/models.md to ${{ steps.strings.outputs.work-dir }}/results/$markdown_name"
+        mv ${{ steps.strings.outputs.work-dir }}/results/models.md ${{ steps.strings.outputs.work-dir }}/results/$markdown_name
 
-    - name: Upload report to archive
+    - name: Upload xls report to archive
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.git-info.outputs.spreadsheet_name }}
         path: "${{ steps.strings.outputs.work-dir }}/results/${{ steps.git-info.outputs.spreadsheet_name }}"
+
+    - name: Upload markdown report to archive
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.git-info.outputs.markdown_name }}
+        path: "${{ steps.strings.outputs.work-dir }}/results/${{ steps.git-info.outputs.markdown_name }}"


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Fix parse_op_by_op_results.py legacy bug causing first occurences of ops to be dropped (single op occurrences were completely missed from All Ops sheet)
 - Add column to parse_op_by_op_results.py to display number of "Error message not extracted." which is the most popular signature lately, want to be able to quickly ignore it.
 - Apply data/git-info to models.md like was done for xls recently, and upload as artifact since it's created but not used. Is a nice summary (just realized it existed today after looking around ... )

### Checklist
- [x] New/Existing tests provide coverage for changes

Here is a branch testing run with the md report uploaded:
https://github.com/tenstorrent/tt-torch/actions/runs/13996487208

See couple screenshots for new stuff (md report from above branch, and new column to xlsx indicating that in the models reported "Error message not extracted" (board issues in this case) was basically 100% of the errors).

![Screenshot 2025-03-21 at 4 03 47 PM](https://github.com/user-attachments/assets/f6e002b7-d496-4178-ba69-837da0e5ed9c)
![Screenshot 2025-03-21 at 4 34 16 PM](https://github.com/user-attachments/assets/bd48230f-1ffe-4067-bcaf-4345bd062aa4)


