### PR TITLE
Add 31 models to run-e2e-tests.yml (full model compile-only nightly job)

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -19,15 +19,74 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: wormhole_b0, name: "run"},
+          {
+            # Approximately 65 minutes.
+            runs-on: wormhole_b0, name: "compile_1", tests: "
+                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval]
+                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]
+                  tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval]
+                  tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd[full-eval]
+                  tests/models/segformer/test_segformer.py::test_segformer[full-eval]
+                  tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[full-eval]
+                  tests/models/vilt/test_vilt.py::test_vilt[full-eval]
+                  tests/models/bert/test_bert.py::test_bert[full-eval]
+                  tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
+                  tests/models/whisper/test_whisper.py::test_whisper[full-eval]
+                  tests/models/yolos/test_yolos.py::test_yolos[full-eval]
+                  tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval]
+            "
+          },
+          {
+            # Approximately 65 minutes.
+            runs-on: wormhole_b0, name: "compile_2", tests: "
+                  tests/models/detr/test_detr.py::test_detr[full-eval]
+                  tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
+                  tests/models/hardnet/test_hardnet.py::test_hardnet[full-eval]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19_bn]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_h_14]
+                  tests/models/dpr/test_dpr.py::test_dpr[full-eval]
+                  tests/models/roberta/test_roberta.py::test_roberta[full-eval]
+                  tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xlarge-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-large-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-base-v2-eval]
+                  tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[full-textattack/albert-base-v2-imdb-eval]
+                  tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[full-twmkn9/albert-base-v2-squad2-eval]
+                  tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[full-albert/albert-base-v2-eval]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-xception71.tf_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite0.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite1.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite2.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite3.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite4.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mobilenetv1_100.ra4_e3600_r224_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-dla34.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mixer_b16_224.goog_in21k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ghostnet_100.in1k]
+                  tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]
+                  tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
+            "
+          },
+          {
+            # Approximately 40 minutes.
+            runs-on: wormhole_b0, name: "compile_3", tests: "
+                  tests/models/opt/test_opt.py::test_opt[full-eval]
+                  tests/models/bloom/test_bloom.py::test_bloom[full-eval]
+                  tests/models/yolov5/test_yolov5.py::test_yolov5[full-eval]
+                  tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
+            "
+          }
         ]
-
     runs-on:
       - ${{ matrix.build.runs-on }}
 
+    name: "test compile (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=2gb
+      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -46,7 +105,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "${{ github.job }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+        job_name: "test compile (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
     - name: Set reusable strings
       id: strings
       shell: bash
@@ -91,24 +150,11 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest -v \
-                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval] \
-                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval] \
-                  tests/models/detr/test_detr.py::test_detr[full-eval] \
-                  tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval] \
-                  tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval] \
-                  tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd[full-eval] \
-                  tests/models/segformer/test_segformer.py::test_segformer[full-eval] \
-                  tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[full-eval] \
-                  tests/models/vilt/test_vilt.py::test_vilt[full-eval] \
-                  tests/models/bert/test_bert.py::test_bert[full-eval] \
-                  tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval] \
-                  tests/models/whisper/test_whisper.py::test_whisper[full-eval] \
-                  tests/models/yolos/test_yolos.py::test_yolos[full-eval] \
-                  tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval] \
-                  tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval] \
-           --junit-xml=${{ steps.strings.outputs.test_report_path_models }}
+        apt-get update
+        apt install -y libgl1 libglx-mesa0
 
+        TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v ${{matrix.build.tests}} \
+          --junit-xml=${{ steps.strings.outputs.test_report_path_models }}
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Ticket
None

### What's changed
- These models all pass op-by-op flow for all ops
- Parallelize tests in run-e2e-tests.yml across 3 runners which takes
  65 mins, 65 mins, 40 mins each. Overall runtime slightly reduced
  compare to single runner original list.
- Add durations flag to print per-test times for keeping an eye on times
- Remove llama3B from list which was duplicated with full model execute job

### Checklist
- [x] New/Existing tests provide coverage for changes

I am currently [testing](https://github.com/tenstorrent/tt-torch/actions/runs/14004025392/job/39215505476) on a different branch to see if all compile.  Not going to merge tests if any happen to fail compile... let's see. Edit: Refactored a bit more, removed a long compiling test, passing now at TOTT for 31 new models.