### PR TITLE
Create run-full-model-execution-tests-nightly.yml w/ 13 tests passing

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -42,6 +42,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test_full_model_nightly:
+    needs: [docker-build, build]
+    uses: ./.github/workflows/run-full-model-execution-tests-nightly.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
   download-report:
     if: success() || failure()
     needs: test_op_by_op

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -37,43 +37,30 @@ jobs:
             "
           },
           {
-            # Approximately 65 minutes.
+            # Approximately 55 minutes.
             runs-on: wormhole_b0, name: "compile_2", tests: "
                   tests/models/detr/test_detr.py::test_detr[full-eval]
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
                   tests/models/hardnet/test_hardnet.py::test_hardnet[full-eval]
-                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19_bn]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_h_14]
-                  tests/models/dpr/test_dpr.py::test_dpr[full-eval]
                   tests/models/roberta/test_roberta.py::test_roberta[full-eval]
                   tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xlarge-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-large-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-base-v2-eval]
-                  tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[full-textattack/albert-base-v2-imdb-eval]
                   tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[full-twmkn9/albert-base-v2-squad2-eval]
-                  tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[full-albert/albert-base-v2-eval]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-xception71.tf_in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite0.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite1.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite2.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite3.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite4.in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mobilenetv1_100.ra4_e3600_r224_in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-dla34.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mixer_b16_224.goog_in21k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ghostnet_100.in1k]
                   tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]
                   tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
             "
           },
           {
-            # Approximately 40 minutes.
+            # Approximately 30 minutes.
             runs-on: wormhole_b0, name: "compile_3", tests: "
                   tests/models/opt/test_opt.py::test_opt[full-eval]
-                  tests/models/bloom/test_bloom.py::test_bloom[full-eval]
                   tests/models/yolov5/test_yolov5.py::test_yolov5[full-eval]
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
             "

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -1,0 +1,145 @@
+name: Run Full Model Execution Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
+      run-codecov:
+        description: 'Run code coverage reports'
+        required: false
+        type: string # properly a boolean but autocast to string when passed in using 'with' inputs
+        default: 'true'
+  workflow_run:
+    workflows: [Build] # backref to run-build as dependency
+    types: [completed]
+
+jobs:
+  tests:
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [
+          {
+            runs-on: wormhole_b0, name: "eval_1", tests: "
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vgg19]
+                  tests/models/dpr/test_dpr.py::test_dpr[full-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-xlarge-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-large-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[full-albert/albert-base-v2-eval]
+                  tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[full-textattack/albert-base-v2-imdb-eval]
+                  tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[full-albert/albert-base-v2-eval]
+            "
+          },
+          {
+            runs-on: wormhole_b0, name: "eval_2", tests: "
+                  tests/models/bloom/test_bloom.py::test_bloom[full-eval]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ghostnet_100.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-xception71.tf_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mobilenetv1_100.ra4_e3600_r224_in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-dla34.in1k]
+            "
+          }
+        ]
+    runs-on:
+      - ${{ matrix.build.runs-on }}
+
+    name: "test execution_nightly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+
+    container:
+      image: ${{ inputs.docker-image }}
+      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: true
+
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "test execution_nightly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      env:
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
+        echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+    - name: Use build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: install-artifacts
+        path: ${{ steps.strings.outputs.install-dir }}
+
+    - name: 'Untar install directory'
+      shell: bash
+      working-directory: ${{ steps.strings.outputs.install-dir }}
+      run: |
+        tar xvf artifact.tar
+        mkdir -p ${{ steps.strings.outputs.dist-dir }}
+        mv wheels/* ${{ steps.strings.outputs.dist-dir }}
+
+    - name: install tt-torch
+      shell: bash
+      run: |
+        source env/activate
+        pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
+
+    - name: Run Full Model Execution Tests
+      env:
+        HF_HOME: /mnt/dockercache/huggingface
+        TORCH_HOME: /mnt/dockercache/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      shell: bash
+      run: |
+        source env/activate
+        apt-get update
+        apt install -y libgl1 libglx-mesa0
+
+        pytest --durations=50 -v ${{matrix.build.tests}} \
+          --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
+          --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+
+    - name: Upload Test Report Models
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.test_report_path_models }}
+
+    - name: Upload coverage reports to Codecov
+      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
+      continue-on-error: true
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.info,.coverage,coverage.xml
+        # disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload test results to Codecov
+      if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}
+      continue-on-error: true
+      uses: codecov/test-results-action@v1
+      with:
+        files: ${{ steps.strings.outputs.test_report_path_models }}
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -155,7 +155,7 @@ jobs:
         apt-get update
         apt install -y libgl1 libglx-mesa0
 
-        pytest -v ${{matrix.build.tests}} \
+        pytest --durations=50 -v ${{matrix.build.tests}} \
           --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
           --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
 


### PR DESCRIPTION
### Ticket
None

### Problem description
 - We have more passing full-model-execution coming online, and desire to keep them out of push/pr and only in nightly, so need to create a home for them.  Also, since we have a bunch of new ones passing now, would like to keep them protected. I suspect in the future this will be more regular occurrance and could benefit from automated flow to do this that is WIP.

### What's changed
 - Create new file run-full-model-execution-tests-nightly.yml used only by nightly-tests.yml that contains 13 tests passing
 - They are part of set of 23 tests passing op-by-op flow to execute but 10 other tests have runtime issues or pcc fails, so excluding
 - Ideally wanted these to be inside existing yaml and have matrix be dynamically configured for push vs nightly, but not simple.
 - 2 parallel jobs take about 10 minutes each

### Checklist
- [x] New/Existing tests provide coverage for changes

Link to passing run at TOTT before creating this branch and PR: https://github.com/tenstorrent/tt-torch/actions/runs/14024930263/job/39262196611 (I moved 2 tests from group 2 to group 1 after it ran to better balance load).