### PR TITLE
Fix location of torch-mlir license reference

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -209,6 +209,7 @@ The following separate and independent dependencies are utilized by this
 project and are included in a distributed build and are subject to their own license terms listed as follows:
 
 - yolov3 - MIT License (https://github.com/holli/yolov3_pytorch/blob/master/LICENSE)
+- torch-mlir - Apache v2.0 License with LLVM Exceptions and a BSD-style License (https://github.com/llvm/torch-mlir/blob/main/LICENSE)
 
 The following dependencies are utilized by this project but are not explicitly
 distributed as part of the software:
@@ -216,7 +217,6 @@ distributed as part of the software:
 - llvm-project - Apache v2.0 License with LLVM Exceptions (https://github.com/llvm/llvm-project/blob/main/LICENSE.TXT)
 - flatbuffers - Apache v2.0 License (https://github.com/google/flatbuffers/blob/master/LICENSE)
 - stablehlo - Apache v2.0 License (https://github.com/openxla/stablehlo/blob/main/LICENSE)
-- torch-mlir - Apache v2.0 License with LLVM Exceptions and a BSD-style License (https://github.com/llvm/torch-mlir/blob/main/LICENSE)
 - torch - Custom License (https://github.com/intel/torch/blob/master/LICENSE.md)
 - black - MIT License (https://github.com/psf/black/blob/main/LICENSE)
 - mdutils - MIT License (https://github.com/didix21/mdutils/blob/master/LICENSE.txt)


### PR DESCRIPTION
Fix location of torch-mlir license reference