### PR TITLE
Update img file url in alibaba-damo/mgp-str-base test to be more reliable

### DIFF
--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -23,7 +23,7 @@ class ThisTester(ModelTester):
         return model
 
     def _load_inputs(self):
-        url = "https://i.postimg.cc/ZKwLg2Gw/367-14.png"  # generated_text = "ticket"
+        url = "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/ocr-demo.png"  # generated_text = "ticket"
         image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
         inputs = self.processor(
             images=image,


### PR DESCRIPTION
### Ticket
#483 

### Problem description
- This test will often hit timeout fetching png from postimg.cc website during nightly CI, not great.
- it's reproducible locally, especially when stress testing image downloads. 

### What's changed
- Point test to a different more reliable url of the samge image, rock solid download rate from stress testing
- Found same change in onnx-community/mgp-str-base repo, nice.

### Checklist
- [x] New/Existing tests provide coverage for changes
