### PR TITLE
Replace openDevice and closeDevice functions with new mesh API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+.*
 env/venv
 build
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-.*
+.cache
 env/venv
 build
 dist

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -78,7 +78,7 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
-    cc.enable_async = True
+    cc.mesh_device_options.enable_async_ttnn = True
     cc.cache_preprocessed_constants = True
     cc.initialize_device()
 

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -196,10 +196,14 @@ class Executor:
     def _get_device(self):
         if self.compiler_config.runtime_device is not None:
             return self.compiler_config.runtime_device
+        
 
-        return tt_mlir.open_device(
-            device_ids=[0], enable_async_ttnn=self.compiler_config.enable_async
-        )
+        mesh_device_options = tt_mlir.MeshDeviceOptions()
+        mesh_device_options.meshShape = [1, 1]
+        return tt_mlir.open_mesh_device(mesh_device_options)
+        # return tt_mlir.open_device(
+        #     device_ids=[0], enable_async_ttnn=self.compiler_config.enable_async
+        # )
 
     def _cache_constants_if_needed(self, preprocessed_constants):
         if (
@@ -214,7 +218,8 @@ class Executor:
             tt_mlir.deallocate_tensor(t, force=True)
 
         if self.compiler_config.runtime_device is None:
-            tt_mlir.close_device(device)
+            # tt_mlir.close_device(device)
+            tt_mlir.close_mesh_device(device)
 
     def __call__(self, *inputs):
         if self.compiler_config.compile_depth != CompileDepth.EXECUTE:

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -196,14 +196,18 @@ class Executor:
     def _get_device(self):
         if self.compiler_config.runtime_device is not None:
             return self.compiler_config.runtime_device
-        
-
-        mesh_device_options = tt_mlir.MeshDeviceOptions()
-        mesh_device_options.meshShape = [1, 1]
-        return tt_mlir.open_mesh_device(mesh_device_options)
-        # return tt_mlir.open_device(
-        #     device_ids=[0], enable_async_ttnn=self.compiler_config.enable_async
-        # )
+        if self.compiler_config.mesh_device_options is None:
+            self.compiler_config.mesh_device_options = tt_mlir.MeshDeviceOptions()
+        assert (
+            self.compiler_config.mesh_device_shape is not None
+        ), "Please set mesh_device_shape within compiler_config"
+        assert (
+            len(self.compiler_config.mesh_device_shape) == 2
+        ), "Only a 2D mesh is supported for now"
+        return tt_mlir.open_mesh_device(
+            self.compiler_config.mesh_device_shape,
+            self.compiler_config.mesh_device_options,
+        )
 
     def _cache_constants_if_needed(self, preprocessed_constants):
         if (
@@ -218,7 +222,6 @@ class Executor:
             tt_mlir.deallocate_tensor(t, force=True)
 
         if self.compiler_config.runtime_device is None:
-            # tt_mlir.close_device(device)
             tt_mlir.close_mesh_device(device)
 
     def __call__(self, *inputs):

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -14,8 +14,12 @@ import math
 import sys
 import shutil
 
-# from tt_mlir import open_device, close_device, is_runtime_debug_enabled
-from tt_mlir import open_mesh_device, close_mesh_device, MeshDeviceOptions, is_runtime_debug_enabled
+from tt_mlir import (
+    open_mesh_device,
+    close_mesh_device,
+    MeshDeviceOptions,
+    is_runtime_debug_enabled,
+)
 
 
 """
@@ -267,10 +271,11 @@ class CompilerConfig:
         self._verify_op_by_op = False
         self.typecast_inputs = True
         self.runtime_device = None
-        self.enable_async = False
         self.cache_preprocessed_constants = False
         self.inline_parameters = False
+        self.mesh_device_shape = [1, 1]
         self.mesh_device_options = MeshDeviceOptions()
+        self.mesh_device_options.enable_async_ttnn = False
 
         self.apply_environment_overrides()
         self.post_init()
@@ -347,17 +352,14 @@ class CompilerConfig:
         assert self.runtime_device is None
         if device_ids is None:
             device_ids = [0]
-        self.mesh_device_options.meshShape = [1, len(device_ids)]
-        self.mesh_device_options.deviceIds = device_ids
-        self.mesh_device_options.enableAsyncTTNN = self.enable_async
-        self.runtime_device = open_mesh_device(self.mesh_device_options)
-        # self.runtime_device = open_device(
-        #     device_ids=device_ids, enable_async_ttnn=self.enable_async
-        # )
+        self.mesh_device_shape = [1, len(device_ids)]
+        self.mesh_device_options.device_ids = device_ids
+        self.runtime_device = open_mesh_device(
+            self.mesh_device_shape, self.mesh_device_options
+        )
 
     def cleanup_device(self):
         assert self.runtime_device is not None
-        # close_device(self.runtime_device)
         close_mesh_device(self.runtime_device)
         self.runtime_device = None
 

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -14,7 +14,8 @@ import math
 import sys
 import shutil
 
-from tt_mlir import open_device, close_device, is_runtime_debug_enabled
+# from tt_mlir import open_device, close_device, is_runtime_debug_enabled
+from tt_mlir import open_mesh_device, close_mesh_device, MeshDeviceOptions, is_runtime_debug_enabled
 
 
 """
@@ -269,6 +270,7 @@ class CompilerConfig:
         self.enable_async = False
         self.cache_preprocessed_constants = False
         self.inline_parameters = False
+        self.mesh_device_options = MeshDeviceOptions()
 
         self.apply_environment_overrides()
         self.post_init()
@@ -345,13 +347,18 @@ class CompilerConfig:
         assert self.runtime_device is None
         if device_ids is None:
             device_ids = [0]
-        self.runtime_device = open_device(
-            device_ids=device_ids, enable_async_ttnn=self.enable_async
-        )
+        self.mesh_device_options.meshShape = [1, len(device_ids)]
+        self.mesh_device_options.deviceIds = device_ids
+        self.mesh_device_options.enableAsyncTTNN = self.enable_async
+        self.runtime_device = open_mesh_device(self.mesh_device_options)
+        # self.runtime_device = open_device(
+        #     device_ids=device_ids, enable_async_ttnn=self.enable_async
+        # )
 
     def cleanup_device(self):
         assert self.runtime_device is not None
-        close_device(self.runtime_device)
+        # close_device(self.runtime_device)
+        close_mesh_device(self.runtime_device)
         self.runtime_device = None
 
     def post_init(self):


### PR DESCRIPTION
### Ticket
[493](https://github.com/tenstorrent/tt-torch/issues/493)

### Problem description
A new API for opening and closing devices was provided in this [commit](https://github.com/tenstorrent/tt-mlir/commit/436290947d53368774ab272c26405d90a3a540de) to the tt-mlir repo. The API we currently use will soon be deprecated

### What's changed
- Added PyBindings for the new API functions
- Replaced occurrences of `openDevice` and `closeDevice` with `openMeshDevice` and `closeMeshDevice`

### Checklist
- [x] New/Existing tests provide coverage for changes
