### PR TITLE
Adding libraries and wheel build to docker

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -32,7 +32,9 @@ RUN apt-get update && apt-get install -y \
     libboost-all-dev \
     jq \
     curl \
-    lcov
+    lcov \
+    libgl1 \
+    libglx-mesa0
 
 # Install python3.11 packages
 RUN python3.11 -m pip install \

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-venv \
     python3-pip \
+    python3.11-dev \
+    python3.11-venv \
     git \
     git-lfs \
     libhwloc-dev \
@@ -31,6 +33,12 @@ RUN apt-get update && apt-get install -y \
     jq \
     curl \
     lcov
+
+# Install python3.11 packages
+RUN python3.11 -m pip install \
+    setuptools \
+    wheel \
+    torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -9,11 +9,13 @@ ARG GIT_SHA
 ENV PROJECT_NAME=tt-torch
 ENV BUILD_DIR=/home/build
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
+ENV TTTORCH_DIST_DIR=/opt/dist
 
 RUN echo "Building $PROJECT_NAME at $GIT_SHA"
 
 RUN mkdir -p $BUILD_DIR && \
-    mkdir -p $TTMLIR_TOOLCHAIN_DIR
+    mkdir -p $TTMLIR_TOOLCHAIN_DIR && \
+    mkdir -p $TTTORCH_DIST_DIR
 
 # Copy the project from host, cloned in build-image.yml
 COPY . $BUILD_DIR/$PROJECT_NAME
@@ -23,6 +25,16 @@ WORKDIR $BUILD_DIR/$PROJECT_NAME
 RUN cd third_party && \
     cmake -B toolchain -DBUILD_TOOLCHAIN=ON
 
+# Build torchvision wheel and copy it to /dist
+RUN git clone https://github.com/pytorch/vision.git && \
+    cd vision && \
+    git checkout v0.21.0 && \
+    TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang \
+    CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python3.11 setup.py bdist_wheel && \
+    cp dist/*.whl $TTTORCH_DIST_DIR && \
+    cd .. && \
+    rm -rf vision
+
 # Final stage
 FROM ghcr.io/tenstorrent/tt-torch/tt-torch-base-ubuntu-22-04:${FROM_TAG} AS ci
 
@@ -30,5 +42,10 @@ FROM ghcr.io/tenstorrent/tt-torch/tt-torch-base-ubuntu-22-04:${FROM_TAG} AS ci
 ENV TTMLIR_TOOLCHAIN_DIR=/opt/ttmlir-toolchain
 RUN echo "Copying from ci-build stage $TTMLIR_TOOLCHAIN_DIR"
 COPY --from=ci-build $TTMLIR_TOOLCHAIN_DIR $TTMLIR_TOOLCHAIN_DIR
+
+# Copy the dist directory from the previous stage
+ENV TTTORCH_DIST_DIR=/opt/dist
+COPY --from=ci-build $TTTORCH_DIST_DIR $TTTORCH_DIST_DIR
+RUN echo "Copying from ci-build stage $TTTORCH_DIST_DIR"
 
 RUN du -h --max-depth=2 $TTMLIR_TOOLCHAIN_DIR

--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
+          echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
           echo "test-output-dir=$(pwd)/results/models/tests/" >> "$GITHUB_OUTPUT"
 
       - name: Git safe dir
@@ -45,6 +46,20 @@ jobs:
         with:
           name: ${{ inputs.spreadsheet_name }}
           path: ${{ steps.strings.outputs.work-dir }}/results
+
+      - name: Use build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: install-artifacts
+          path: ${{ steps.strings.outputs.install-dir }}
+
+      - name: 'Untar install directory'
+        shell: bash
+        working-directory: ${{ steps.strings.outputs.install-dir }}
+        run: |
+          tar xvf artifact.tar
+          mkdir -p ${{ steps.strings.outputs.dist-dir }}
+          mv wheels/* ${{ steps.strings.outputs.dist-dir }}
 
       - name: Generate TTNN MD Files
         shell: bash

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -130,8 +130,6 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        apt-get update
-        apt install -y libgl1 libglx-mesa0
 
         TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v ${{matrix.build.tests}} \
           --junit-xml=${{ steps.strings.outputs.test_report_path_models }}

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -119,8 +119,6 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        apt-get update
-        apt install -y libgl1 libglx-mesa0
 
         pytest --durations=50 -v ${{matrix.build.tests}} \
           --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -153,8 +153,6 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        apt-get update
-        apt install -y libgl1 libglx-mesa0
 
         pytest --durations=50 -v ${{matrix.build.tests}} \
           --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \

--- a/.github/workflows/run-op-by-op-model-tests.yml
+++ b/.github/workflows/run-op-by-op-model-tests.yml
@@ -306,8 +306,6 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        apt-get update
-        apt install -y libgl1 libglx-mesa0
 
         # Make sure we don't stop on first failure
         set +e

--- a/env/activate
+++ b/env/activate
@@ -30,6 +30,10 @@ else
   python3.11 -m pip install -r requirements.txt
 
   mkdir -p $TT_TORCH_HOME/dist
+  if [ -n "$TTTORCH_DIST_DIR" ]; then
+    cp -r -n $TTTORCH_DIST_DIR/* $TT_TORCH_HOME/dist/
+  fi
+
   if [ ! -f $TT_TORCH_HOME/dist/torchvision*.whl ]; then
     cd $TT_TORCH_HOME/third_party
     git clone https://github.com/pytorch/vision.git
@@ -39,9 +43,12 @@ else
     TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python setup.py bdist_wheel
 
     cp dist/*.whl $TT_TORCH_HOME/dist
+    cd ..
+    rm -rf vision
     cd $TT_TORCH_HOME
   fi
   pip install $TT_TORCH_HOME/dist/torchvision*.whl
+
   pip install stablehlo -f https://github.com/openxla/stablehlo/releases/expanded_assets/v1.0.0
 fi
 export TTTORCH_ENV_ACTIVATED=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,6 @@ kornia
 timm
 ml_dtypes
 opencv-contrib-python
-setuptools
-wheel
 scikit-build
 nanobind
 loguru


### PR DESCRIPTION
### Ticket
#316 #449

### Problem description
- The torchvision wheel is built every time we run CI and we want to move it into the docker.
- libgl1 and libglx-mesa0 are being installed every op-by-op and full-model CI runs for the yolo models and we want to move it into the docker
- We have duplicate libraries in requirements.txt


### What's changed
- Added torchvision wheel build into dockerfile.ci (installed dependencies in dockerfile.base) and copied wheel in a /opt/dist/ dir to final stage so its available when generating new containers
- Added a check in env/activation to check if wheel is available in /opt/dist/ and install wheel from that file
- removed duplicated libraries from requirements.txt
- added install of libgl1 and libglx-mesa0 to dockerfile.base
- removed install of libgl1 and libglx-mesa0 from *.yml files

### Checklist
- [x] Tested the build of the new Docker image https://github.com/tenstorrent/tt-torch/actions/runs/14049828360
- [x] Checked that CI run does not build wheel from scratch for each job that runs source env/activate https://github.com/tenstorrent/tt-torch/actions/runs/14066665483
- [x]  Tested models that use torchvision https://github.com/tenstorrent/tt-torch/actions/runs/14067904743
