### PR TITLE
Fix onnx model tester regressions and add onnx mobilenet to On PR

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -37,6 +37,7 @@ jobs:
             runs-on: wormhole_b0, name: "eval_2", tests: "
                   tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]
                   tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2[full-eval]
+                  tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2[full-eval]
                   tests/models/openpose/test_openpose_v2.py::test_openpose_v2[full-eval]
                   tests/models/resnet/test_resnet.py::test_resnet[full-eval]
                   tests/models/resnet50/test_resnet50.py::test_resnet[full-eval]

--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -24,6 +24,9 @@ class ThisTester(OnnxModelTester):
         os.remove(f"{self.model_name}.onnx")
         return model
 
+    def _extract_outputs(self, output_object):
+        return (torch.from_numpy(output_object),)
+
     def _load_torch_inputs(self):
         # Define a transformation to preprocess the input image using the weights transforms
         preprocess = self.weights.transforms()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -379,6 +379,7 @@ class OnnxModelTester(ModelTester):
         assert_pcc=True,
         assert_atol=True,
         record_property_handle=None,
+        model_group="generality",
     ):
 
         super().__init__(
@@ -391,6 +392,7 @@ class OnnxModelTester(ModelTester):
             assert_pcc,
             assert_atol,
             record_property_handle,
+            model_group,
         )
         # Hold an onnxruntime session for golden / non-full compile execution
         self.sess = onnxruntime.InferenceSession(
@@ -432,7 +434,7 @@ class OnnxModelTester(ModelTester):
     def test_model_train(self, on_device=True):
         raise NotImplementedError("TODO: Implement this method")
 
-    def test_model_eval(self, on_device=True):
+    def test_model_eval(self, on_device=True, _assert_eval_token_mismatch=False):
         golden = self.run_model(self.framework_model, self.numpy_inputs)
 
         if on_device == True:


### PR DESCRIPTION
### Ticket
None

### Problem description
Onnx model tester infra had regressions that went uncaught because nothing in CI was using it

### What's changed
Added fixes for regressions due to recent test infra changes:
- skip token mismatch commit 586dd1f
- model name deduplication commit 155fb9a

Added test using this infra to CI to catch future regressions

### Checklist
- [x] New/Existing tests provide coverage for changes
