### PR TITLE
Change pcc threshold for PASSED status to be model specific

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -339,7 +339,7 @@ class ModelTester:
         if compile_depth is not CompileDepth.EXECUTE:
             return compile_depth_translation_table[compile_depth]
 
-        return "PASSED" if min_pcc >= 0.99 else "INCORRECT_RESULT"
+        return "PASSED" if min_pcc >= self.required_pcc else "INCORRECT_RESULT"
 
     def flush_tag_cache_to_record(self):
         # record the tags property at the very end of the test as data may


### PR DESCRIPTION
### Ticket
None

### Problem description
We're using 0.99 as global threshold for marking a 
model's bringup_status as PASSED.

### What's changed
Use model specific required_pcc override to makr a 
model's bringup_status as PASSED. Constructor
default is 0.99, unless overridden.

### Checklist
- [x] New/Existing tests provide coverage for changes
