### PR TITLE
Followup to 6d6ea7a fix weekly yml dependency, move 3 tests, and revert op-by-op job name changes

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -174,6 +174,17 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "mistral", tests: "
+              tests/models/mistral/test_mistral_7b.py::test_mistral_7b
+              "
+          },
+          {
+            runs-on: wormhole_b0, name: "deepseek", tests: "
+              tests/models/deepseek/test_deepseek.py::test_deepseek
+              tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "phi", tests: "
               tests/models/phi/test_phi_1_1p5_2.py::test_phi[op_by_op_torch-microsoft/phi-1-eval]
               tests/models/phi/test_phi_1_1p5_2.py::test_phi[op_by_op_torch-microsoft/phi-1.5-eval]
@@ -184,7 +195,7 @@ jobs:
     runs-on:
       - ${{ matrix.build.runs-on }}
 
-    name: "tests op_by_op nightly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+    name: "tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
@@ -207,7 +218,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "tests op_by_op nightly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
+        job_name: "tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -114,23 +114,12 @@ jobs:
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[op_by_op_torch-eval-regnet_y_32gf]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[op_by_op_torch-eval-regnet_x_32gf]
               "
-          },
-          {
-            runs-on: wormhole_b0, name: "mistral", tests: "
-              tests/models/mistral/test_mistral_7b.py::test_mistral_7b
-              "
-          },
-          {
-            runs-on: wormhole_b0, name: "deepseek", tests: "
-              tests/models/deepseek/test_deepseek.py::test_deepseek
-              tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen
-              "
           }
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}
 
-    name: "tests op_by_op weekly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+    name: "tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
@@ -153,7 +142,7 @@ jobs:
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "tests op_by_op weekly (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
+        job_name: "tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})" # reference above tests.name
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -35,7 +35,7 @@ jobs:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
   download-report:
     if: success() || failure()
-    needs: [test_op_by_op_nightly, test_op_by_op_weekly]
+    needs: [test_op_by_op_weekly]
     uses: ./.github/workflows/generate-model-report.yml
     secrets: inherit
   generate-ttnn-md:


### PR DESCRIPTION
### Ticket
None

### Problem description
Weekly job failed to start due to missing dependency, 3 tests got added to weekly list by accident, and nightly op-by-op job names are less ideal to read.

### What's changed
 - Removed test_op_by_op_nightly before merging but forgot to remove dependency on this job in download_report job.
 - Revert op-by-op job names back to original. The extra text added was to allow for nightly/weekly workflows to run in same CI (not used) but model name was after truncation.
 - Move mistral_7b, 2x deepseek tests back to op-by-op nightly, was mistakenly added due to bad conflict resolve. They aren't covered in full-model-execute, so we want them in nightly.

### Checklist
- [x] New/Existing tests provide coverage for changes
- Testing CI (nightly) https://github.com/tenstorrent/tt-torch/actions/runs/14146418344 
- Testing CI (weekly) https://github.com/tenstorrent/tt-torch/actions/runs/14146517469
