### PR TITLE
Add XGLM model to op-by-op nightly

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -57,11 +57,11 @@ jobs:
               tests/models/mamba/test_mamba.py::test_mamba[op_by_op_torch-state-spaces/mamba-790m-hf-eval]
               "
           },
-          # { https://github.com/tenstorrent/tt-torch/issues/298
-          #   runs-on: wormhole_b0, name: "xglm", tests: "
-          #     tests/models/xglm/test_xglm.py::test_xglm
-          #     "
-          # },
+          {
+            runs-on: wormhole_b0, name: "xglm", tests: "
+              tests/models/xglm/test_xglm.py::test_xglm
+              "
+          },
           {
             runs-on: wormhole_b0, name: "mobilenet", tests: "
               tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2


### PR DESCRIPTION
### Ticket
Closes #298

### What's changed
- Add the existing model to op by op flow, whatever issue it had 2 months ago must be solved since test now can execute 89/92 ops in the graph.

### Checklist
- [x] New/Existing tests provide coverage for changes
