### PR TITLE
Test cleanup - remove 8 duplicate tests from e2e compile list covered by full-model-execute

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -20,21 +20,23 @@ jobs:
       matrix:
         build: [
           {
-            # Approximately 10 minutes.
+            # Approximately 12 minutes.
             runs-on: wormhole_b0, name: "compile_1", tests: "
                   tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval]
                   tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]
                   tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval]
-                  tests/models/segformer/test_segformer.py::test_segformer[full-eval]
                   tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[full-eval]
                   tests/models/vilt/test_vilt.py::test_vilt[full-eval]
                   tests/models/whisper/test_whisper.py::test_whisper[full-eval]
                   tests/models/yolos/test_yolos.py::test_yolos[full-eval]
                   tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval]
+                  tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
+                  tests/models/mistral/test_mistral_7b.py::test_mistral_7b[full-eval]
+                  tests/models/vit/test_vit.py::test_vit[full-eval]
             "
           },
           {
-            # Approximately 70 minutes.
+            # Approximately 35 minutes.
             runs-on: wormhole_b0, name: "compile_2", tests: "
                   tests/models/detr/test_detr.py::test_detr[full-eval]
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
@@ -45,28 +47,13 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_b_32]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-vit_l_16]
                   tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite0.in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite1.in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite2.in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite3.in1k]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-tf_efficientnet_lite4.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-mixer_b16_224.goog_in21k]
-                  tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]
                   tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
-            "
-          },
-          {
-            # Approximately 50 minutes.
-            runs-on: wormhole_b0, name: "compile_3", tests: "
-                  tests/models/opt/test_opt.py::test_opt[full-eval]
-                  tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
-                  tests/models/mistral/test_mistral_7b.py::test_mistral_7b[full-eval]
-                  tests/models/vit/test_vit.py::test_vit[full-eval]
             "
           },
           # Approximately 150 minutes.
           {
-            runs-on: wormhole_b0, name: "compile_4", tests: "
+            runs-on: wormhole_b0, name: "compile_3", tests: "
                   tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-790m-hf-eval]
             "
           }

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -62,11 +62,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "mobilenet", tests: "
-              tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "openpose", tests: "
               tests/models/openpose/test_openpose.py::test_openpose
               "

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -56,6 +56,7 @@ jobs:
           {
             runs-on: wormhole_b0, name: "mobilenet", tests: "
               tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd
+              tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2
               "
           },
           {


### PR DESCRIPTION
### Ticket
None

### What's changed
 - test_segformer, tf_efficientnet_lite_* (5x), test_qwen2_casual_lm, test_opt and reorganize test groups. Shaved off at least an hour. Fell through cracks recently.
 - Also, promote test_MobileNetV2.py::test_MobileNetV2 from op-by-op nightly to weekly, already in full-model-execute push

### Checklist
- [x] New/Existing tests provide coverage for changes
