### PR TITLE
Add model_group to config, remove efficientnet_lite from red group

### DIFF
--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -80,7 +80,7 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
 
     model_group = (
         "red"
-        if any(keyword in model_name.lower() for keyword in ["efficientnet", "vovnet"])
+        if any(keyword in model_name.lower() for keyword in ["vovnet"])
         else "generality"
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,7 +83,10 @@ class ModelTester:
         self.record_tag_cache["frontend"] = "tt-torch"
 
         # configs should be set at test start, so they can be flushed immediately
-        self.record_property("config", {"compiler_config": compiler_config.to_dict()})
+        self.record_property(
+            "config",
+            {"model_group": model_group, "compiler_config": compiler_config.to_dict()},
+        )
 
     def _load_model(self):
         raise NotImplementedError(


### PR DESCRIPTION
### Ticket
None

### Problem description
- The pytest infra makes it seem like the model group is a test parameterization scoped feature, but the database ingester will turn it into a file-wide parameter based on the last one consumed. This leads to data anomalies and strange race conditions.
- Efficientnet lite is not an approved red model variant of efficientnet

### What's changed
- Pack model group into tags and config for redundancy
- Remove red marking from efficientnet_lite

### Checklist
- [x] New/Existing tests provide coverage for changes
