### PR TITLE
Pin to mdbook v0.4.47 to prevent unexpected regressions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           curl -sSf https://sh.rustup.rs -o sh.rustup && sh sh.rustup -y
           source $HOME/.cargo/env
-          cargo install mdbook
+          cargo install --version 0.4.47 mdbook
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
### Ticket
None

### What's changed
- Pin to version we were previously using, to prevent regressions in future when version changes on us
- Shows "Installed package `mdbook v0.4.47` (executable `mdbook`)" when using this change.

### Checklist
- [ ] New/Existing tests provide coverage for changes
