### PR TITLE
Put test_opt.py back in compile instead of execute list and return to op-by-op nightly

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         build: [
           {
-            # Approximately 12 minutes.
+            # Approximately 65 minutes.
             runs-on: wormhole_b0, name: "compile_1", tests: "
                   tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval]
                   tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]
@@ -33,6 +33,7 @@ jobs:
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
                   tests/models/mistral/test_mistral_7b.py::test_mistral_7b[full-eval]
                   tests/models/vit/test_vit.py::test_vit[full-eval]
+                  tests/models/opt/test_opt.py::test_opt[full-eval]
             "
           },
           {

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -75,12 +75,6 @@ jobs:
             "
           },
           {
-            # Approximately 50 minutes.
-            runs-on: wormhole_b0, name: "eval_4", tests: "
-                  tests/models/opt/test_opt.py::test_opt[full-eval]
-            "
-          },
-          {
             # Approximately 45 minutes.
             runs-on: wormhole_b0, name: "eval_5", tests: "
                   tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -101,6 +101,11 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "opt", tests: "
+              tests/models/opt/test_opt.py::test_opt
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "timm", tests: "
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-ghostnetv2_100.in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-inception_v4.tf_in1k]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -65,11 +65,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "opt", tests: "
-              tests/models/opt/test_opt.py::test_opt
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "resnet", tests: "
               tests/models/resnet50/test_resnet50.py::test_resnet
               tests/models/resnet/test_resnet.py::test_resnet

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -36,7 +36,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.xfail(reason="Need to debug")
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],


### PR DESCRIPTION
### Ticket
None

### What's changed
- Move test around. It is failing at eval in full model execute, needs debug/fix
   opened https://github.com/tenstorrent/tt-torch/issues/544 in meantime.
- Remove xfail, was hiding the runtime failure a bit

### Checklist
- [ ] New/Existing tests provide coverage for changes