### PR TITLE
Add user-facing error message for tt-torch compilation failures #496

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -30,6 +30,7 @@ from tt_torch.tools.utils import (
     OpByOpBackend,
     CompilerConfig,
     CompileDepth,
+    tt_torch_error_message,
 )
 
 
@@ -135,6 +136,7 @@ def _base_backend(gm, example_inputs, compiler_config):
     return executor
 
 
+@tt_torch_error_message
 def backend(gm, example_inputs, options=None):
     assert isinstance(gm, torch.fx.GraphModule), "Backend only supports torch graphs"
 

--- a/tt_torch/onnx_compile/onnx_compile.py
+++ b/tt_torch/onnx_compile/onnx_compile.py
@@ -11,7 +11,7 @@ from torch_mlir.dialects import torch as torch_dialect
 import os
 import sys
 
-from tt_torch.tools.utils import CompilerConfig, CompileDepth
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, tt_torch_error_message
 
 from torch_mlir.compiler_utils import (
     OutputType,
@@ -67,6 +67,7 @@ def torch_backend_ir_to_stablehlo(module: Module, compiler_config: CompilerConfi
     return module
 
 
+@tt_torch_error_message
 def compile_onnx(model_proto: onnx.ModelProto, compiler_config: CompilerConfig = None):
     if compiler_config is None:
         compiler_config = CompilerConfig()

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -756,3 +756,27 @@ class FileManager:
             raise Exception(f"an unexpected error occurred: {e}")
 
         return exists
+
+
+def tt_torch_error_message(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            print(
+                """
+\033[91m[tt-torch] An error occurred during compilation.
+
+Please file a bug report by opening an issue at:
+https://github.com/tenstorrent/tt-torch/issues/new
+
+Include the following details in your report:
+- The source code or model that triggered the error
+- Steps to reproduce the issue
+- Relevant logs or stack traces\033[0m
+            """,
+                file=sys.stderr,
+            )
+            raise
+
+    return wrapper


### PR DESCRIPTION
### Ticket
#496 

### Problem description
Add user-facing error messages with a link to file an issue for tt-torch compilation failures

### What's changed
- added function to append tt-torch compilation error message to stderr with instructions on where/how to open tt-torch issue when there is compilation failures
- added functions as a wrapper for backend() and compiler_onnx()

### Checklist
- [x] New/Existing tests provide coverage for changes
