### PR TITLE
Remove 10 duplicate tests and update generate_md.py to capture compilation_status field 

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -20,35 +20,25 @@ jobs:
       matrix:
         build: [
           {
-            # Approximately 65 minutes.
+            # Approximately 60 minutes.
             runs-on: wormhole_b0, name: "compile_1", tests: "
-                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-base-patch16-224-eval]
-                  tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]
-                  tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval]
-                  tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[full-eval]
                   tests/models/vilt/test_vilt.py::test_vilt[full-eval]
                   tests/models/whisper/test_whisper.py::test_whisper[full-eval]
-                  tests/models/yolos/test_yolos.py::test_yolos[full-eval]
-                  tests/models/deit/test_deit.py::test_deit[full-facebook/deit-base-patch16-224-eval]
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
                   tests/models/mistral/test_mistral_7b.py::test_mistral_7b[full-eval]
-                  tests/models/vit/test_vit.py::test_vit[full-eval]
                   tests/models/opt/test_opt.py::test_opt[full-eval]
             "
           },
           {
-            # Approximately 35 minutes.
+            # Approximately 30 minutes.
             runs-on: wormhole_b0, name: "compile_2", tests: "
-                  tests/models/detr/test_detr.py::test_detr[full-eval]
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
-                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-vit_h_14]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-regnet_y_128gf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-vit_l_32]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-vit_b_16]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-vit_b_32]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-vit_l_16]
                   tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-mixer_b16_224.goog_in21k]
                   tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
             "
           },

--- a/tt_torch/tools/generate_md.py
+++ b/tt_torch/tools/generate_md.py
@@ -149,11 +149,12 @@ class AllOps:
             # Extract row details
             pcc = row["PCC"]
             atol = row["ATOL"]
+            status = row["Status"]
 
             # Process operation details
-            self.process_ops(raw_ttnnir, pcc, atol)
+            self.process_ops(raw_ttnnir, pcc, atol, status)
 
-    def process_ops(self, ttnnir_string, pcc, atol):
+    def process_ops(self, ttnnir_string, pcc, atol, status):
         """
         Process TTNN operations from an IR string, extracting shapes, layouts, and metadata.
 
@@ -161,6 +162,7 @@ class AllOps:
             ttnnir_string: TTNN Intermediate Representation string
             pcc: Percent Correct Classification metric
             atol: Absolute tolerance for numerical comparisons
+            status: Compilation status for the op
         """
 
         ttnn_parser = TTNNOps(ttnnir_string)
@@ -229,6 +231,7 @@ class AllOps:
             opToWrite["output_layouts"] = output_layouts
             opToWrite["pcc"] = pcc
             opToWrite["atol"] = atol
+            opToWrite["status"] = status
             if self.ops.get(opToWrite["name"]) is None:
                 self.ops[opToWrite["name"]] = [opToWrite]
             else:
@@ -313,6 +316,7 @@ class AllOps:
                 atol = (
                     "N/A" if pd.isna(item.get("atol")) else str(item.get("atol", "N/A"))
                 )
+                status = item.get("status", "N/A")
 
                 input_layouts = item.get("input_layouts", [])
                 processed_input_layouts = [
@@ -345,6 +349,7 @@ class AllOps:
                     "output_layouts": processed_output_layouts,
                     "pcc": pcc,
                     "atol": atol,
+                    "compilation_status": status,
                 }
 
                 processed_items.append(processed_item)


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Not possible to filter the generated op ttnn.*.json files by compilation status right now because it's not captured.
 - 10 duplicate tests between e2e compile list and full-model-execute list in nightly, meant to remove yesterday.

### What's changed
- Add compilation status to the generated .json files like ttnn.conv2d.json, etc. Useful for filtering when providing ops to ttnn folks and/or creating test cases from.  Avoid adding it to md files, they are not used for scripting.
- Remove 10 duplicate tests from run-e2e-tests.yml

### Checklist
- Tested locally on a models_op_per_op.xlsx file, works good.
