### PR TITLE
Remove op by op and compile test from nightly just for today's report

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -24,15 +24,9 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_op_by_op:
+  test_full_model_nightly:
     needs: [docker-build, build]
-    uses: ./.github/workflows/run-op-by-op-model-tests-nightly.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_e2e:
-    needs: [docker-build, build]
-    uses: ./.github/workflows/run-e2e-tests.yml
+    uses: ./.github/workflows/run-full-model-execution-tests-nightly.yml
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
@@ -42,21 +36,3 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_full_model_nightly:
-    needs: [docker-build, build]
-    uses: ./.github/workflows/run-full-model-execution-tests-nightly.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  download-report:
-    if: success() || failure()
-    needs: test_op_by_op
-    uses: ./.github/workflows/generate-model-report.yml
-    secrets: inherit
-  generate-ttnn-md:
-    if: success() || failure()
-    needs: [download-report]
-    uses: ./.github/workflows/generate-ttnn-md.yml
-    secrets: inherit
-    with:
-      spreadsheet_name: ${{ needs.download-report.outputs.spreadsheet_name }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Bert consistently segfaulting during compile in latest nightlies causes many E2E test results to not be reported.
 
### What's changed

Create and retrigger a fresh nightly job on main with E2E execute tests only only so it can go into the FE daily report on E2E model status.

### Checklist
- [x] New/Existing tests provide coverage for changes
