### PR TITLE
Isolate Full Model Execute Pytest Processes and Quarantine Bert

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -24,9 +24,15 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  test_full_model_nightly:
+  test_op_by_op:
     needs: [docker-build, build]
-    uses: ./.github/workflows/run-full-model-execution-tests-nightly.yml
+    uses: ./.github/workflows/run-op-by-op-model-tests-nightly.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test_e2e:
+    needs: [docker-build, build]
+    uses: ./.github/workflows/run-e2e-tests.yml
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
@@ -36,3 +42,21 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test_full_model_nightly:
+    needs: [docker-build, build]
+    uses: ./.github/workflows/run-full-model-execution-tests-nightly.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  download-report:
+    if: success() || failure()
+    needs: test_op_by_op
+    uses: ./.github/workflows/generate-model-report.yml
+    secrets: inherit
+  generate-ttnn-md:
+    if: success() || failure()
+    needs: [download-report]
+    uses: ./.github/workflows/generate-ttnn-md.yml
+    secrets: inherit
+    with:
+      spreadsheet_name: ${{ needs.download-report.outputs.spreadsheet_name }}

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -136,6 +136,8 @@ jobs:
         echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_dir=$(pwd)/test-reports" >> "$GITHUB_OUTPUT"
+
     - name: Use build artifacts
       uses: actions/download-artifact@v4
       with:
@@ -165,6 +167,9 @@ jobs:
       run: |
         source env/activate
 
+        # Create a directory for test reports
+        mkdir -p ${{ steps.strings.outputs.test_report_dir }}
+
         # prevent script termination on failure
         set +e
 
@@ -174,7 +179,8 @@ jobs:
         echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
           if [[ -n "$test" ]]; then
             echo "Running test: $test"
-            report_file="$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
+            report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
+
             echo "JUnitXML logged to $report_file"
 
             pytest --durations=0 -v "$test" \
@@ -204,7 +210,7 @@ jobs:
       if: success() || failure()
       with:
         name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
-        path: ${{ steps.strings.outputs.test_report_path_models }}
+        path: ${{ steps.strings.outputs.test_report_dir }}
 
     - name: Upload coverage reports to Codecov
       if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -44,7 +44,6 @@ jobs:
                   tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd[full-eval]
                   tests/models/roberta/test_roberta.py::test_roberta[full-eval]
                   tests/models/hardnet/test_hardnet.py::test_hardnet[full-eval]
-                  tests/models/bert/test_bert.py::test_bert[full-eval]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-tf_efficientnet_lite0.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-tf_efficientnet_lite1.in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-tf_efficientnet_lite2.in1k]
@@ -95,6 +94,12 @@ jobs:
             # Approximately 60 minutes.
             runs-on: wormhole_b0, name: "eval_6", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
+            "
+          },
+          {
+            # Approximately 60 minutes.
+            runs-on: wormhole_b0, name: "eval_7_bert_qrtn", tests: "
+                  tests/models/bert/test_bert.py::test_bert[full-eval]
             "
           }
         ]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -165,9 +165,39 @@ jobs:
       run: |
         source env/activate
 
-        pytest --durations=50 -v ${{matrix.build.tests}} \
-          --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
-          --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+        # prevent script termination on failure
+        set +e
+
+        failure=0
+
+        # Split the test string into individual tests and run them one by one
+        echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
+          if [[ -n "$test" ]]; then
+            echo "Running test: $test"
+            report_file="$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
+            echo "JUnitXML logged to $report_file"
+
+            pytest --durations=0 -v "$test" \
+              --junit-xml="$report_file" \
+              --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+            # Check the return code of pytest
+            if [[ $? -ne 0 ]]; then
+              echo "Test failed: $test"
+              failure=1
+            fi
+          fi
+        done
+
+        set -e
+
+        # Exit with the appropriate code
+        if [[ $failure -ne 0 ]]; then
+          echo "One or more tests failed."
+          exit 1
+        else
+          echo "All tests passed."
+          exit 0
+        fi
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -154,9 +154,40 @@ jobs:
       run: |
         source env/activate
 
-        pytest --durations=50 -v ${{matrix.build.tests}} \
-          --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
-          --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+
+        # prevent script termination on failure
+        set +e
+
+        failure=0
+
+        # Split the test string into individual tests and run them one by one
+        echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
+          if [[ -n "$test" ]]; then
+            echo "Running test: $test"
+            report_file="$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
+            echo "JUnitXML logged to $report_file"
+
+            pytest --durations=0 -v "$test" \
+              --junit-xml="$report_file" \
+              --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+            # Check the return code of pytest
+            if [[ $? -ne 0 ]]; then
+              echo "Test failed: $test"
+              failure=1
+            fi
+          fi
+        done
+
+        set -e
+
+        # Exit with the appropriate code
+        if [[ $failure -ne 0 ]]; then
+          echo "One or more tests failed."
+          exit 1
+        else
+          echo "All tests passed."
+          exit 0
+        fi
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -125,6 +125,8 @@ jobs:
         echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_dir=$(pwd)/test-reports" >> "$GITHUB_OUTPUT"
+
     - name: Use build artifacts
       uses: actions/download-artifact@v4
       with:
@@ -154,6 +156,7 @@ jobs:
       run: |
         source env/activate
 
+        mkdir -p ${{ steps.strings.outputs.test_report_dir }}
 
         # prevent script termination on failure
         set +e
@@ -164,7 +167,7 @@ jobs:
         echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
           if [[ -n "$test" ]]; then
             echo "Running test: $test"
-            report_file="$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
+            report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
             echo "JUnitXML logged to $report_file"
 
             pytest --durations=0 -v "$test" \
@@ -194,7 +197,7 @@ jobs:
       if: success() || failure()
       with:
         name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
-        path: ${{ steps.strings.outputs.test_report_path_models }}
+        path: ${{ steps.strings.outputs.test_report_dir }}
 
     - name: Upload coverage reports to Codecov
       if: ${{ (success() || failure()) && inputs.run-codecov == 'true' }}


### PR DESCRIPTION
### Ticket
None

### Problem description
Full model pytests are run in a single invocation of pytest and therefore generate a single test report and run in a single process. Process-killing failures are rare, but will cause the report to not be generated.

### What's changed
- Isolate full execute pytest processes so each generates individual report
- Restore op-by-op and compile jobs temporarily removed earlier today

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] CollectData job picks up all pytest results even though they are written to unique files. Post-processed report JSONs look well formed on inspection
