### PR TITLE
Remove failing benchmark matrix autogeneration job from workflow

### DIFF
--- a/.github/workflows/depth-benchmarks.yml
+++ b/.github/workflows/depth-benchmarks.yml
@@ -24,17 +24,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  generate-matrix-dynamic:
-    needs: [build]
-    uses: ./.github/workflows/generate-benchmark-matrix-dynamic.yml
-    secrets: inherit
   run-benchmark:
-    needs: [docker-build, build, generate-matrix-dynamic]
+    needs: [docker-build, build]
     uses: ./.github/workflows/run-depth-benchmark-tests.yml
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      matrix-json: ${{ needs.generate-matrix-dynamic.outputs.matrix-json }} # Pass the dynamically generated matrix to the benchmark job
   generate-report:
     needs: [run-benchmark]
     uses: ./.github/workflows/generate-benchmark-report.yml

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -8,10 +8,6 @@ on:
         description: 'Docker image to use for build'
         required: true
         type: string
-      matrix-json:
-        description: 'Matrix of tests to run as a JSON string'
-        required: true
-        type: string
   workflow_run:
     workflows: [Build] # backref to run-build as dependency
     types: [completed]


### PR DESCRIPTION
### Ticket
None

### Problem description
Autopromotion job fails only when triggered on main, due to self-ingestion of artifacts generated from the currently running job.

### What's changed
Remove autopromotion job and dependencies.

### Checklist
- [x] New/Existing tests provide coverage for changes
