### PR TITLE
Add a multi-device support API

### DIFF
--- a/demos/resnet/README.md
+++ b/demos/resnet/README.md
@@ -3,5 +3,122 @@ Build/install and activate the environment as you would for development on tt-to
 
 From the project root, run
 ```
-python resnet50_demo.py
+python demos/resnet/resnet50_demo.py
+```
+for the interactive demo that uses a single-device to classify an image using ResNet.
+
+Or run,
+```
+python demos/resnet/resnet50_data_parallel_demo.py
+```
+for the demo on how to leverage the `DeviceManager` module to run ResNet image classification across multiple chips in parallel.
+
+# Results
+## resnet50_demo.py
+When running this on the default image (http://images.cocodataset.org/val2017/000000039769.jpg):
+
+![Image of two cats](http://images.cocodataset.org/val2017/000000039769.jpg)
+
+The output is ResNet's top 5 predictions:
+```
+Top 5 Predictions
+----------------------------------
+tabby: 0.56640625
+tiger cat: 0.236328125
+Egyptian cat: 0.02734375
+pillow: 0.005218505859375
+remote control: 0.0037689208984375
+```
+Notice that in the code there was no explicit device management:
+```Python
+options = {}
+options["compiler_config"] = cc
+# We didn't provide any explicit device while
+# compiling the model.
+tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
+```
+This causes the model to be compiled onto the default device present in the board. The device acquisition and release get handled automatically.
+
+## resnet50_data_parallel_demo.py
+This file shows how to split multiple model requests across all available devices on the board using the `DeviceManager` module. The relevant device management code is:
+
+```Python
+from tt_torch.tools.device_manager import DeviceManager
+...
+def main():
+    ...
+    options = {}
+    options["compiler_config"] = cc
+    # Acquires all available devices and returns them in a list
+    devices = DeviceManager.get_available_devices()
+    tt_models = []
+    for device in devices:
+        options["device"] = device # Explicitly compile the model for a specific device
+        tt_models.append(
+            torch.compile(model, backend=backend, dynamic=False, options=options)
+        )
+    ...
+    DeviceManager.release_devices() # Release all acquired devices after use
+```
+Note that in this case, the user is responsible for releasing the acquired devices.
+
+The file defines 10 Image URLs, which get split into N groups of 10/N URLs (where N is the number of available devices on the board).
+
+Each device will then call the relevant compiled model to independently process the assigned grouping in parallel.
+
+When ran on an N300 board with 2 available devices the results are:
+
+### First device:
+```
+****************************************
+Results from Device: <tt_mlir.Device object at 0x7fc4e283d1b0>
+Image URL: http://images.cocodataset.org/val2017/000000039769.jpg
+Top 5 Predictions
+----------------------------------
+tabby: 0.56640625
+tiger cat: 0.236328125
+Egyptian cat: 0.02734375
+pillow: 0.005218505859375
+remote control: 0.0037689208984375
+
+Image URL: https://farm5.staticflickr.com/4106/4962771032_82d3b7ccea_z.jpg
+Top 5 Predictions
+----------------------------------
+zebra: 0.85546875
+ostrich: 0.00115203857421875
+hartebeest: 0.00067138671875
+Arabian camel: 0.00046539306640625
+cheetah: 0.000400543212890625
+.
+.
+.
+{3 other URL results}
+****************************************
+```
+### Second device:
+```
+****************************************
+Results from Device: <tt_mlir.Device object at 0x7fc400e79f70>
+Image URL: https://farm4.staticflickr.com/3596/3687601495_73a46536b8_z.jpg
+Top 5 Predictions
+------------------------------
+ballplayer: 0.77734375
+baseball: 0.06787109375
+racket: 0.0028533935546875
+scoreboard: 0.0011138916015625
+collie: 0.000713348388671875
+
+Image URL: https://farm2.staticflickr.com/1375/5163062341_fbeb2e6678_z.jpg
+Top 5 Predictions
+----------------------------
+suit: 0.703125
+spotlight: 0.07861328125
+Windsor tie: 0.0155029296875
+groom: 0.005889892578125
+notebook: 0.005523681640625
+.
+.
+.
+{3 other URL results}
+****************************************
 ```

--- a/demos/resnet/README.md
+++ b/demos/resnet/README.md
@@ -122,3 +122,20 @@ notebook: 0.005523681640625
 {3 other URL results}
 ****************************************
 ```
+
+## resnet50_single_vs_multi_device_compare.py
+
+This file just performs a simple performance test to verify the speedup of using multiple devices to split up the workload, compared to using only a single device.
+
+It tests the performance of two functions:
+- `singledevice()`: which compiles the ResNet model on a single device and uses that model to process 10 Image URLs.
+- `multidevice()`: which compiles the ResNet model on all available devices and uses each model to process an equal subset of the 10 Image URLs in parallel.
+
+Each function is ran for 10 iterations and the durations are averaged out.
+
+Running this on an N300 board with 2 available devices gives the following results:
+
+```
+Average Single device time (in s):  75.16102676391601
+Average Multi device time (in s):  41.56483373641968
+```

--- a/demos/resnet/README.md
+++ b/demos/resnet/README.md
@@ -9,7 +9,7 @@ for the interactive demo that uses a single-device to classify an image using Re
 
 Or run,
 ```
-python demos/resnet/resnet50_data_parallel_demo.py
+python demos/resnet/resnet50_data_parallel_demo.py [--use_simplified_manager]
 ```
 for the demo on how to leverage the `DeviceManager` module to run ResNet image classification across multiple chips in parallel.
 
@@ -50,7 +50,7 @@ def main():
     options = {}
     options["compiler_config"] = cc
     # Acquires all available devices and returns them in a list
-    devices = DeviceManager.get_available_devices()
+    parent, devices = DeviceManager.acquire_available_devices()
     tt_models = []
     for device in devices:
         options["device"] = device # Explicitly compile the model for a specific device
@@ -58,7 +58,8 @@ def main():
             torch.compile(model, backend=backend, dynamic=False, options=options)
         )
     ...
-    DeviceManager.release_devices() # Release all acquired devices after use
+    # Release all acquired devices after use
+    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
 ```
 Note that in this case, the user is responsible for releasing the acquired devices.
 
@@ -121,21 +122,4 @@ notebook: 0.005523681640625
 .
 {3 other URL results}
 ****************************************
-```
-
-## resnet50_single_vs_multi_device_compare.py
-
-This file just performs a simple performance test to verify the speedup of using multiple devices to split up the workload, compared to using only a single device.
-
-It tests the performance of two functions:
-- `singledevice()`: which compiles the ResNet model on a single device and uses that model to process 10 Image URLs.
-- `multidevice()`: which compiles the ResNet model on all available devices and uses each model to process an equal subset of the 10 Image URLs in parallel.
-
-Each function is ran for 10 iterations and the durations are averaged out.
-
-Running this on an N300 board with 2 available devices gives the following results:
-
-```
-Average Single device time (in s):  75.16102676391601
-Average Multi device time (in s):  41.56483373641968
 ```

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -13,6 +13,8 @@ from threading import Thread
 import requests
 from tt_torch.tools.device_manager import DeviceManager
 
+import pprint
+
 # A custom thread class to simplify returning values from threads
 class CustomThread(Thread):
     def __init__(
@@ -80,7 +82,14 @@ def main():
 
     options = {}
     options["compiler_config"] = cc
-    devices = DeviceManager.get_available_devices()  # Acquire all available devices
+    (
+        parent,
+        devices,
+    ) = DeviceManager.acquire_available_devices()  # Acquire all available devices
+    print("AFTER ACQUIRE:")
+    for _parent in DeviceManager.get_parent_devices():
+        print("Parent Device:", _parent)
+        print("Sub Devices:", DeviceManager.get_sub_mesh_devices(_parent))
     num_devices = len(devices)
     tt_models = []
     for device in devices:
@@ -136,7 +145,12 @@ def main():
             print()
         print("*" * 40)
 
-    DeviceManager.release_devices()  # Release all devices after use
+    # DeviceManager.release_devices()  # Release all devices after use
+    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
+    print("AFTER RELEASE:")
+    for _parent in DeviceManager.get_parent_devices():
+        print("Parent Device:", _parent)
+        print("Sub Devices:", DeviceManager.get_sub_mesh_devices(_parent))
 
 
 if __name__ == "__main__":

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -1,19 +1,17 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+import argparse
 import torch
 from tt_torch.tools.utils import CompilerConfig
 from tt_torch.dynamo.backend import backend
 from PIL import Image
-import torch
 from torchvision import transforms
 import torchvision.models as models
 import tabulate
 from threading import Thread
 import requests
 from tt_torch.tools.device_manager import DeviceManager
-
-import pprint
 
 # A custom thread class to simplify returning values from threads
 class CustomThread(Thread):
@@ -70,7 +68,7 @@ def get_predictions(tt_model, urls, topk=5):
     return results
 
 
-def main():
+def main(use_simplified_manager):
     """
     This demo shows how to run the ResNet image classification model on all available devices on the board in parallel.
     Each device will process a different set of images.
@@ -82,15 +80,23 @@ def main():
 
     options = {}
     options["compiler_config"] = cc
-    (
-        parent,
-        devices,
-    ) = DeviceManager.acquire_available_devices()  # Acquire all available devices
-    print("AFTER ACQUIRE:")
-    for _parent in DeviceManager.get_parent_devices():
-        print("Parent Device:", _parent)
-        print("Sub Devices:", DeviceManager.get_sub_mesh_devices(_parent))
-    num_devices = len(devices)
+    num_devices = DeviceManager.get_num_available_devices()
+    if use_simplified_manager:
+        print("Using simplified device manager")
+        # The "simplified" acquire_available_devices() method will return a parent mesh
+        # and a list of sub mesh devices in a 1D mesh.
+        parent, devices = DeviceManager.acquire_available_devices()
+    else:
+        print("Using full device manager")
+        # The DeviceManager class also provides methods to manually create parent meshes
+        # and sub mesh devices. This is useful for more complex device topologies.
+        parent = DeviceManager.create_parent_mesh_device(mesh_shape=[1, num_devices])
+        for i in range(num_devices):
+            DeviceManager.create_sub_mesh_device(
+                parent, mesh_offset=(0, i), mesh_shape=[1, 1]
+            )
+        devices = list(DeviceManager.get_sub_mesh_devices(parent))
+
     tt_models = []
     for device in devices:
         options["device"] = device
@@ -145,13 +151,23 @@ def main():
             print()
         print("*" * 40)
 
-    # DeviceManager.release_devices()  # Release all devices after use
-    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
-    print("AFTER RELEASE:")
-    for _parent in DeviceManager.get_parent_devices():
-        print("Parent Device:", _parent)
-        print("Sub Devices:", DeviceManager.get_sub_mesh_devices(_parent))
+    if use_simplified_manager:
+        # The cleanup_sub_devices flag will call the release_sub_mesh_device() method
+        # for each sub mesh under the specified parent device automatically.
+        DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
+    else:
+        # The option to manually release the sub mesh devices is also available.
+        for device in devices:
+            DeviceManager.release_sub_mesh_device(device)
+        DeviceManager.release_parent_device(parent)
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--use_simplified_manager",
+        action="store_true",
+        help="Use simplified device manager to run file",
+    )
+    args = parser.parse_args()
+    main(args.use_simplified_manager)

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from tt_torch.tools.utils import CompilerConfig
+from tt_torch.dynamo.backend import backend
+from PIL import Image
+import torch
+from torchvision import transforms
+import torchvision.models as models
+import tabulate
+from threading import Thread
+import requests
+from tt_torch.tools.device_manager import DeviceManager
+
+# A custom thread class to simplify returning values from threads
+class CustomThread(Thread):
+    def __init__(
+        self, group=None, target=None, name=None, args=(), kwargs={}, verbose=None
+    ):
+        super().__init__(group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self):
+        super().join()
+        return self._return
+
+
+weights = models.ResNet152_Weights.IMAGENET1K_V2
+model = models.resnet152(weights=weights).to(torch.bfloat16).eval()
+classes = weights.meta["categories"]
+preprocess = weights.transforms()
+
+
+def download_image(url):
+    """
+    Helper function to download an image from a URL and preprocess it.
+    """
+    img = Image.open(requests.get(url, stream=True).raw)
+    img = preprocess(img)
+    img = torch.unsqueeze(img, 0)
+    img = img.to(torch.bfloat16)
+    return img
+
+
+def get_predictions(tt_model, urls, topk=5):
+    """
+    Given the compiled tt_model and a list of URLs, this function calls the model
+    for each URL and returns the top K predictions.
+    """
+    results = []
+    headers = [f"Top {topk} Predictions"]
+    for url in urls:
+        img = download_image(url)
+        top5, top5_indices = torch.topk(tt_model(img).squeeze().softmax(-1), topk)
+        tt_classes = []
+        for class_likelihood, class_idx in zip(top5.tolist(), top5_indices.tolist()):
+            tt_classes.append(f"{classes[class_idx]}: {class_likelihood}")
+        rows = []
+        url_string = f"Image URL: {url}\n"
+        for i in range(topk):
+            rows.append([tt_classes[i]])
+        results.append(url_string + tabulate.tabulate(rows, headers=headers))
+    return results
+
+
+def main():
+    """
+    This demo shows how to run the ResNet image classification model on all available devices on the board in parallel.
+    Each device will process a different set of images.
+    """
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+
+    options = {}
+    options["compiler_config"] = cc
+    devices = DeviceManager.get_available_devices()  # Acquire all available devices
+    num_devices = len(devices)
+    tt_models = []
+    for device in devices:
+        options["device"] = device
+        # Compile the model for each device
+        tt_models.append(
+            torch.compile(model, backend=backend, dynamic=False, options=options)
+        )
+
+    # List of image URLs to be processed
+    image_urls = [
+        "http://images.cocodataset.org/val2017/000000039769.jpg",  # Two cats
+        "https://farm5.staticflickr.com/4106/4962771032_82d3b7ccea_z.jpg",  # Two zebras
+        "https://farm5.staticflickr.com/4039/4184303499_115369327f_z.jpg",  # Pizza
+        "https://farm5.staticflickr.com/4117/4902338213_9c6fb559b8_z.jpg",  # Park bench
+        "https://farm4.staticflickr.com/3744/10085008474_8d72a9dc5e_z.jpg",  # Locomotive
+        "https://farm4.staticflickr.com/3596/3687601495_73a46536b8_z.jpg",  # Baseball player
+        "https://farm2.staticflickr.com/1375/5163062341_fbeb2e6678_z.jpg",  # Person in suit
+        "https://farm2.staticflickr.com/1366/976992600_3927559756_z.jpg",  # Microwave
+        "https://farm6.staticflickr.com/5056/5457805814_df70ed85c3_z.jpg",  # Labrador retriever
+        "https://farm8.staticflickr.com/7325/9536735356_c1e2e5a0d5_z.jpg",  # Two elephants
+    ]
+    # Evenly distribute the image URLs across all devices.
+    # This creates a list of lists of length num_devices, where the ith sublist
+    # contains the image URLs that will be processed by the ith device.
+    k, m = divmod(len(image_urls), num_devices)
+    divided_urls = [
+        image_urls[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
+        for i in range(num_devices)
+    ]
+
+    threads = []
+    for i in range(num_devices):
+        thread = CustomThread(
+            target=get_predictions, args=(tt_models[i], divided_urls[i])
+        )
+        threads.append((devices[i], thread))
+
+    for _, thread in threads:
+        thread.start()
+
+    final_results = []
+    for device_used, thread in threads:
+        predictions = thread.join()
+        final_results.append((device_used, predictions))
+
+    # Print the results
+    for device_used, prediction_results in final_results:
+        print("*" * 40)
+        print(f"Results from Device: {device_used}")
+        for result in prediction_results:
+            print(result)
+            print()
+        print("*" * 40)
+
+    DeviceManager.release_devices()  # Release all devices after use
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/resnet/resnet50_demo.py
+++ b/demos/resnet/resnet50_demo.py
@@ -10,6 +10,7 @@ from torchvision import transforms
 import torchvision.models as models
 import tabulate
 import requests
+from tt_torch.tools.device_manager import DeviceManager
 
 
 def main():
@@ -22,10 +23,12 @@ def main():
     cc.enable_consteval = True
     cc.consteval_parameters = True
 
-    # devices = tt_torch.query_devices()
-    tt_model = torch.compile(model, backend=backend, dynamic=False, options=cc)
+    devices = DeviceManager.get_available_devices()
+    options = {}
+    options["compiler_config"] = cc
+    options["device"] = devices[0]
+    tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
 
-    # tt_model(*inputs, devices[0])
     headers = ["Top 5 Predictions"]
     topk = 5
     prompt = 'Enter the path of the image (type "stop" to exit or hit enter to use a default image): '
@@ -55,6 +58,7 @@ def main():
         print()
 
         img_path = input(prompt)
+    DeviceManager.release_devices()
 
 
 if __name__ == "__main__":

--- a/demos/resnet/resnet50_demo.py
+++ b/demos/resnet/resnet50_demo.py
@@ -23,10 +23,8 @@ def main():
     cc.enable_consteval = True
     cc.consteval_parameters = True
 
-    devices = DeviceManager.get_available_devices()
     options = {}
     options["compiler_config"] = cc
-    options["device"] = devices[0]
     tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
 
     headers = ["Top 5 Predictions"]
@@ -58,7 +56,6 @@ def main():
         print()
 
         img_path = input(prompt)
-    DeviceManager.release_devices()
 
 
 if __name__ == "__main__":

--- a/demos/resnet/resnet50_demo.py
+++ b/demos/resnet/resnet50_demo.py
@@ -22,8 +22,10 @@ def main():
     cc.enable_consteval = True
     cc.consteval_parameters = True
 
+    # devices = tt_torch.query_devices()
     tt_model = torch.compile(model, backend=backend, dynamic=False, options=cc)
 
+    # tt_model(*inputs, devices[0])
     headers = ["Top 5 Predictions"]
     topk = 5
     prompt = 'Enter the path of the image (type "stop" to exit or hit enter to use a default image): '

--- a/demos/resnet/resnet50_single_vs_multi_device_compare.py
+++ b/demos/resnet/resnet50_single_vs_multi_device_compare.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from tt_torch.tools.utils import CompilerConfig
+from tt_torch.dynamo.backend import backend
+from PIL import Image
+import torch
+from torchvision import transforms
+import torchvision.models as models
+import tabulate
+from threading import Thread
+import requests
+from tt_torch.tools.device_manager import DeviceManager
+import time
+import pprint
+
+# A custom thread class to simplify returning values from threads
+class CustomThread(Thread):
+    def __init__(
+        self, group=None, target=None, name=None, args=(), kwargs={}, verbose=None
+    ):
+        super().__init__(group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self):
+        super().join()
+        return self._return
+
+
+weights = models.ResNet152_Weights.IMAGENET1K_V2
+model = models.resnet152(weights=weights).to(torch.bfloat16).eval()
+classes = weights.meta["categories"]
+preprocess = weights.transforms()
+
+
+def download_image(url):
+    """
+    Helper function to download an image from a URL and preprocess it.
+    """
+    img = Image.open(requests.get(url, stream=True).raw)
+    img = preprocess(img)
+    img = torch.unsqueeze(img, 0)
+    img = img.to(torch.bfloat16)
+    return img
+
+
+def get_predictions(tt_model, urls, topk=5):
+    """
+    Given the compiled tt_model and a list of URLs, this function calls the model
+    for each URL and returns the top K predictions.
+    """
+    results = []
+    headers = [f"Top {topk} Predictions"]
+    for url in urls:
+        img = download_image(url)
+        top5, top5_indices = torch.topk(tt_model(img).squeeze().softmax(-1), topk)
+        tt_classes = []
+        for class_likelihood, class_idx in zip(top5.tolist(), top5_indices.tolist()):
+            tt_classes.append(f"{classes[class_idx]}: {class_likelihood}")
+        rows = []
+        url_string = f"Image URL: {url}\n"
+        for i in range(topk):
+            rows.append([tt_classes[i]])
+        results.append(url_string + tabulate.tabulate(rows, headers=headers))
+    return results
+
+
+def multidevice(divided_urls):
+    """
+    Running the ResNet model on all available devices in parallel.
+    """
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+
+    options = {}
+    options["compiler_config"] = cc
+    devices = DeviceManager.get_available_devices()  # Acquire all available devices
+    num_devices = len(devices)
+    tt_models = []
+    for device in devices:
+        options["device"] = device
+        # Compile the model for each device
+        tt_models.append(
+            torch.compile(model, backend=backend, dynamic=False, options=options)
+        )
+
+    threads = []
+    for i in range(num_devices):
+        thread = CustomThread(
+            target=get_predictions, args=(tt_models[i], divided_urls[i])
+        )
+        threads.append(thread)
+
+    for thread in threads:
+        thread.start()
+
+    final_results = []
+    for thread in threads:
+        predictions = thread.join()
+        final_results.append(predictions)
+    DeviceManager.release_devices()  # Release all devices after use
+    return final_results
+
+
+def singledevice(image_urls):
+    """
+    Running the ResNet model on a single device.
+    """
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+
+    options = {}
+    options["compiler_config"] = cc
+    tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
+
+    return get_predictions(tt_model, image_urls)
+
+
+if __name__ == "__main__":
+    NUM_ITERATIONS = 10  # Number of perf testing iterations to run
+    image_urls = [
+        "http://images.cocodataset.org/val2017/000000039769.jpg",  # Two cats
+        "https://farm5.staticflickr.com/4106/4962771032_82d3b7ccea_z.jpg",  # Two zebras
+        "https://farm5.staticflickr.com/4039/4184303499_115369327f_z.jpg",  # Pizza
+        "https://farm5.staticflickr.com/4117/4902338213_9c6fb559b8_z.jpg",  # Park bench
+        "https://farm4.staticflickr.com/3744/10085008474_8d72a9dc5e_z.jpg",  # Locomotive
+        "https://farm4.staticflickr.com/3596/3687601495_73a46536b8_z.jpg",  # Baseball player
+        "https://farm2.staticflickr.com/1375/5163062341_fbeb2e6678_z.jpg",  # Person in suit
+        "https://farm2.staticflickr.com/1366/976992600_3927559756_z.jpg",  # Microwave
+        "https://farm6.staticflickr.com/5056/5457805814_df70ed85c3_z.jpg",  # Labrador retriever
+        "https://farm8.staticflickr.com/7325/9536735356_c1e2e5a0d5_z.jpg",  # Two elephants
+    ]
+
+    # Prepare the input for the multidevice testing function.
+    # This creates a list of lists of length num_devices, where the ith sublist
+    # contains the image URLs that will be processed by the ith device.
+    num_devices = DeviceManager.get_num_available_devices()
+    k, m = divmod(len(image_urls), num_devices)
+    divided_urls = [
+        image_urls[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)]
+        for i in range(num_devices)
+    ]
+
+    single_results = None
+    multi_results = None
+    acc_duration = 0
+    for _ in range(NUM_ITERATIONS):
+        start_time = time.time()
+        single_results = singledevice(image_urls)
+        end_time = time.time()
+        acc_duration += end_time - start_time
+    avg_duration_single = acc_duration / NUM_ITERATIONS
+    acc_duration = 0
+    for _ in range(NUM_ITERATIONS):
+        start_time = time.time()
+        multi_results = multidevice(divided_urls)
+        end_time = time.time()
+        acc_duration += end_time - start_time
+    avg_duration_multi = acc_duration / NUM_ITERATIONS
+    print("\n" * 5)
+    print("Average Single device time (in s): ", avg_duration_single)
+    print("Average Multi device time (in s): ", avg_duration_multi)
+    print("\n" * 5)
+
+    print("Single Device Results from latest iteration:")
+    pprint.pprint(single_results)
+    print("*" * 50)
+    print("Multi Device Results from latest iteration:")
+    pprint.pprint(multi_results)

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -83,11 +83,7 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
     devices = DeviceManager.get_available_devices(
         mesh_shape=[1, 1], enable_async_ttnn=True
     )
-    assert len(devices) == 1, (
-        "Failed to get available devices"
-        if len(devices) == 0
-        else "More than 1 device taken"
-    )
+    assert len(devices) == 1, f"Expected 1 device, got {len(devices)}"
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -80,10 +80,11 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
     cc.enable_consteval = True
     cc.consteval_parameters = True
     cc.cache_preprocessed_constants = True
-    devices = DeviceManager.get_available_devices(
+
+    device = DeviceManager.create_parent_mesh_device(
         mesh_shape=[1, 1], enable_async_ttnn=True
     )
-    assert len(devices) == 1, f"Expected 1 device, got {len(devices)}"
+
     tester = ThisTester(
         model_name,
         mode,
@@ -92,7 +93,7 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
         compiler_config=cc,
         record_property_handle=record_property,
         model_name_suffix="-multiloop",
-        device=devices[0],
+        device=device,
     )
     model = tester.compile_model(tester.get_framework_model(), tester.compiler_config)
 
@@ -106,4 +107,4 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
         print(f"{num_loops} iterations took {(end_time - start_time)} seconds")
 
     tester.finalize()
-    DeviceManager.release_devices()
+    DeviceManager.release_parent_device(device)

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -54,13 +54,10 @@ def test_add_multidevice():
             return torch.add(x, y)
 
     num_devices = DeviceManager.get_num_available_devices()
-    print("Number of available devices: ", num_devices)
     device_list = DeviceManager.get_available_devices()
     assert (
         len(device_list) == num_devices
     ), "Number of devices is not equal to expected."
-    print("Submeshes secured: ", device_list)
-    print("Parent mesh: ", DeviceManager._parent)
     threads = []
     compiler_configs = [CompilerConfig() for _ in range(num_devices)]
     for i in range(num_devices):

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -10,13 +10,7 @@ import threading
 import tt_torch
 from tt_torch.tools.verify import verify_module
 from tt_torch.tools.utils import CompilerConfig
-from tt_mlir import (
-    open_mesh_device,
-    close_mesh_device,
-    MeshDeviceOptions,
-    create_sub_mesh_device,
-    release_sub_mesh_device,
-)
+from tt_torch.tools.device_manager import DeviceManager
 
 
 def test_abs():
@@ -40,9 +34,17 @@ def test_add():
 
     verify_module(Basic(), input_shapes=[(256, 256)] * 2)
 
-def verify_module_helper(module, input_shapes, compiler_config):
-    verify_module(module, input_shapes=input_shapes, compiler_config=compiler_config)
 
+def verify_module_helper(module, input_shapes, compiler_config, device):
+    verify_module(
+        module,
+        input_shapes=input_shapes,
+        compiler_config=compiler_config,
+        device=device,
+    )
+
+
+# Runs the AddOp on all detected chips in parallel
 def test_add_multidevice():
     class AddOp(nn.Module):
         def __init__(self):
@@ -50,45 +52,35 @@ def test_add_multidevice():
 
         def forward(self, x, y):
             return torch.add(x, y)
-    
-    class MultOp(nn.Module):
-        def __init__(self):
-            super().__init__()
 
-        def forward(self, x, y):
-            return x * y
-
-    mesh_options = MeshDeviceOptions()
-    mesh_options.device_ids = [0, 1]
-    parent_mesh_shape = [1, 2] # 2 devices
-    parent_mesh = open_mesh_device(parent_mesh_shape, mesh_options)
-    
+    num_devices = DeviceManager.get_num_available_devices()
+    print("Number of available devices: ", num_devices)
+    device_list = DeviceManager.get_available_devices()
+    assert (
+        len(device_list) == num_devices
+    ), "Number of devices is not equal to expected."
+    print("Submeshes secured: ", device_list)
+    print("Parent mesh: ", DeviceManager._parent)
     threads = []
-    compiler_configs = [CompilerConfig() for i in range(len(mesh_options.device_ids))]
-    for i in range(len(mesh_options.device_ids)):
+    compiler_configs = [CompilerConfig() for _ in range(num_devices)]
+    for i in range(num_devices):
         cc = compiler_configs[i]
-        cc.is_sub_mesh_device = True
-        cc.initialize_device(parent_mesh=parent_mesh, sub_mesh_offset=(0, i))
-        mod = AddOp() if i == 0 else MultOp()
-        if i == 0:
-            mod = AddOp()
-            input_shapes = [(256,256)] * 2
-        else:
-            mod = MultOp()
-            input_shapes = [(32, 32), (32, 32)]
-
-        thread = threading.Thread(target=verify_module_helper, args=(mod, input_shapes, cc))
+        device = device_list[i]
+        mod = AddOp()
+        input_shapes = [(256, 256)] * 2
+        thread = threading.Thread(
+            target=verify_module_helper, args=(mod, input_shapes, cc, device)
+        )
         threads.append(thread)
 
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
-    for i in range(len(threads)):
-        compiler_configs[i].cleanup_device()
-    
-    close_mesh_device(parent_mesh)
 
+    DeviceManager.release_devices()
+    assert DeviceManager._parent is None, "Parent device is not released."
+    assert len(DeviceManager._devices) == 0, "Submesh devices are not released."
 
 
 def test_concat_dim0():

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -73,7 +73,9 @@ def test_add_multidevice():
         thread.join()
 
     DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
-    assert len(DeviceManager._devices) == 0, "Some devices are not released."
+    assert (
+        len(DeviceManager.get_parent_devices()) == 0
+    ), "Some devices are not released."
 
 
 def test_concat_dim0():

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -45,7 +45,7 @@ def test_add_multidevice():
             return torch.add(x, y)
 
     num_devices = DeviceManager.get_num_available_devices()
-    device_list = DeviceManager.get_available_devices()
+    parent, device_list = DeviceManager.acquire_available_devices()
     assert (
         len(device_list) == num_devices
     ), "Number of devices is not equal to expected."
@@ -72,9 +72,8 @@ def test_add_multidevice():
     for thread in threads:
         thread.join()
 
-    DeviceManager.release_devices()
-    assert DeviceManager._parent is None, "Parent device is not released."
-    assert len(DeviceManager._devices) == 0, "Submesh devices are not released."
+    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
+    assert len(DeviceManager._devices) == 0, "Some devices are not released."
 
 
 def test_concat_dim0():

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -35,15 +35,6 @@ def test_add():
     verify_module(Basic(), input_shapes=[(256, 256)] * 2)
 
 
-def verify_module_helper(module, input_shapes, compiler_config, device):
-    verify_module(
-        module,
-        input_shapes=input_shapes,
-        compiler_config=compiler_config,
-        device=device,
-    )
-
-
 # Runs the AddOp on all detected chips in parallel
 def test_add_multidevice():
     class AddOp(nn.Module):
@@ -66,7 +57,13 @@ def test_add_multidevice():
         mod = AddOp()
         input_shapes = [(256, 256)] * 2
         thread = threading.Thread(
-            target=verify_module_helper, args=(mod, input_shapes, cc, device)
+            target=verify_module,
+            kwargs={
+                "mod": mod,
+                "input_shapes": input_shapes,
+                "compiler_config": cc,
+                "device": device,
+            },
         )
         threads.append(thread)
 

--- a/tests/torch/test_device_manager.py
+++ b/tests/torch/test_device_manager.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from unittest.mock import patch, MagicMock
+from tt_torch.tools.device_manager import DeviceManager
+
+
+class MockDevice:
+    def __init__(self, id):
+        self.device_id = id
+
+    def __eq__(self, other):
+        return self.device_id == other.device_id
+
+    def __hash__(self):
+        return hash(self.device_id)
+
+
+@pytest.fixture
+def mock_tt_mlir():
+    # Reset the DeviceManager state before each test
+    DeviceManager._devices = set()
+    DeviceManager._parent = None
+
+    # Mock the tt_mlir module and its methods
+    with patch("tt_torch.tools.device_manager.tt_mlir") as mock_mlir:
+        mock_mlir.get_num_available_devices.return_value = 4
+        mock_mlir.MeshDeviceOptions.return_value = MagicMock()
+        mock_mlir.open_mesh_device.return_value = MockDevice(-1)
+        mock_mlir.create_sub_mesh_device = MagicMock()
+        mock_mlir.create_sub_mesh_device.side_effect = [MockDevice(i) for i in range(4)]
+        mock_mlir.release_sub_mesh_device.return_value = MagicMock()
+        mock_mlir.close_mesh_device.return_value = MagicMock()
+        yield mock_mlir
+
+
+def test_get_available_devices_all(mock_tt_mlir):
+    """Test acquiring all available devices."""
+    devices = DeviceManager.get_available_devices()
+
+    assert mock_tt_mlir.open_mesh_device.call_count == 1
+    assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
+    assert len(devices) == 4
+    assert DeviceManager._parent is not None
+
+
+def test_get_available_devices_reuse(mock_tt_mlir):
+    """Test get_available_devices returns existing devices if already previously created."""
+    # Call once to initialize
+    initial_devices = DeviceManager.get_available_devices()
+    # Call again to see if the same devices are returned
+    reused_devices = DeviceManager.get_available_devices()
+    # The parent and mesh subdevice calls should not be made again
+    # since we are reusing the devices
+    assert mock_tt_mlir.open_mesh_device.call_count == 1
+    assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
+    assert len(initial_devices) == len(reused_devices)
+    assert DeviceManager._parent is not None
+    for i in range(4):
+        assert initial_devices[i] == reused_devices[i]
+
+
+def test_release_devices_all(mock_tt_mlir):
+    """Releasing all devices should close the parent as well."""
+    DeviceManager.get_available_devices()
+    DeviceManager.release_devices()
+    assert DeviceManager._parent is None
+    assert len(DeviceManager._devices) == 0
+
+
+def test_release_devices_single(mock_tt_mlir):
+    """Releasing a single device should release only that device."""
+    devices = DeviceManager.get_available_devices()
+    one_device = devices[0]
+    DeviceManager.release_devices(device=one_device)
+    assert one_device not in DeviceManager._devices
+    assert len(DeviceManager._devices) == 3
+    assert DeviceManager._parent is not None
+
+
+def test_release_devices_non_existent(mock_tt_mlir):
+    """Releasing non-existent device should warn and not affect existing devices."""
+    DeviceManager.get_available_devices()
+    with pytest.warns(UserWarning, match="not found in the list of managed devices"):
+        DeviceManager.release_devices(device=MockDevice(99))
+    assert len(DeviceManager._devices) == 4
+    assert DeviceManager._parent is not None

--- a/tests/torch/test_device_manager.py
+++ b/tests/torch/test_device_manager.py
@@ -37,20 +37,20 @@ def mock_tt_mlir():
 
 def test_get_available_devices_all(mock_tt_mlir):
     """Test acquiring all available devices."""
-    devices = DeviceManager.get_available_devices()
+    parent, devices = DeviceManager.acquire_available_devices()
 
     assert mock_tt_mlir.open_mesh_device.call_count == 1
     assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
     assert len(devices) == 4
-    assert DeviceManager._parent is not None
+    assert parent is not None
 
 
 def test_get_available_devices_reuse(mock_tt_mlir):
     """Test get_available_devices returns existing devices if already previously created."""
     # Call once to initialize
-    initial_devices = DeviceManager.get_available_devices()
+    initial_devices = DeviceManager.acquire_available_devices()
     # Call again to see if the same devices are returned
-    reused_devices = DeviceManager.get_available_devices()
+    reused_devices = DeviceManager.acquire_available_devices()
     # The parent and mesh subdevice calls should not be made again
     # since we are reusing the devices
     assert mock_tt_mlir.open_mesh_device.call_count == 1

--- a/tests/torch/test_device_manager.py
+++ b/tests/torch/test_device_manager.py
@@ -20,14 +20,15 @@ class MockDevice:
 @pytest.fixture
 def mock_tt_mlir():
     # Reset the DeviceManager state before each test
-    DeviceManager._devices = set()
-    DeviceManager._parent = None
+    DeviceManager._devices = {}
+    DeviceManager._parent_shapes = {}
+    DeviceManager._submesh_shapes = {}
 
     # Mock the tt_mlir module and its methods
     with patch("tt_torch.tools.device_manager.tt_mlir") as mock_mlir:
         mock_mlir.get_num_available_devices.return_value = 4
         mock_mlir.MeshDeviceOptions.return_value = MagicMock()
-        mock_mlir.open_mesh_device.return_value = MockDevice(-1)
+        mock_mlir.open_mesh_device.side_effect = [MockDevice(i) for i in range(4, 8)]
         mock_mlir.create_sub_mesh_device = MagicMock()
         mock_mlir.create_sub_mesh_device.side_effect = [MockDevice(i) for i in range(4)]
         mock_mlir.release_sub_mesh_device.return_value = MagicMock()
@@ -35,54 +36,109 @@ def mock_tt_mlir():
         yield mock_mlir
 
 
-def test_get_available_devices_all(mock_tt_mlir):
-    """Test acquiring all available devices."""
-    parent, devices = DeviceManager.acquire_available_devices()
+def test_create_parent_mesh_device(mock_tt_mlir):
+    # Create a 1x1 parent mesh
+    device = DeviceManager.create_parent_mesh_device((1, 1))
+
+    # Attempt to create a 2x3 parent mesh
+    with pytest.raises(AssertionError, match="Mesh shape exceeds available devices."):
+        DeviceManager.create_parent_mesh_device((2, 3))
+
+    # Attempt to create a 3D mesh with invalid shape
+    with pytest.raises(
+        AssertionError, match="Mesh shape must be a list of two integers."
+    ):
+        DeviceManager.create_parent_mesh_device((1, 1, 1))
 
     assert mock_tt_mlir.open_mesh_device.call_count == 1
-    assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
-    assert len(devices) == 4
-    assert parent is not None
+    assert device in DeviceManager._devices
+    assert len(DeviceManager._devices[device]) == 0
+    assert len(DeviceManager._submesh_shapes) == 0
+    assert DeviceManager._parent_shapes[device] == (1, 1)
 
 
-def test_get_available_devices_reuse(mock_tt_mlir):
-    """Test get_available_devices returns existing devices if already previously created."""
-    # Call once to initialize
-    initial_devices = DeviceManager.acquire_available_devices()
-    # Call again to see if the same devices are returned
-    reused_devices = DeviceManager.acquire_available_devices()
-    # The parent and mesh subdevice calls should not be made again
-    # since we are reusing the devices
-    assert mock_tt_mlir.open_mesh_device.call_count == 1
-    assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
-    assert len(initial_devices) == len(reused_devices)
-    assert DeviceManager._parent is not None
+def test_create_sub_mesh_device(mock_tt_mlir):
+    with pytest.raises(AssertionError, match="Parent mesh not found."):
+        DeviceManager.create_sub_mesh_device(MockDevice(99), (1, 1))
+
+    parent = DeviceManager.create_parent_mesh_device((2, 2))
+    valid_subdevices = []
     for i in range(4):
-        assert initial_devices[i] == reused_devices[i]
+        subdevice = DeviceManager.create_sub_mesh_device(
+            parent, mesh_offset=(0, i), mesh_shape=(1, 1)
+        )
+        valid_subdevices.append(subdevice)
+
+    with pytest.raises(AssertionError, match="Sub mesh shape is too big."):
+        DeviceManager.create_sub_mesh_device(
+            parent, mesh_offset=(0, 4), mesh_shape=(1, 1)
+        )
+
+    assert mock_tt_mlir.create_sub_mesh_device.call_count == 4
+    for subdevice in valid_subdevices:
+        assert subdevice in DeviceManager._devices[parent]
+        assert DeviceManager._submesh_shapes[subdevice] == (1, 1)
 
 
-def test_release_devices_all(mock_tt_mlir):
-    """Releasing all devices should close the parent as well."""
-    DeviceManager.get_available_devices()
-    DeviceManager.release_devices()
-    assert DeviceManager._parent is None
+def test_release_sub_mesh_device(mock_tt_mlir):
+    with pytest.raises(
+        AssertionError, match="Parent mesh not found in the list of managed devices."
+    ):
+        DeviceManager.release_sub_mesh_device(
+            sub_device=MockDevice(99), parent=MockDevice(98)
+        )
+    parent = DeviceManager.create_parent_mesh_device((1, 2))
+    with pytest.raises(
+        AssertionError, match="Sub device not found in the specified parent mesh."
+    ):
+        DeviceManager.release_sub_mesh_device(sub_device=MockDevice(99), parent=parent)
+
+    with pytest.raises(
+        AssertionError, match="Sub device not found in any parent mesh."
+    ):
+        DeviceManager.release_sub_mesh_device(sub_device=MockDevice(99))
+
+    subdevice_1 = DeviceManager.create_sub_mesh_device(
+        parent, mesh_offset=(0, 0), mesh_shape=(1, 1)
+    )
+    subdevice_2 = DeviceManager.create_sub_mesh_device(
+        parent, mesh_offset=(0, 1), mesh_shape=(1, 1)
+    )
+
+    DeviceManager.release_sub_mesh_device(subdevice_1)
+
+    assert subdevice_1 not in DeviceManager._devices[parent]
+    assert subdevice_1 not in DeviceManager._submesh_shapes
+    assert subdevice_2 in DeviceManager._devices[parent]
+
+    DeviceManager.release_sub_mesh_device(subdevice_2, parent=parent)
+    assert subdevice_2 not in DeviceManager._devices[parent]
+    assert subdevice_2 not in DeviceManager._submesh_shapes
+    assert len(DeviceManager._devices[parent]) == 0
+
+    subdevice_3 = DeviceManager.create_sub_mesh_device(
+        parent, mesh_offset=(0, 0), mesh_shape=(1, 1)
+    )
+    DeviceManager.release_sub_mesh_device(subdevice_3, cleanup_parent=True)
+    assert mock_tt_mlir.release_sub_mesh_device.call_count == 3
+    assert parent not in DeviceManager._devices
+    assert subdevice_3 not in DeviceManager._devices
     assert len(DeviceManager._devices) == 0
 
 
-def test_release_devices_single(mock_tt_mlir):
-    """Releasing a single device should release only that device."""
-    devices = DeviceManager.get_available_devices()
-    one_device = devices[0]
-    DeviceManager.release_devices(device=one_device)
-    assert one_device not in DeviceManager._devices
-    assert len(DeviceManager._devices) == 3
-    assert DeviceManager._parent is not None
+def test_release_parent_device(mock_tt_mlir):
+    with pytest.raises(AssertionError, match="Parent Device not found."):
+        DeviceManager.release_parent_device(MockDevice(99))
 
+    parent = DeviceManager.create_parent_mesh_device((1, 2))
+    subdevice = DeviceManager.create_sub_mesh_device(parent, (0, 0))
 
-def test_release_devices_non_existent(mock_tt_mlir):
-    """Releasing non-existent device should warn and not affect existing devices."""
-    DeviceManager.get_available_devices()
-    with pytest.warns(UserWarning, match="not found in the list of managed devices"):
-        DeviceManager.release_devices(device=MockDevice(99))
-    assert len(DeviceManager._devices) == 4
-    assert DeviceManager._parent is not None
+    with pytest.raises(
+        AssertionError, match="Sub devices still exist under this parent mesh."
+    ):
+        DeviceManager.release_parent_device(parent, cleanup_sub_devices=False)
+
+    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
+    assert parent not in DeviceManager._devices
+    assert parent not in DeviceManager._parent_shapes
+    assert subdevice not in DeviceManager._submesh_shapes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -43,6 +43,7 @@ class ModelTester:
         model_group="generality",
         is_token_output=False,
         model_name_suffix="",
+        device=None,
     ):
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
@@ -55,6 +56,7 @@ class ModelTester:
                 "is_token_output is set to True. Please set `self.tokenizer` inside _load_model method."
             )
         self.compiled_model = None
+        self.device = device
         self.inputs = self._load_inputs()
         self.required_pcc = required_pcc
         self.assert_pcc = assert_pcc
@@ -165,10 +167,10 @@ class ModelTester:
 
     def compile_model(self, model, compiler_config):
         # Compile model
-        model = torch.compile(
-            model, backend=backend, dynamic=False, options=compiler_config
-        )
-
+        options = {}
+        options["compiler_config"] = compiler_config
+        options["device"] = self.device
+        model = torch.compile(model, backend=backend, dynamic=False, options=options)
         self.compiled_model = model
         return self.compiled_model
 

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -134,6 +134,7 @@ class Executor:
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
+        device=None,
     ):
         self.program = program
         self.binary = None
@@ -161,6 +162,7 @@ class Executor:
 
         self.binary = None
         self.preprocessed_graph_constants = None
+        self.device = device
 
     def register_intermediate_callback(self, callback):
         if not tt_mlir.is_runtime_debug_enabled():
@@ -193,20 +195,11 @@ class Executor:
         self.binary = binary
 
     def _get_device(self):
-        if self.compiler_config.runtime_device is not None:
-            return self.compiler_config.runtime_device
-        if self.compiler_config.mesh_device_options is None:
-            self.compiler_config.mesh_device_options = tt_mlir.MeshDeviceOptions()
-        assert (
-            self.compiler_config.mesh_device_shape is not None
-        ), "Please set mesh_device_shape within compiler_config"
-        assert (
-            len(self.compiler_config.mesh_device_shape) == 2
-        ), "Only a 2D mesh is supported for now"
-        return tt_mlir.open_mesh_device(
-            self.compiler_config.mesh_device_shape,
-            self.compiler_config.mesh_device_options,
-        )
+        if self.device is not None:
+            return self.device
+        # Return a default parent mesh
+        device = tt_mlir.open_mesh_device([1, 1], tt_mlir.MeshDeviceOptions())
+        return device
 
     def _cache_constants_if_needed(self, preprocessed_constants):
         if (
@@ -220,7 +213,7 @@ class Executor:
         for t in preprocessed_activations:
             tt_mlir.deallocate_tensor(t, force=True)
 
-        if self.compiler_config.runtime_device is None:
+        if self.device is None:
             tt_mlir.close_mesh_device(device)
 
     def _generate_golden_intermediate_cache(self, gm, inputs):
@@ -278,7 +271,7 @@ class Executor:
                 tensor = node.target(*args, **node.kwargs)
                 node_to_tensor[node] = tensor
 
-    def __call__(self, *inputs, device=None):
+    def __call__(self, *inputs):
         if self.compiler_config.compile_depth != CompileDepth.EXECUTE:
             assert (
                 self.program.graph_module != None
@@ -299,8 +292,7 @@ class Executor:
             inputs = self.graph_constants + inputs
 
         inputs = list(inputs)
-        if device is None:
-            device = self._get_device()
+        device = self._get_device()
 
         binary = tt_mlir.create_binary_from_bytestream(self.binary)
         program_idx = 0
@@ -358,6 +350,7 @@ class OpByOpExecutor(Executor):
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
+        device=None,
     ):
         super().__init__(
             program=None,
@@ -365,6 +358,7 @@ class OpByOpExecutor(Executor):
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,
+            device=device,
         )
 
         # Debug mode to run only specific op given global_op_idx

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -299,7 +299,8 @@ class Executor:
             inputs = self.graph_constants + inputs
 
         inputs = list(inputs)
-        device = self._get_device()
+        if device is None:
+            device = self._get_device()
 
         binary = tt_mlir.create_binary_from_bytestream(self.binary)
         program_idx = 0

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -278,7 +278,7 @@ class Executor:
                 tensor = node.target(*args, **node.kwargs)
                 node_to_tensor[node] = tensor
 
-    def __call__(self, *inputs):
+    def __call__(self, *inputs, device=None):
         if self.compiler_config.compile_depth != CompileDepth.EXECUTE:
             assert (
                 self.program.graph_module != None

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -226,11 +226,13 @@ class StablehloExecutor(OpByOpExecutor):
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
+        device=None,
     ):
         super().__init__(
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,
+            device=device,
         )
         self.parsed_module = None
         if module is not None:

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -168,11 +168,13 @@ class TorchExecutor(OpByOpExecutor):
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
+        device=None,
     ):
         super().__init__(
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,
+            device=device,
         )
         self.program = program
         self.graph_constants = (

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -8,7 +8,6 @@ import warnings
 class DeviceManager:
     _devices = set()
     _parent = None
-    _num_available = tt_mlir.get_num_available_devices()
 
     @staticmethod
     def _get_parent_mesh_options(
@@ -36,8 +35,7 @@ class DeviceManager:
 
     @classmethod
     def get_num_available_devices(self):
-        """Get the number of available devices."""
-        return self._num_available
+        return tt_mlir.get_num_available_devices()
 
     @classmethod
     def get_available_devices(
@@ -50,15 +48,20 @@ class DeviceManager:
         l1_small_size=None,
         dispatch_core_type=None,
     ):
+        num_available = tt_mlir.get_num_available_devices()
         if mesh_shape is None:
-            mesh_shape = [1, self._num_available]
+            mesh_shape = [1, num_available]
         if len(self._devices) > 0:
             assert self._parent is not None, "Parent device is not set."
+            warnings.warn(
+                "Devices already created, returning existing devices."
+                "If you want to create new devices, please call release_devices() first."
+            )
             return list(self._devices)
 
         assert len(mesh_shape) == 2, "Mesh shape must be a list of two integers."
         assert (
-            mesh_shape[0] * mesh_shape[1] <= self._num_available
+            mesh_shape[0] * mesh_shape[1] <= num_available
         ), "Mesh shape exceeds available devices."
 
         options = self._get_parent_mesh_options(

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -2,93 +2,105 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import tt_mlir
-
-_devices = set()
-_parent = None
-_num_available = tt_mlir.get_num_available_devices()
+import warnings
 
 
-def _get_parent_mesh_options(
-    device_ids=None,
-    num_hw_cqs=None,
-    enable_async_ttnn=None,
-    enable_program_cache=None,
-    l1_small_size=None,
-    dispatch_core_type=None,
-):
-    options = tt_mlir.MeshDeviceOptions()
-    if device_ids is not None:
-        options.device_ids = device_ids
-    if num_hw_cqs is not None:
-        options.num_hw_cqs = num_hw_cqs
-    if enable_async_ttnn is not None:
-        options.enable_async_ttnn = enable_async_ttnn
-    if enable_program_cache is not None:
-        options.enable_program_cache = enable_program_cache
-    if l1_small_size is not None:
-        options.l1_small_size = l1_small_size
-    if dispatch_core_type is not None:
-        options.dispatch_core_type = dispatch_core_type
-    return options
+class DeviceManager:
+    _devices = set()
+    _parent = None
+    _num_available = tt_mlir.get_num_available_devices()
 
+    @staticmethod
+    def _get_parent_mesh_options(
+        device_ids=None,
+        num_hw_cqs=None,
+        enable_async_ttnn=None,
+        enable_program_cache=None,
+        l1_small_size=None,
+        dispatch_core_type=None,
+    ):
+        options = tt_mlir.MeshDeviceOptions()
+        if device_ids is not None:
+            options.device_ids = device_ids
+        if num_hw_cqs is not None:
+            options.num_hw_cqs = num_hw_cqs
+        if enable_async_ttnn is not None:
+            options.enable_async_ttnn = enable_async_ttnn
+        if enable_program_cache is not None:
+            options.enable_program_cache = enable_program_cache
+        if l1_small_size is not None:
+            options.l1_small_size = l1_small_size
+        if dispatch_core_type is not None:
+            options.dispatch_core_type = dispatch_core_type
+        return options
 
-def get_num_available_devices():
-    """Get the number of available devices."""
-    return _num_available
+    @classmethod
+    def get_num_available_devices(self):
+        """Get the number of available devices."""
+        return self._num_available
 
+    @classmethod
+    def get_available_devices(
+        self,
+        mesh_shape=None,
+        device_ids=None,
+        num_hw_cqs=None,
+        enable_async_ttnn=None,
+        enable_program_cache=None,
+        l1_small_size=None,
+        dispatch_core_type=None,
+    ):
+        if mesh_shape is None:
+            mesh_shape = [1, self._num_available]
+        if len(self._devices) > 0:
+            assert self._parent is not None, "Parent device is not set."
+            return list(self._devices)
 
-def get_available_devices(
-    mesh_shape=[1, 1],
-    device_ids=None,
-    num_hw_cqs=None,
-    enable_async_ttnn=None,
-    enable_program_cache=None,
-    l1_small_size=None,
-    dispatch_core_type=None,
-):
-    if len(_devices) > 0:
-        assert _parent is not None, "Parent device is not set."
-        return _devices
+        assert len(mesh_shape) == 2, "Mesh shape must be a list of two integers."
+        assert (
+            mesh_shape[0] * mesh_shape[1] <= self._num_available
+        ), "Mesh shape exceeds available devices."
 
-    assert len(mesh_shape) == 2, "Mesh shape must be a list of two integers."
-    assert (
-        mesh_shape[0] * mesh_shape[1] <= _num_available
-    ), "Mesh shape exceeds available devices."
+        options = self._get_parent_mesh_options(
+            device_ids,
+            num_hw_cqs,
+            enable_async_ttnn,
+            enable_program_cache,
+            l1_small_size,
+            dispatch_core_type,
+        )
 
-    global _devices
-    global _parent
+        # Secure a parent mesh device
+        self._parent = tt_mlir.open_mesh_device(
+            mesh_shape=mesh_shape,
+            options=options,
+        )
+        num_devices = mesh_shape[0] * mesh_shape[1]
+        for i in range(num_devices):
+            sub_device = tt_mlir.create_sub_mesh_device(self._parent, (1, 1), (0, i))
+            self._devices.add(sub_device)
+        return list(self._devices)
 
-    options = _get_parent_mesh_options(
-        device_ids,
-        num_hw_cqs,
-        enable_async_ttnn,
-        enable_program_cache,
-        l1_small_size,
-        dispatch_core_type,
-    )
+    @classmethod
+    def release_devices(self, device=None):
+        devices_copy = self._devices.copy()
+        if device is None:
+            # If no device is specified, release all devices
+            for device in devices_copy:
+                tt_mlir.release_sub_mesh_device(device)
+                self._devices.remove(device)
+        else:
+            if device in devices_copy:
+                tt_mlir.release_sub_mesh_device(device)
+                self._devices.remove(device)
+            else:
+                warnings.warn(
+                    f"Device {device} not found in the list of managed devices. Ignoring it."
+                )
 
-    # Secure a parent mesh device
-    _parent = tt_mlir.open_mesh_device(
-        mesh_shape=mesh_shape,
-        options=options,
-    )
-    num_devices = mesh_shape[0] * mesh_shape[1]
-    for i in range(num_devices):
-        sub_device = tt_mlir.create_sub_mesh_device(_parent, (1, 1), (0, i))
-        _devices.add(sub_device)
-    return list(_devices)
-
-
-def release_devices(device=None):
-    if device is None:
-        # If no device is specified, release all devices
-        for device in _devices:
-            tt_mlir.release_sub_mesh_device(device)
-            _devices.remove(device)
-    else:
-        if device in _devices:
-            tt_mlir.release_sub_mesh_device(device)
-            _devices.remove(device)
-    
-    if len(_devices) == 0:
-        tt_mlir.close_mesh_device(_parent)
+        if len(self._devices) == 0:
+            assert (
+                self._parent is not None
+            ), "Trying to release a non-existent parent device"
+            tt_mlir.close_mesh_device(self._parent)
+            self._parent = None

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import tt_mlir
+
+_devices = set()
+_parent = None
+_num_available = tt_mlir.get_num_available_devices()
+
+
+def _get_parent_mesh_options(
+    device_ids=None,
+    num_hw_cqs=None,
+    enable_async_ttnn=None,
+    enable_program_cache=None,
+    l1_small_size=None,
+    dispatch_core_type=None,
+):
+    options = tt_mlir.MeshDeviceOptions()
+    if device_ids is not None:
+        options.device_ids = device_ids
+    if num_hw_cqs is not None:
+        options.num_hw_cqs = num_hw_cqs
+    if enable_async_ttnn is not None:
+        options.enable_async_ttnn = enable_async_ttnn
+    if enable_program_cache is not None:
+        options.enable_program_cache = enable_program_cache
+    if l1_small_size is not None:
+        options.l1_small_size = l1_small_size
+    if dispatch_core_type is not None:
+        options.dispatch_core_type = dispatch_core_type
+    return options
+
+
+def get_num_available_devices():
+    """Get the number of available devices."""
+    return _num_available
+
+
+def get_available_devices(
+    mesh_shape=[1, 1],
+    device_ids=None,
+    num_hw_cqs=None,
+    enable_async_ttnn=None,
+    enable_program_cache=None,
+    l1_small_size=None,
+    dispatch_core_type=None,
+):
+    if len(_devices) > 0:
+        assert _parent is not None, "Parent device is not set."
+        return _devices
+
+    assert len(mesh_shape) == 2, "Mesh shape must be a list of two integers."
+    assert (
+        mesh_shape[0] * mesh_shape[1] <= _num_available
+    ), "Mesh shape exceeds available devices."
+
+    global _devices
+    global _parent
+
+    options = _get_parent_mesh_options(
+        device_ids,
+        num_hw_cqs,
+        enable_async_ttnn,
+        enable_program_cache,
+        l1_small_size,
+        dispatch_core_type,
+    )
+
+    # Secure a parent mesh device
+    _parent = tt_mlir.open_mesh_device(
+        mesh_shape=mesh_shape,
+        options=options,
+    )
+    num_devices = mesh_shape[0] * mesh_shape[1]
+    for i in range(num_devices):
+        sub_device = tt_mlir.create_sub_mesh_device(_parent, (1, 1), (0, i))
+        _devices.add(sub_device)
+    return list(_devices)
+
+
+def release_devices(device=None):
+    if device is None:
+        # If no device is specified, release all devices
+        for device in _devices:
+            tt_mlir.release_sub_mesh_device(device)
+            _devices.remove(device)
+    else:
+        if device in _devices:
+            tt_mlir.release_sub_mesh_device(device)
+            _devices.remove(device)
+    
+    if len(_devices) == 0:
+        tt_mlir.close_mesh_device(_parent)

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -35,6 +35,9 @@ class DeviceManager:
 
     @classmethod
     def get_num_available_devices(self):
+        """
+        Returns the number of available devices.
+        """
         return tt_mlir.get_num_available_devices()
 
     @classmethod
@@ -48,6 +51,10 @@ class DeviceManager:
         l1_small_size=None,
         dispatch_core_type=None,
     ):
+        """
+        Returns a list of available devices based on the specified mesh shape and options.
+        If no mesh shape is provided, returns all available devices in a 1D mesh.
+        """
         num_available = tt_mlir.get_num_available_devices()
         if mesh_shape is None:
             mesh_shape = [1, num_available]
@@ -86,6 +93,10 @@ class DeviceManager:
 
     @classmethod
     def release_devices(self, device=None):
+        """
+        Releases the specified device.
+        If no device is specified, releases all currently acquired devices.
+        """
         devices_copy = self._devices.copy()
         if device is None:
             # If no device is specified, release all devices

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -3,11 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import tt_mlir
 import warnings
+from typing import KeysView
 
 
 class DeviceManager:
-    _devices = set()
-    _parent = None
+    # Key: Parent mesh device
+    # Value: Set of sub mesh devices
+    _devices: dict[tt_mlir.Device, set[tt_mlir.Device]] = {}
 
     @staticmethod
     def _get_parent_mesh_options(
@@ -17,7 +19,7 @@ class DeviceManager:
         enable_program_cache=None,
         l1_small_size=None,
         dispatch_core_type=None,
-    ):
+    ) -> tt_mlir.MeshDeviceOptions:
         options = tt_mlir.MeshDeviceOptions()
         if device_ids is not None:
             options.device_ids = device_ids
@@ -34,43 +36,31 @@ class DeviceManager:
         return options
 
     @classmethod
-    def get_num_available_devices(cls):
+    def get_num_available_devices(cls) -> int:
         """
         Returns the number of available devices.
         """
         return tt_mlir.get_num_available_devices()
 
     @classmethod
-    def get_available_devices(
+    def create_parent_mesh_device(
         cls,
-        mesh_shape=None,
+        mesh_shape,
         device_ids=None,
         num_hw_cqs=None,
         enable_async_ttnn=None,
         enable_program_cache=None,
         l1_small_size=None,
         dispatch_core_type=None,
-    ):
+    ) -> tt_mlir.Device:
         """
-        Returns a list of available devices based on the specified mesh shape and options.
-        If no mesh shape is provided, returns all available devices in a 1D mesh.
+        Creates a new tt_mlir.Device object representing a parent mesh device.
         """
-        num_available = tt_mlir.get_num_available_devices()
-        if mesh_shape is None:
-            mesh_shape = [1, num_available]
-        if len(cls._devices) > 0:
-            assert cls._parent is not None, "Parent device is not set."
-            warnings.warn(
-                "Devices already created, returning existing devices."
-                "If you want to create new devices, please call release_devices() first."
-            )
-            return list(cls._devices)
-
+        num_available = cls.get_num_available_devices()
         assert len(mesh_shape) == 2, "Mesh shape must be a list of two integers."
         assert (
             mesh_shape[0] * mesh_shape[1] <= num_available
         ), "Mesh shape exceeds available devices."
-
         options = cls._get_parent_mesh_options(
             device_ids,
             num_hw_cqs,
@@ -79,43 +69,123 @@ class DeviceManager:
             l1_small_size,
             dispatch_core_type,
         )
-
-        # Secure a parent mesh device
-        cls._parent = tt_mlir.open_mesh_device(
-            mesh_shape=mesh_shape,
-            options=options,
-        )
-        num_devices = mesh_shape[0] * mesh_shape[1]
-        for i in range(num_devices):
-            sub_device = tt_mlir.create_sub_mesh_device(
-                cls._parent, mesh_shape=(1, 1), mesh_offset=(0, i)
-            )
-            cls._devices.add(sub_device)
-        return list(cls._devices)
+        parent_mesh = tt_mlir.open_mesh_device(mesh_shape=mesh_shape, options=options)
+        cls._devices[parent_mesh] = set()
+        return parent_mesh
 
     @classmethod
-    def release_devices(cls, device=None):
+    def get_parent_devices(cls) -> KeysView[tt_mlir.Device]:
         """
-        Releases the specified device.
-        If no device is specified, releases all currently acquired devices.
+        Returns a view of all acquired parent mesh devices.
         """
-        if device is None:
-            # If no device is specified, release all devices
-            for device in cls._devices:
-                tt_mlir.release_sub_mesh_device(device)
-            cls._devices.clear()
-        else:
-            if device in cls._devices:
-                tt_mlir.release_sub_mesh_device(device)
-                cls._devices.remove(device)
-            else:
-                warnings.warn(
-                    f"Device {device} not found in the list of managed devices. Ignoring it."
-                )
+        return cls._devices.keys()
 
-        if len(cls._devices) == 0:
+    @classmethod
+    def release_parent_device(
+        cls, parent_device: tt_mlir.Device, cleanup_sub_devices: bool = False
+    ):
+        """
+        Releases the specified parent mesh device.
+        """
+        assert parent_device in cls._devices, "Parent Device not found."
+        sub_devices = cls._devices[parent_device]
+        assert (
+            len(sub_devices) == 0 or cleanup_sub_devices
+        ), "Sub devices still exist under this parent mesh."
+        if cleanup_sub_devices:
+            for sub_device in sub_devices.copy():
+                cls.release_sub_mesh_device(sub_device, parent=parent_device)
+        tt_mlir.close_mesh_device(parent_device)
+        del cls._devices[parent_device]
+
+    @classmethod
+    def create_sub_mesh_device(
+        cls,
+        parent_mesh: tt_mlir.Device,
+        mesh_offset: tuple[int, int],
+        mesh_shape: tuple[int, int] = (1, 1),
+    ) -> tt_mlir.Device:
+        assert parent_mesh in cls._devices, "Parent mesh not found."
+        sub_device = tt_mlir.create_sub_mesh_device(
+            parent_mesh, mesh_shape, mesh_offset
+        )
+        cls._devices[parent_mesh].add(sub_device)
+        return sub_device
+
+    @classmethod
+    def get_sub_mesh_devices(
+        cls, parent_mesh: tt_mlir.Device
+    ) -> set[tt_mlir.Device] | dict[tt_mlir.Device, set[tt_mlir.Device]]:
+        """
+        Returns all acquired sub mesh devices under a given parent mesh device.
+        """
+        assert parent_mesh in cls._devices, "Parent mesh not found."
+        return cls._devices[parent_mesh]
+
+    @classmethod
+    def release_sub_mesh_device(
+        cls,
+        sub_device: tt_mlir.Device,
+        cleanup_parent: bool = False,
+        parent: tt_mlir.Device = None,
+    ):
+        """
+        Closes the specified sub_mesh device.
+        If cleanup_parent is True, it will also close the parent mesh device
+        if the sub device is the last one under that parent.
+        """
+        if parent is not None:
+            # Parent mesh is specified by caller, validate it
             assert (
-                cls._parent is not None
-            ), "Trying to release a non-existent parent device"
-            tt_mlir.close_mesh_device(cls._parent)
-            cls._parent = None
+                parent in cls._devices
+            ), "Parent mesh not found in the list of managed devices."
+            assert (
+                sub_device in cls._devices[parent]
+            ), "Sub device not found in the specified parent mesh."
+        else:
+            # Parent mesh is not specified, find it
+            for parent_mesh, sub_devices in cls._devices.items():
+                if sub_device in sub_devices:
+                    parent = parent_mesh
+                    break
+            assert parent is not None, "Sub device not found in any parent mesh."
+        tt_mlir.release_sub_mesh_device(sub_device)
+        cls._devices[parent].remove(sub_device)
+        if cleanup_parent:
+            if len(cls._devices[parent]) == 0:
+                tt_mlir.close_mesh_device(parent)
+                del cls._devices[parent]
+
+    @classmethod
+    def acquire_available_devices(
+        cls,
+        num_devices=None,
+        device_ids=None,
+        num_hw_cqs=None,
+        enable_async_ttnn=None,
+        enable_program_cache=None,
+        l1_small_size=None,
+        dispatch_core_type=None,
+    ) -> tuple[tt_mlir.Device, list[tt_mlir.Device]]:
+        """
+        Returns a list of available devices based on the specified mesh shape and options.
+        If no mesh shape is provided, returns all available devices in a 1D mesh.
+        """
+        num_available = tt_mlir.get_num_available_devices()
+        if num_devices is None:
+            num_devices = num_available
+        mesh_shape = [1, num_devices]
+
+        parent = cls.create_parent_mesh_device(
+            mesh_shape,
+            device_ids,
+            num_hw_cqs,
+            enable_async_ttnn,
+            enable_program_cache,
+            l1_small_size,
+            dispatch_core_type,
+        )
+
+        for i in range(num_devices):
+            cls.create_sub_mesh_device(parent, (0, i))
+        return (parent, list(cls._devices[parent]))

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -278,13 +278,8 @@ class CompilerConfig:
         self.check_all_ops_execute = False
         self._verify_op_by_op = False
         self.typecast_inputs = True
-        self.runtime_device = None
         self.cache_preprocessed_constants = False
         self.inline_parameters = False
-        self.mesh_device_shape = [1, 1]
-        self.mesh_device_options = MeshDeviceOptions()
-        self.mesh_device_options.enable_async_ttnn = False
-        self.is_sub_mesh_device = False
         self.record_property = None
         self.record_property = lambda *args, **kwargs: None  # Default to no-op
         self.runtime_intermediate_cache = None  # Do not serialize.
@@ -361,35 +356,6 @@ class CompilerConfig:
         if dump_intermediates:
             self.dump_debug = dump_intermediates == "DEBUG"
             self.dump_info = self.dump_debug or dump_intermediates == "INFO"
-
-    def initialize_device(self, device_ids=None, parent_mesh=None, sub_mesh_offset=None, sub_mesh_shape=[1, 1]):
-        assert self.runtime_device is None
-        if not self.is_sub_mesh_device:
-            if device_ids is None:
-                device_ids = [0]
-            self.mesh_device_shape = [1, len(device_ids)]
-            self.mesh_device_options.device_ids = device_ids
-            self.runtime_device = open_mesh_device(
-                self.mesh_device_shape, self.mesh_device_options
-            )
-        else:
-            assert parent_mesh is not None, "Parent mesh must be provided when creating a sub-mesh"
-            self.runtime_device = create_sub_mesh_device(parent_mesh, sub_mesh_shape, sub_mesh_offset)
-
-
-    def initialize_sub_mesh_device(self, parent_mesh, mesh_offset, mesh_shape = [1, 1]):
-        assert self.runtime_device is None
-        assert parent_mesh is not None
-        self.runtime_device = create_sub_mesh_device(parent_mesh, mesh_shape, mesh_offset)
-
-
-    def cleanup_device(self):
-        assert self.runtime_device is not None
-        if self.is_sub_mesh_device:
-            release_sub_mesh_device(self.runtime_device)
-        else:
-            close_mesh_device(self.runtime_device)
-        self.runtime_device = None
 
     def post_init(self):
         if self.consteval_parameters:

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -18,6 +18,8 @@ from onnxruntime import SessionOptions, InferenceSession
 from tt_mlir import (
     open_mesh_device,
     close_mesh_device,
+    create_sub_mesh_device,
+    release_sub_mesh_device,
     MeshDeviceOptions,
     is_runtime_debug_enabled,
 )
@@ -282,6 +284,7 @@ class CompilerConfig:
         self.mesh_device_shape = [1, 1]
         self.mesh_device_options = MeshDeviceOptions()
         self.mesh_device_options.enable_async_ttnn = False
+        self.is_sub_mesh_device = False
         self.record_property = None
         self.record_property = lambda *args, **kwargs: None  # Default to no-op
         self.runtime_intermediate_cache = None  # Do not serialize.
@@ -359,19 +362,33 @@ class CompilerConfig:
             self.dump_debug = dump_intermediates == "DEBUG"
             self.dump_info = self.dump_debug or dump_intermediates == "INFO"
 
-    def initialize_device(self, device_ids=None):
+    def initialize_device(self, device_ids=None, parent_mesh=None, sub_mesh_offset=None, sub_mesh_shape=[1, 1]):
         assert self.runtime_device is None
-        if device_ids is None:
-            device_ids = [0]
-        self.mesh_device_shape = [1, len(device_ids)]
-        self.mesh_device_options.device_ids = device_ids
-        self.runtime_device = open_mesh_device(
-            self.mesh_device_shape, self.mesh_device_options
-        )
+        if not self.is_sub_mesh_device:
+            if device_ids is None:
+                device_ids = [0]
+            self.mesh_device_shape = [1, len(device_ids)]
+            self.mesh_device_options.device_ids = device_ids
+            self.runtime_device = open_mesh_device(
+                self.mesh_device_shape, self.mesh_device_options
+            )
+        else:
+            assert parent_mesh is not None, "Parent mesh must be provided when creating a sub-mesh"
+            self.runtime_device = create_sub_mesh_device(parent_mesh, sub_mesh_shape, sub_mesh_offset)
+
+
+    def initialize_sub_mesh_device(self, parent_mesh, mesh_offset, mesh_shape = [1, 1]):
+        assert self.runtime_device is None
+        assert parent_mesh is not None
+        self.runtime_device = create_sub_mesh_device(parent_mesh, mesh_shape, mesh_offset)
+
 
     def cleanup_device(self):
         assert self.runtime_device is not None
-        close_mesh_device(self.runtime_device)
+        if self.is_sub_mesh_device:
+            release_sub_mesh_device(self.runtime_device)
+        else:
+            close_mesh_device(self.runtime_device)
         self.runtime_device = None
 
     def post_init(self):

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -168,6 +168,7 @@ def _verify_torch_module(
     input_range_int,
     compiler_config,
     do_assert,
+    device,
 ):
     if input_data_types is None:
         input_data_types = [torch.float32] * (
@@ -176,7 +177,10 @@ def _verify_torch_module(
 
     from tt_torch.dynamo.backend import backend  # avoid circular import
 
-    tt_mod = torch.compile(mod, backend=backend, options=compiler_config)
+    torch_options = {}
+    torch_options["compiler_config"] = compiler_config
+    torch_options["device"] = device
+    tt_mod = torch.compile(mod, backend=backend, options=torch_options)
     if inputs is None:
         if all([dtype.is_floating_point for dtype in input_data_types]):
             low, high = input_range
@@ -197,9 +201,7 @@ def _verify_torch_module(
             ]
 
     ret = tt_mod(*inputs)
-    print(f"Output of the compiled module: {ret}")
     golden = mod(*inputs)
-    print(f"Output of the original module: {golden}")
 
     if isinstance(golden, torch.Tensor):
         golden = (golden,)
@@ -291,6 +293,7 @@ def verify_module(
     input_range_int=(0, 1000),
     compiler_config=None,
     do_assert=True,
+    device=None,
 ):
 
     if isinstance(mod, torch.nn.Module):
@@ -308,6 +311,7 @@ def verify_module(
             input_range_int,
             compiler_config,
             do_assert,
+            device,
         )
     elif isinstance(mod, onnx.ModelProto):
         assert (

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -197,7 +197,9 @@ def _verify_torch_module(
             ]
 
     ret = tt_mod(*inputs)
+    print(f"Output of the compiled module: {ret}")
     golden = mod(*inputs)
+    print(f"Output of the original module: {golden}")
 
     if isinstance(golden, torch.Tensor):
         golden = (golden,)


### PR DESCRIPTION
### Ticket
[441](https://github.com/tenstorrent/tt-torch/issues/441)

### Problem description
Allow a user to acquire multiple devices (if using a multi-device board), and select what chip to use for a specific model run.

### What's changed
- Created a singleton class called DeviceManager that provides functions to enable creation of parent and sub-meshes. It also provides some basic validation to make sure that the sub-meshes being created fit into the capacity of the parent mesh.
    - Note: currently we just validate that the area defined by the sub-mesh shape is valid, not the actual configuration (such as by taking mesh_offset into account). This will be added in a future PR.
  
- Removed device management from `CompilerConfig`. This includes:
   - Removing `runtime_device`, `mesh_device_shape`, and `mesh_device_options` member variables
   - Removing the `initialize_device` and `cleanup_device` functions

- Changed the backend logic:
   - Each backend function now takes an additional argument for `device` (with the default being `None`)
   - If `device` remains None, then a single device will automatically be used for execution and the user will not have to do any manual device management.
   - Instead of the user now just providing the backend with only `compiler_config`, the user can optionally choose to provide a device as well via the `torch.compile` call.
   - In order to support this, the convention of passing options to `torch.compile` has changed.
      - Previously, the `options` sent to the backend was a `CompilerConfig` object:
         ```
         cc = CompilerConfig()
         tt_model = torch.compile(model, backend=backend, options=cc)
         ```
      - Now, `options` is a map with `"compiler_config"` and `"device"` being the optional keys:
         ```
         options = {}
         options["compiler_config"] = CompilerConfig()
         parent_mesh, devices = DeviceManager.acquire_available_devices()
         options["device"] = devices[0]
         tt_model = torch.compile(model, backend=backend, options=options)
         ...
         DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
         ```

### Checklist
- [x] New/Existing tests provide coverage for changes
