### PR TITLE
Replace PCC/ATOL invalid numeric values with -1

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -318,6 +318,22 @@ class ModelTester:
         else:
             raise ValueError(f"Current mode is not supported: {self.mode}")
 
+    def filter_nan_inf_for_record(self, metric_key):
+        metric_list = self.record_tag_cache.get(metric_key, [])
+        if metric_list:
+            metric_list = [
+                -1
+                if (isinstance(x, float) and x != x)
+                else -1  # NaN case
+                if (isinstance(x, float) and x == float("inf"))
+                else -1
+                if (isinstance(x, float) and x == -float("inf"))
+                else x
+                for x in metric_list
+                if isinstance(x, (int, float)) or isinstance(x, str)
+            ]
+        self.record_tag_cache[metric_key] = metric_list
+
     def record_aggregate_model_metric(self, metric_key, default_value=-1):
         # read a metric from the tag cache and write out the average and min values
 
@@ -359,6 +375,9 @@ class ModelTester:
 
     def finalize(self):
         # to be called at the end of the test
+
+        self.filter_nan_inf_for_record("pccs")
+        self.filter_nan_inf_for_record("atols")
 
         self.record_aggregate_model_metric("pccs")
         self.record_aggregate_model_metric("atols")


### PR DESCRIPTION
### Ticket
None

### Problem description
YoloV5 results are not being ingested by the database because the tags it generates are not parsable. This is because it generates a numeric infinite ATOL. 

Both the JSON and postgres spec "officially" do not support NaN or infinity values and those should be stripped from the reports.

### What's changed
Replace infinity and NaN values with -1 in PCC and ATOL. 

### Checklist
- [x] New/Existing tests provide coverage for changes
