### PR TITLE
Add Gliner

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -157,6 +157,11 @@ jobs:
               tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[op_by_op_torch-eval-lstm]
               tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[op_by_op_torch-eval-gru]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "gliner", tests: "
+              tests/models/gliner/test_gliner.py::test_gliner[op_by_op_torch-eval]
+              "
           }
         ]
     runs-on:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,7 +64,7 @@ jobs:
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
         echo "test_report_path_torch=report_torch_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
-        echo "test_report_path_mnist=report_mnist_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_check_all_ops_execute=report_check_all_ops_execute_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_onnx=report_onnx_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
 
@@ -127,20 +127,20 @@ jobs:
         name: test-reports-onnx-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path_onnx }}
 
-    - name: Run Mnist Op-By-Op and Check All Ops Execute
+    - name: Check All Ops Execute
       shell: bash
       run: |
         source env/activate
-        TT_TORCH_CHECK_ALL_OPS_EXECUTE=1 pytest -svv tests/models/mnist/test_mnist.py --op_by_op_torch \
-            --junit-xml=${{ steps.strings.outputs.test_report_path_mnist }} \
+        TT_TORCH_CHECK_ALL_OPS_EXECUTE=1 pytest -svv tests/models/MobileNetV2/test_MobileNetV2.py tests/models/mnist/test_mnist.py --op_by_op_torch \
+            --junit-xml=${{ steps.strings.outputs.test_report_path_check_all_ops_execute }} \
             --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
 
-    - name: Upload Test Report Mnist
+    - name: Upload Test Report - Check All Ops Execute
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-reports-mnist-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
-        path: ${{ steps.strings.outputs.test_report_path_mnist }}
+        name: test-reports-check-all-ops-execute-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.test_report_path_check_all_ops_execute }}
 
 
     - name: Show Test Report
@@ -168,6 +168,6 @@ jobs:
       continue-on-error: true
       uses: codecov/test-results-action@v1
       with:
-        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}, ${{ steps.strings.outputs.test_report_path_mnist }}
+        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}, ${{ steps.strings.outputs.test_report_path_check_all_ops_execute }}
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ scikit-build
 nanobind
 loguru
 seaborn
+gliner

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from gliner import GLiNER
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model = GLiNER.from_pretrained("urchade/gliner_largev2")
+        return model.predict_entities
+
+    def _load_inputs(self):
+        text = """
+        Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
+        """
+
+        labels = ["person", "award", "date", "competitions", "teams"]
+        return (text, labels)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_gliner(record_property, mode, op_by_op):
+    model_name = "gliner-v2"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group="red",
+    )
+    entities = tester.test_model()
+    if mode == "eval":
+        for entity in entities:
+            print(entity["text"], "=>", entity["label"])
+    tester.finalize()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -101,6 +101,10 @@ class ModelTester:
     def _extract_outputs(self, output_object):
         if isinstance(output_object, torch.Tensor):
             return (output_object,)
+        elif isinstance(output_object, (int, float)):
+            return (torch.tensor(output_object),)
+        elif isinstance(output_object, str):
+            return (output_object,)
         elif isinstance(output_object, (tuple, list)):
 
             def flatten_tensor_lists(obj):
@@ -343,12 +347,17 @@ class ModelTester:
         avg_metric = default_value
         min_metric = default_value
         max_metric = default_value
+        filtered_metrics = [
+            x for x in metric_list if x is not None
+        ]  # remove None values
 
-        if metric_list:  # check null or empty list
-            metric_list = [x for x in metric_list if isinstance(x, (int, float))]
-            avg_metric = sum(metric_list) / len(metric_list)
-            min_metric = min(metric_list)
-            max_metric = max(metric_list)
+        if filtered_metrics:  # check null or empty list
+            filtered_metrics = [
+                x for x in filtered_metrics if isinstance(x, (int, float))
+            ]
+            avg_metric = sum(filtered_metrics) / len(filtered_metrics)
+            min_metric = min(filtered_metrics)
+            max_metric = max(filtered_metrics)
 
         self.record_tag_cache["avg_" + metric_key] = avg_metric
         self.record_tag_cache["min_" + metric_key] = min_metric

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -172,9 +172,6 @@ class Executor:
         for input in inputs:
             # Handle scalar inputs.
             if not hasattr(input, "dtype"):
-                assert (
-                    type(input) is not bool
-                ), "Conversion for scalar boolean is not supported."
                 new_inputs = new_inputs + ((input),)
                 continue
 
@@ -349,29 +346,7 @@ class OpByOpExecutor(Executor):
                 transformed_inp = self.transform_input(inp)
                 if transformed_inp is not None:
                     processed_inputs.append(transformed_inp)
-
-        # Typecast the unsupported data types to hardware supported types.
-        supported_inputs = ()
-        for input in processed_inputs:
-            # Handle scalar inputs.
-            if not hasattr(input, "dtype"):
-                assert (
-                    type(input) is not bool
-                ), "Conversion for scalar boolean is not supported."
-                supported_inputs = supported_inputs + ((input),)
-                continue
-
-            # Apply type conversion if required.
-            input_type = input.dtype
-            if input_type in self.type_conversion.keys():
-                supported_inputs = supported_inputs + (
-                    (input.to(dtype=self.type_conversion[input_type])),
-                )
-                continue
-
-            # No conversion required.
-            supported_inputs = supported_inputs + ((input),)
-
+        supported_inputs = self.typecast_inputs(processed_inputs)
         return supported_inputs
 
     def get_input_shapes_and_constants(self, *inputs):

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -96,7 +96,7 @@ def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
 
     gm = bypass_redundant_getitem(gm)
 
-    reduce_graph(gm)
+    # reduce_graph(gm) - ISSUE: https://github.com/tenstorrent/tt-torch/issues/513
     program = torch.export.export(gm, tuple(example_inputs), strict=False)
     # The proper order of inputs when outlining everything is constants + parameters + buffers + example_inputs
     if not compiler_config.inline_parameters:

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -39,8 +39,27 @@ def verify_against_golden(
 
     # Distinct value to put in the `pccs` list so we can append the correct log
     SKIPPED_PCC_CALCULATION_FOR_SINGLE_VALUE = None
+    SKIPPED_NON_TENSOR_ITEM = None
 
     for i, (golden, calculated) in enumerate(zip(golden_tensors, calculated_tensors)):
+        if not isinstance(golden, torch.Tensor) or not isinstance(
+            calculated, torch.Tensor
+        ):
+            # For non-tensor items, check exact equality
+            if golden == calculated:
+                pccs.append(SKIPPED_NON_TENSOR_ITEM)
+                pcc_passeds.append(True)
+                atols.append(SKIPPED_NON_TENSOR_ITEM)
+                atol_thresholds.append(0)
+                atols_passeds.append(True)
+            else:
+                # Items don't match
+                pccs.append(SKIPPED_NON_TENSOR_ITEM)
+                pcc_passeds.append(False)
+                atols.append(SKIPPED_NON_TENSOR_ITEM)
+                atol_thresholds.append(0)
+                atols_passeds.append(False)
+            continue
         assert (
             golden.shape == calculated.shape
         ), f"Shape mismatch on output {i}: {golden.shape} vs {calculated.shape}"
@@ -83,7 +102,10 @@ def verify_against_golden(
     ):
         msg = msg + f"Results for output {i}:\n"
         if pcc_passed:
-            if pcc_ != SKIPPED_PCC_CALCULATION_FOR_SINGLE_VALUE:
+            if (
+                pcc_ != SKIPPED_PCC_CALCULATION_FOR_SINGLE_VALUE
+                or pcc_ != SKIPPED_NON_TENSOR_ITEM
+            ):
                 msg = msg + f"  PCC: {pcc_:0,.4f}, threshold: {required_pcc} "
                 msg = msg + f"{check_mark}\n"
         else:
@@ -95,11 +117,13 @@ def verify_against_golden(
             )
             passed_pcc = False
 
-        msg = (
-            msg
-            + f"  ATOL: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} "
-        )
         if atol_passed:
+            if atol_ != SKIPPED_NON_TENSOR_ITEM:
+                msg = (
+                    msg
+                    + f"  ATOL: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} "
+                )
+                msg = msg + f"{check_mark}\n"
             msg = msg + f"{check_mark}\n"
         else:
             msg = msg + f"{red_x if assert_atol else atol_warning}\n"


### PR DESCRIPTION
Add urchade/gliner_large-v2 #424

Added to op-by-op-flow.

This model unearthed an issue with reduce_graph #513

Fixed typecast_inputs:
- using typecast_inputs before tt_mlir.run_op
- leaving scalar inputs, including booleans, as is

### Ticket
#424

### Problem description
Add urchade/gliner_large-v2 to op by op flow
This model unearthed an issue with reduce_graph #513 

### What's changed
- Added `MobileNetV2` to "Check All Ops Execute" test
- Added `int`, `float`, `str` support to `extract_outputs`
- Changed typecast inputs to not skip scalar booleans
- Edited `verify_against_golden` to support gliner output format, i.e.

```
(tensor(44), 'person', tensor(0.8770), tensor(9), 'Cristiano Ronaldo dos Santos Aveiro', tensor(115), 'date', tensor(0.9673), tensor(100), '5 February 1985', tensor(357), 'award', tensor(0.7488), tensor(346), "Ballon d'Or", tensor(425), 'award', tensor(0.9330), tensor(389), "UEFA Men's Player of the Year Awards", tensor(457), 'award', tensor(0.9340), tensor(436), 'European Golden Shoes', tensor(586), 'competitions', tensor(0.5432), tensor(564), 'UEFA Champions Leagues', tensor(646), 'competitions', tensor(0.7276), tensor(627), 'UEFA Nations League')
```

### Checklist
- Add `tests/models/gliner/test_gliner.py`
- Add `gliner` to `requirements.txt`
- Add `gliner` to op-by-op nightly tests
