### PR TITLE
Add new model test_bi_lstm_crf.py w/ BiRnnCrf model (GRU/LSTM RNN variants)

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -151,6 +151,12 @@ jobs:
             runs-on: wormhole_b0, name: "phi", tests: "
               tests/models/phi/test_phi_1_1p5_2.py::test_phi[op_by_op_torch-microsoft/phi-2-eval]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "bi_lstm_crf", tests: "
+              tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[op_by_op_torch-eval-lstm]
+              tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[op_by_op_torch-eval-gru]
+              "
           }
         ]
     runs-on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
 black
+bi-lstm-crf
 mdutils
 ninja
 pre-commit

--- a/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
+++ b/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+from bi_lstm_crf import BiRnnCrf
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def __init__(self, *args, rnn_type="lstm", **kwargs):
+
+        # Some arbitrary sanity test values, and configurable rnn.
+        self.model_config = {
+            "rnn_type": rnn_type.lower(),
+            "vocab_size": 30000,
+            "tagset_size": 20,
+            "embedding_dim": 256,
+            "hidden_dim": 512,
+            "num_rnn_layers": 2,
+        }
+
+        super(ThisTester, self).__init__(*args, **kwargs)
+
+    def _load_model(self):
+        # Create the model with random weights
+        model = BiRnnCrf(
+            vocab_size=self.model_config["vocab_size"],
+            tagset_size=self.model_config["tagset_size"],
+            embedding_dim=self.model_config["embedding_dim"],
+            hidden_dim=self.model_config["hidden_dim"],
+            num_rnn_layers=self.model_config["num_rnn_layers"],
+            rnn=self.model_config["rnn_type"],
+        )
+
+        return model
+
+    def _load_inputs(self):
+        # Generate random token ids within vocabulary range
+        batch_size = 4
+        seq_length = 16
+        input_ids = torch.randint(
+            0, self.model_config["vocab_size"], (batch_size, seq_length)
+        )
+        return input_ids
+
+
+@pytest.mark.parametrize(
+    "rnn_type",
+    ["lstm", "gru"],
+    ids=["lstm", "gru"],
+)
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_bi_lstm_crf(record_property, rnn_type, mode, op_by_op):
+    model_name = f"BiRnnCrf-{rnn_type.upper()}"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        rnn_type=rnn_type,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group="red",
+    )
+
+    results = tester.test_model()
+    emissions, best_tag_sequence = results
+
+    print(
+        f"""
+        Model: {model_name}
+        Input shape: {tester.inputs.shape}
+        Output:
+          - Emissions shape: {emissions.shape}
+          - Best tag sequence length: {len(best_tag_sequence[0])}
+        """
+    )
+
+    tester.finalize()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -110,6 +110,8 @@ class ModelTester:
                         flattened.append(item)
                     elif isinstance(item, (np.ndarray)):
                         flattened.append(torch.from_numpy(item))
+                    elif np.isscalar(item):
+                        flattened.append(torch.tensor(item))
                     elif isinstance(item, (tuple, list)):
                         flattened.extend(flatten_tensor_lists(item))
                     else:

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -76,6 +76,8 @@ def verify_against_golden(
     passed_atol = True
     err_msg = ""
     msg = ""
+
+    # Iterate over all tensors and their results and build a message for printing.
     for i, ((pcc_passed, pcc_), (atol_passed, atol_), atol_threshold) in enumerate(
         zip(zip(pcc_passeds, pccs), zip(atols_passeds, atols), atol_thresholds)
     ):
@@ -108,25 +110,26 @@ def verify_against_golden(
             )
             passed_atol = False
 
-        if assert_pcc and assert_atol:
-            if passed_pcc and passed_atol:
-                print(msg)
-            else:
-                assert False, err_msg
-        elif not assert_pcc and assert_atol:
-            print("Ignoring PCC check\n")
-            if passed_atol:
-                print(msg)
-            else:
-                assert False, err_msg
-        elif assert_pcc and not assert_atol:
-            print("Ignoring ATOL check\n")
-            if passed_pcc:
-                print(msg)
-            else:
-                assert False, err_msg
-        else:
+    # Now that all tensors are checked, print the final message
+    if assert_pcc and assert_atol:
+        if passed_pcc and passed_atol:
             print(msg)
+        else:
+            assert False, err_msg
+    elif not assert_pcc and assert_atol:
+        print("Ignoring PCC check\n")
+        if passed_atol:
+            print(msg)
+        else:
+            assert False, err_msg
+    elif assert_pcc and not assert_atol:
+        print("Ignoring ATOL check\n")
+        if passed_pcc:
+            print(msg)
+        else:
+            assert False, err_msg
+    else:
+        print(msg)
 
     return pccs, atols, passed_pcc, passed_atol
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/422

### What's changed
 - Add the new test and bi-lstm-crf to requirements.txt and import BiRnnCrf class
 - Test both rnn=lstm/gru variants, arguable if necessary, same ops, add both to nightly op-by-op yml. Some ops fail compile.
 - Fix to add np.isscalar(item) support to flatten_tensor_lists() needed by best_tag_sequence output from model
 - Fix verify_against_golden() typo with printing msg while building it
### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Passes locally and CI https://github.com/tenstorrent/tt-torch/actions/runs/14322315592/job/40141758284
