### PR TITLE
Lock down setuptools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ transformers==4.47.1
 protobuf
 tiktoken
 sentencepiece
-setuptools
+setuptools==77.0.3
 pytorchcv
 diffusers
 scipy


### PR DESCRIPTION
### Problem description
Wheel pypi release was upgraded breaking build.

### What's changed
Locked down setuptools version

### Checklist
- [x] New/Existing tests provide coverage for changes
