### PR TITLE
Fix incorrect reporting of Full Execute isolated pytest success

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -184,7 +184,7 @@ jobs:
         failure=0
 
         # Split the test string into individual tests and run them one by one
-        echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
+        while read -r test; do
           if [[ -n "$test" ]]; then
             echo "Running test: $test"
             report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
@@ -200,7 +200,8 @@ jobs:
               failure=1
             fi
           fi
-        done
+        # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved
+        done < <(echo "${{ matrix.build.tests }}" | tr ' ' '\n')
 
         set -e
 

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -173,21 +173,13 @@ jobs:
             report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
             echo "JUnitXML will be logged to $report_file"
 
-            # pytest --durations=0 -v "$test" \
-            #   --junit-xml="$report_file" \
-            #   --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+            pytest --durations=0 -v "$test" \
+              --junit-xml="$report_file" \
+              --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
 
-            # Randomly decide the exit code
-            if (( RANDOM % 2 == 0 )); then
-                echo "Simulating failure for test: $test"
-                ec=1
-            else
-                echo "Simulating success for test: $test"
-                ec=0  # Simulate success
-            fi
 
-            # Check the return code of pytest (TODO FIX)
-            if [[ $ec -ne 0 ]]; then
+            # Check the return code of pytest
+            if [[ $? -ne 0 ]]; then
               echo "Test failed: $test"
               failure=1
             fi

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -164,6 +164,8 @@ jobs:
 
         failure=0
 
+        ec=0
+
         # Split the test string into individual tests and run them one by one
         echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
           if [[ -n "$test" ]]; then
@@ -171,11 +173,21 @@ jobs:
             report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
             echo "JUnitXML logged to $report_file"
 
-            pytest --durations=0 -v "$test" \
-              --junit-xml="$report_file" \
-              --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+            # pytest --durations=0 -v "$test" \
+            #   --junit-xml="$report_file" \
+            #   --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+
+            # Randomly decide the exit code
+            if (( RANDOM % 2 == 0 )); then
+                echo "Simulating failure for test: $test"
+                ec=1
+            else
+                echo "Simulating success for test: $test"
+                ec=0  # Simulate success
+            fi
+
             # Check the return code of pytest
-            if [[ $? -ne 0 ]]; then
+            if [[ $ec -ne 0 ]]; then
               echo "Test failed: $test"
               failure=1
             fi

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -167,11 +167,11 @@ jobs:
         ec=0
 
         # Split the test string into individual tests and run them one by one
-        echo "${{ matrix.build.tests }}" | tr ' ' '\n' | while read -r test; do
+        while read -r test; do
           if [[ -n "$test" ]]; then
             echo "Running test: $test"
             report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
-            echo "JUnitXML logged to $report_file"
+            echo "JUnitXML will be logged to $report_file"
 
             # pytest --durations=0 -v "$test" \
             #   --junit-xml="$report_file" \
@@ -186,13 +186,14 @@ jobs:
                 ec=0  # Simulate success
             fi
 
-            # Check the return code of pytest
+            # Check the return code of pytest (TODO FIX)
             if [[ $ec -ne 0 ]]; then
               echo "Test failed: $test"
               failure=1
             fi
           fi
-        done
+        # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved
+        done < <(echo "${{ matrix.build.tests }}" | tr ' ' '\n')
 
         set -e
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Full model execution tests were converted to run in isolated pytest processes in #562. They have not been correctly reporting job failure status due to "failure" variable subshell variable scope.

### What's changed
Avoid running bash loop in a subshell so that the "failure" variable is set in the global context.

### Checklist
- [x] Ran tests with simulated failures, with and without this change, to verify it fixes the issue
