### PR TITLE
Misc Changes: change falcon model_group, add MobileNetV2_onnx suffix, generate_md.py capture errors

### DIFF
--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -45,7 +45,7 @@ class ThisTester(OnnxModelTester):
 )
 @pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
 def test_MobileNetV2(record_property, mode, op_by_op):
-    model_name = "MobileNetV2"
+    model_name = "MobileNetV2_onnx"
     cc = CompilerConfig()
     cc.compile_depth = CompileDepth.STABLEHLO
     if op_by_op:

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -53,7 +53,6 @@ def test_falcon(record_property, mode, op_by_op):
         relative_atol=0.015,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group="red",
     )
     results = tester.test_model()
 

--- a/tt_torch/tools/generate_md.py
+++ b/tt_torch/tools/generate_md.py
@@ -135,10 +135,10 @@ class AllOps:
         for index, row in df_cleaned.iterrows():
             # Remove quotes from Raw TTNNIR if present
             raw_ttnnir = row["Raw TTNNIR"].strip("'\"")
+            compile_error = row.get("Compile Error", "")
 
             # If outputing failures only, skip if row is empty, Nan, or "Error message not extracted."
             if failures_only:
-                compile_error = row.get("Compile Error", "")
                 if (
                     pd.isna(compile_error)
                     or str(compile_error).strip() == ""
@@ -152,9 +152,9 @@ class AllOps:
             status = row["Status"]
 
             # Process operation details
-            self.process_ops(raw_ttnnir, pcc, atol, status)
+            self.process_ops(raw_ttnnir, pcc, atol, status, compile_error)
 
-    def process_ops(self, ttnnir_string, pcc, atol, status):
+    def process_ops(self, ttnnir_string, pcc, atol, status, compile_error):
         """
         Process TTNN operations from an IR string, extracting shapes, layouts, and metadata.
 
@@ -163,6 +163,7 @@ class AllOps:
             pcc: Percent Correct Classification metric
             atol: Absolute tolerance for numerical comparisons
             status: Compilation status for the op
+            compile_error: Optional compile error for the op, if there was one
         """
 
         ttnn_parser = TTNNOps(ttnnir_string)
@@ -232,6 +233,7 @@ class AllOps:
             opToWrite["pcc"] = pcc
             opToWrite["atol"] = atol
             opToWrite["status"] = status
+            opToWrite["compile_error"] = compile_error
             if self.ops.get(opToWrite["name"]) is None:
                 self.ops[opToWrite["name"]] = [opToWrite]
             else:
@@ -317,6 +319,7 @@ class AllOps:
                     "N/A" if pd.isna(item.get("atol")) else str(item.get("atol", "N/A"))
                 )
                 status = item.get("status", "N/A")
+                compile_error = item.get("compile_error", "")
 
                 input_layouts = item.get("input_layouts", [])
                 processed_input_layouts = [
@@ -350,6 +353,7 @@ class AllOps:
                     "pcc": pcc,
                     "atol": atol,
                     "compilation_status": status,
+                    "compile_error": compile_error,
                 }
 
                 processed_items.append(processed_item)


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Update test_falcon.py to not have model_group=red, that is intended for falcon3 which we haven't added yet.
 - Allow generate_md.py to include compile_error in generated json useful for converting to ttnn conv2d sweep configs soon.
 - Deduplicate MobileNetV2 tests by applying suffix MobileNetV2_onnx

### Checklist
- [ ] New/Existing tests provide coverage for changes
