### PR TITLE
Downgrade to Python 3.10

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-venv \
     python3-pip \
-    python3.11-dev \
-    python3.11-venv \
+    python3.10-dev \
+    python3.10-venv \
     git \
     git-lfs \
     libhwloc-dev \
@@ -37,10 +37,10 @@ RUN apt-get update && apt-get install -y \
     libglx-mesa0
 
 # Install python3.11 packages
-RUN python3.11 -m pip install \
+RUN python3.10 -m pip install \
     setuptools==59.6.0 \
     wheel \
-    torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
+    torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -30,7 +30,7 @@ RUN git clone https://github.com/pytorch/vision.git && \
     cd vision && \
     git checkout v0.21.0 && \
     TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang \
-    CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python3.11 setup.py bdist_wheel && \
+    CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python3.10 setup.py bdist_wheel && \
     cp dist/*.whl $TTTORCH_DIST_DIR && \
     cd .. && \
     rm -rf vision

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -6,7 +6,7 @@ Main project dependencies are:
  - Ninja
  - CMake >= 3.30
  - git LFS
- - python 0
+ - python 3.10
 
 On Ubuntu 22.04 systems these can be installed using the following commands:
 

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -6,7 +6,7 @@ Main project dependencies are:
  - Ninja
  - CMake >= 3.30
  - git LFS
- - python 3.11
+ - python 0
 
 On Ubuntu 22.04 systems these can be installed using the following commands:
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -2,17 +2,17 @@
 
 ## System Dependencies
 
-`tt-torch` requires the python 3.11 dev package, as well as the venv package. If not already installed, please run the following:
+`tt-torch` requires the python 3.10 dev package, as well as the venv package. If not already installed, please run the following:
 
 ```bash
-sudo apt-get install python3.11-dev python3.11-venv
+sudo apt-get install python3.10-dev python3.10-venv
 ```
 
 ## Creating a Virtual Environment (skip if you already have one)
 
 Create a virtual environment if you do not already have one in your project:
 ```bash
-python3.11 -m venv myvenv
+python3.10 -m venv myvenv
 ```
 This will create a virtual environemnt in the folder `myvenv` in the current directory.
 
@@ -26,7 +26,7 @@ source myvenv/bin/activate
 ### Installation Notes
 - `tt-torch` requires a pytorch installation that ships with their ABI.
     - The `tt-torch` wheel lists the following version of torch as an installation requirement:
-      `torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl`
+      `torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl`
     - This will be installed by pip upon installing the `tt-torch` wheel
 - The `tt-torch` wheel contains a fork of `torch-mlir`. Please ensure that `torch-mlir` has not been installed in your venv before installing the `tt-torch` wheel.
 
@@ -43,7 +43,7 @@ cd vision
 git checkout v0.20.0 # tt-torch requires PyTorch 2.5.0. torchvision 0.20 is the latest version of torchvision that is compatible with PyTorch 2.5.0
 pip uninstall -y torchvision # Ensure torchvision is not in your virtual environment
 pip install wheel
-pip install torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
+pip install torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.5.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl
 TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python setup.py bdist_wheel
 pip install dist/torchvision*.whl --force-reinstall
 ```

--- a/env/activate
+++ b/env/activate
@@ -10,24 +10,24 @@ if [ -z "$TTMLIR_TOOLCHAIN_DIR" ]; then
   export TTMLIR_TOOLCHAIN_DIR="/opt/ttmlir-toolchain/"
 fi
 if command -v sudo > /dev/null 2>&1; then
-  sudo apt-get install -y python3.11-dev python3.11-venv
+  sudo apt-get install -y python3.10-dev python3.10-venv
 else
-  apt-get install -y python3.11-dev python3.11-venv
+  apt-get install -y python3.10-dev python3.10-venv
 fi
 
 export TT_TORCH_HOME="$(pwd)"
-export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRRARY_PATH
+export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.10/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRRARY_PATH
 
 export TTMLIR_VENV_DIR="$(pwd)/env/venv"
 if [ -d $TTMLIR_VENV_DIR/bin ]; then
   [ -f $TTMLIR_VENV_DIR/bin/activate ] && source $TTMLIR_VENV_DIR/bin/activate
 else
   echo "Creating virtual environment in $TTMLIR_VENV_DIR"
-  python3.11 -m venv $TTMLIR_VENV_DIR
+  python3.10 -m venv $TTMLIR_VENV_DIR
   source $TTMLIR_VENV_DIR/bin/activate
   pip install --upgrade pip
 
-  python3.11 -m pip install -r requirements.txt
+  python3.10 -m pip install -r requirements.txt
 
   mkdir -p $TT_TORCH_HOME/dist
   if [ -n "$TTTORCH_DIST_DIR" ]; then
@@ -40,7 +40,7 @@ else
     cd vision
     git checkout v0.21.0
     pip uninstall -y torchvision
-    TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python setup.py bdist_wheel
+    TORCHVISION_USE_VIDEO_CODEC=0 TORCHVISION_USE_FFMPEG=0 CC=clang CXX=clang++ _GLIBCXX_USE_CXX11_ABI=1 USE_CUDA=OFF python3.10 setup.py bdist_wheel
 
     cp dist/*.whl $TT_TORCH_HOME/dist
     cd ..
@@ -53,7 +53,7 @@ else
 fi
 export TTTORCH_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1
-export PATH=$TT_TORCH_HOME/third_party/tt-mlir/src/tt-mlir-build/bin:$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/tt_mlir:$TTMLIR_TOOLCHAIN_DIR/bin:$PATH
+export PATH=$TT_TORCH_HOME/third_party/tt-mlir/src/tt-mlir-build/bin:$TT_TORCH_HOME/env/venv/lib/python3.10/site-packages/tt_mlir:$TTMLIR_TOOLCHAIN_DIR/bin:$PATH
 export TOKENIZERS_PARALLELISM=false
 if [ -n "$PROJECT_ROOT" ]; then
     export TT_METAL_HOME="$PROJECT_ROOT/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl
+torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl
 black
 bi-lstm-crf
 mdutils

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        "torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl",
+        "torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl",
         "numpy",
     ],
 )

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.11/site-packages/pybind11)
-find_package(Python 3.11 REQUIRED COMPONENTS Interpreter Development.Module)
+list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site-packages/pybind11)
+find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
 
@@ -37,7 +37,7 @@ target_link_directories(TT_TORCH_MLIR PUBLIC
     ${TTMLIR_INSTALL_PREFIX}/lib
 )
 
-set(TORCH_INSTALL_PREFIX ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.11/site-packages/torch)
+set(TORCH_INSTALL_PREFIX ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site-packages/torch)
 set(CMAKE_PREFIX_PATH ${TORCH_INSTALL_PREFIX})
 
 find_package(Torch REQUIRED)

--- a/tt_torch/tools/profile_util.py
+++ b/tt_torch/tools/profile_util.py
@@ -95,14 +95,14 @@ class Profiler:
         # For a wheel build, the binaries are in site-packages and need to be properly copied
         else:
             print("Perf tool binaries not found - Installing from wheel.")
-            # expected to be @ env/venv/lib/python3.11/site-packages/tt_metal/tools/profiler/bin/[...]
+            # expected to be @ env/venv/lib/python3.10/site-packages/tt_metal/tools/profiler/bin/[...]
             # in this context the tt_metal_home is at /env/venv/tt_metal
 
             site_packages_dir = os.path.join(
                 self.get_ttmetal_home_path(),
                 "..",
                 "lib",
-                "python3.11",
+                "python3.10",
                 "site-packages",
                 "tt_metal",
                 "tools",


### PR DESCRIPTION
### Ticket
None

### Problem description
We are using python 3.11 and that does not align with other tt-forge frontends.

### What's changed
Downgrade project to python 3.10.

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Swept on PR and subset of nightlies to ensure no obvious breaks or regressions
