### PR TITLE
Prevent torch.hub.load ND rate limiting errors

### DIFF
--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -17,6 +17,7 @@ class ThisTester(ModelTester):
         The model is from https://github.com/facebookresearch/detr
         """
         # Model
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         model = torch.hub.load(
             "facebookresearch/detr:main", "detr_resnet50", pretrained=True
         ).to(torch.bfloat16)

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -15,6 +15,7 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         model = torch.hub.load("PingoLH/Pytorch-HarDNet", "hardnet68", pretrained=False)
         checkpoint = "https://github.com/PingoLH/Pytorch-HarDNet/raw/refs/heads/master/hardnet68.pth"
         model.load_state_dict(

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -15,6 +15,7 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         model = torch.hub.load(
             "mateuszbuda/brain-segmentation-pytorch",
             "unet",

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -17,6 +17,7 @@ class ThisTester(ModelTester):
         Test UNet for brain MRI segmentation
         The model is from https://pytorch.org/hub/mateuszbuda_brain-segmentation-pytorch_unet/
         """
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
         model = torch.hub.load(
             "mateuszbuda/brain-segmentation-pytorch",
             "unet",


### PR DESCRIPTION
### Ticket
#607 

### Problem description
Random torchhub 403 rate limiting errors have been showing up in CI for the past few days.

### What's changed
Add as seen in yolov5 test, add torch.hub._validate_not_a_forked_repo = lambda a, b, c: True to overload a check that's consuming the rate limit.

### Checklist
- [x] New/Existing tests provide coverage for changes
