### PR TITLE
Add Turkish Bert #598

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -63,6 +63,7 @@ jobs:
                   tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small[full-eval]
                   tests/models/yolos/test_yolos.py::test_yolos[full-eval]
                   tests/models/whisper/test_whisper.py::test_whisper[full-eval]
+                  tests/models/bert/test_bert_turkish.py::test_bert_turkish[full-eval]
             "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -41,6 +41,7 @@ jobs:
             runs-on: wormhole_b0, name: "bert", tests: "
               tests/models/distilbert/test_distilbert.py::test_distilbert
               tests/models/bert/test_bert.py::test_bert
+              tests/models/bert/test_bert_turkish.py::test_bert_turkish
               tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert
               "
           },

--- a/tests/models/bert/test_bert_turkish.py
+++ b/tests/models/bert/test_bert_turkish.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from transformers import AutoTokenizer, AutoModel
+
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model_name = "emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_name, torch_dtype=torch.bfloat16
+        )
+        model = AutoModel.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+        return model
+
+    def _load_inputs(self):
+        sentences = ["Bu örnek bir cümle", "Her cümle vektöre çevriliyor"]
+        self.input = self.tokenizer(
+            sentences, padding=True, truncation=True, return_tensors="pt"
+        )
+        return self.input
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_bert_turkish(record_property, mode, op_by_op):
+    model_name = "BERT_Turkish"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group="red",
+    )
+    with torch.no_grad():
+        results = tester.test_model()
+
+    if mode == "eval":
+
+        def mean_pooling(model_output, attention_mask):
+            token_embeddings = model_output[
+                0
+            ]  # First element of model_output contains all token embeddings
+            input_mask_expanded = (
+                attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            )
+            return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(
+                input_mask_expanded.sum(1), min=1e-9
+            )
+
+        sentence_embeddings = mean_pooling(results, tester.input["attention_mask"])
+
+        print("Sentence embeddings:")
+        print(sentence_embeddings)
+
+    tester.finalize()


### PR DESCRIPTION
### Ticket
#598 

### Problem description
Add Turkish Bert from https://huggingface.co/emrecan/bert-base-turkish-cased-mean-nli-stsb-tr
Created a standalone test since the inputs are Turkish, not English (as the original Bert test)

### Checklist
- [X] Added `tests/models/bert/test_bert_turkish.py`
- [X] Added `test_bert_turkish` to nightly execution test (`.github/workflows/run-full-model-execution-tests-nightly.yml`) and weekly op-by-op test (`.github/workflows/run-op-by-op-model-tests-weekly.yml`)
