### PR TITLE
Add add_onnx_model_proto to stablehlo backend #543

### DIFF
--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -24,9 +24,6 @@ class ThisTester(OnnxModelTester):
         os.remove(f"{self.model_name}.onnx")
         return model
 
-    def _extract_outputs(self, output_object):
-        return (torch.from_numpy(output_object),)
-
     def _load_torch_inputs(self):
         # Define a transformation to preprocess the input image using the weights transforms
         preprocess = self.weights.transforms()

--- a/tt_torch/onnx_compile/onnx_compile.py
+++ b/tt_torch/onnx_compile/onnx_compile.py
@@ -88,6 +88,7 @@ def compile_onnx(model_proto: onnx.ModelProto, compiler_config: CompilerConfig =
         module = torch_onnx_to_torch_backend_ir(module, compiler_config)
         module = torch_backend_ir_to_stablehlo(module, compiler_config)
         executor = StablehloExecutor(module=module, compiler_config=compiler_config)
+        executor.add_onnx_model_proto(model_proto)
         return executor
     else:
         model_proto = onnx.shape_inference.infer_shapes(model_proto)


### PR DESCRIPTION
### Ticket
#543 

### Problem description
When we are running an onnx model with stablehlo backend in an op-by-op flow, we rely on the binary flatbuffer generated by the last op to generate an output. However, this is unreliable in cases where last op doesn't compile or run. 

### What's changed
Added support for running an onnx model proto from the stablehlo executor. This entailed restructuring onnx code so that there are 3 essential methods:
- `prepare_inference_session`: Created an onnx inference session and sets number of threads to use to avoid info messages clobbering the output.
- `run_model_proto`: runs an onnx model proto
- `onnx_output_to_torch`: standardized all backends to return a torch output, and this method helps convert onnx output (a numpy object) to a torch object

Added `add_onnx_model_proto` to `StablehloExecutor` which sets the model_proto object.

Assumed that onnx output should be torch by default, thereby making `_extract_outputs` not needed for casting numpy to torch.
