### PR TITLE
Get system descriptor for opened device

### DIFF
--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -260,18 +260,6 @@ std::vector<at::Tensor> run_end_to_end(std::vector<at::Tensor> &inputs,
   return outputs;
 }
 
-tt::runtime::Device
-open_mesh_device(const std::vector<uint32_t> &mesh_shape,
-                 const tt::runtime::MeshDeviceOptions &options) {
-  const char *system_desc_path = std::getenv("SYSTEM_DESC_PATH");
-  if (system_desc_path) {
-    std::remove(system_desc_path);
-    tt::runtime::getCurrentSystemDesc().first.store(system_desc_path);
-  }
-
-  return tt::runtime::openMeshDevice(mesh_shape, options);
-}
-
 PYBIND11_MODULE(tt_mlir, m) {
   m.doc() = "tt_mlir";
   py::class_<tt::runtime::Binary>(m, "Binary")
@@ -320,7 +308,7 @@ PYBIND11_MODULE(tt_mlir, m) {
         "A function that compiles TTIR to a bytestream");
   m.def("compile_stable_hlo_to_ttir", &compile_stable_hlo_to_ttir,
         "A function that compiles stableHLO to TTIR");
-  m.def("open_mesh_device", &open_mesh_device, py::arg("mesh_shape"),
+  m.def("open_mesh_device", &tt::runtime::openMeshDevice, py::arg("mesh_shape"),
         py::arg("options"),
         "Open a mesh of devices for execution using the new API and create "
         "system description");

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdlib>
-#include <filesystem>
 #include <iostream>
 
 #include "tt-mlir-interface.hpp"
@@ -133,27 +132,11 @@ compileTTIRToTTNN(std::string_view code) {
   }
   mlir::tt::ttnn::TTIRToTTNNBackendPipelineOptions options;
 
-  if (std::filesystem::path system_desc_path = std::getenv("SYSTEM_DESC_PATH");
-      !system_desc_path.empty() && std::filesystem::exists(system_desc_path)) {
-
-    // TODO: avoid copying to temp file and create system desc every time
-    // https://github.com/tenstorrent/tt-torch/issues/580
-    std::filesystem::path system_desc_temp_path =
-        std::filesystem::temp_directory_path() /
-        (system_desc_path.stem().string() + "_tmp" +
-         system_desc_path.extension().string());
-
-    std::filesystem::copy_file(
-        system_desc_path, system_desc_temp_path,
-        std::filesystem::copy_options::overwrite_existing);
-
-    options.systemDescPath = system_desc_temp_path;
-  } else { // SYSTEM_DESC_PATH is not set or the file does not exist
-    std::cout << "WARNING: "
-              << (system_desc_path.empty()
-                      ? "SYSTEM_DESC_PATH environment variable is not set"
-                      : "The file in SYSTEM_DESC_PATH does not exist")
-              << ". Default system description will be used instead.\n";
+  if (const char *system_desc_path = std::getenv("SYSTEM_DESC_PATH");
+      system_desc_path) {
+    std::remove(system_desc_path);
+    tt::runtime::getCurrentSystemDesc().first.store(system_desc_path);
+    options.systemDescPath = system_desc_path;
   }
 
   mlir::tt::ttnn::createTTIRToTTNNBackendPipeline(pm, options);


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/580

### Problem description
We couldn't create a system descriptor from tt-mlir while having the device open before.
But now that the function `getCurrentSystemDesc` allows opened device to be passed in, we can use it.
This will be useful for multidevice to make sure we pass system descriptor of the device being used for that workload.

### What's changed
- Create a new system desc for every compilation.
- Pass in device being used to get system desc for that device.

### Checklist
- [ ] New/Existing tests provide coverage for changes
