### PR TITLE
remove flux models from nightly CI runs due to large size of models

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -165,12 +165,6 @@ jobs:
             runs-on: wormhole_b0, name: "OFT", tests: "
               tests/models/oft/test_oft.py::test_oft[op_by_op_torch-eval]
               "
-          },
-          {
-            runs-on: wormhole_b0, name: "Flux", tests: "
-              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_schnell-eval]
-              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_dev-eval]
-              "
           }
         ]
     runs-on:

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -115,6 +115,7 @@ model_info_list = [
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_flux(record_property, model_info, mode, op_by_op):
+    pytest.skip("Large Models can't fit on device for CI")
     _, model_name = model_info
 
     cc = CompilerConfig()


### PR DESCRIPTION
### Ticket
Follow up to #617 

### Problem description
Flux models are 30GB+ and are being cached in CI machines causing them to crash from memory limitations, we will remove models from testing pool until we find a fix for large model caching

### What's changed
removing schnell and dev Flux models from test pool

### Checklist
- [x] New/Existing tests provide coverage for changes
