### PR TITLE
Various op-by-op flow rerun/debug/reporting changes to improve quality of life including global_op_idx

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   tests:
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -34,10 +34,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "bert", tests: "
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "falcon", tests: "
               tests/models/falcon/test_falcon.py::test_falcon
               "

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -753,8 +753,16 @@ def generate_op_reports_xlsx():
                             capture_output=True,
                             text=True,
                         )
+
+                    # For annotating compile depths, use failure if encountered on rerun here. If there was
+                    # no failure, use runtime_stack_error message if it exists, otherwise report pass in msg.
                     if result.returncode != 0:
                         (error, trace_dump) = parse_error_output(result.stderr)
+                    elif op["runtime_stack_error"]:
+                        trace_dump = op["runtime_stack_error"]
+                        trace_dump = trace_dump.replace("\\n", "\n")
+                        error = parse_runtime_output(trace_dump)
+                        trace_dump = re.sub(r"[^\x20-\x7E]", "", trace_dump)
                     else:
                         error = (
                             "Compile stage passed on rerun, did not encounter error."

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,6 +73,7 @@ class ModelTester:
             compiler_config = CompilerConfig()
         self.compiler_config = compiler_config
         self.compiler_config.model_name = model_name
+        self.compiler_config.model_group = model_group
 
         self.record_property = record_property_handle
         self.compiler_config.record_property = record_property_handle

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -312,6 +312,7 @@ class OpByOpExecutor(Executor):
         self.stderror_redirected = False
         self.file_stderr = None
         self.op_memory_limit = gb_to_bytes(0.5)  # 512MB limit
+        self.global_op_idx = 0  # For Debug/Rerunning
 
     def transform_input(self, inp):
         # Convert torch.nn.Parameter to torch.Tensor and convert non-contiguous
@@ -365,12 +366,24 @@ class OpByOpExecutor(Executor):
                 raise ValueError(f"Unexpected input type: {type(inp)}")
         return input_shapes_and_constants
 
+    def set_runtime_stack_dump(self, error, op):
+        if op is None:
+            return
+        self.compiler_config.unique_ops[op.unique_key()].runtime_stack_dump = str(error)
+
+    # Helper function to print markers
+    def print_marker(self, msg, idx, num_nodes, op_info, error=""):
+        print(
+            f"{msg:<10} global_op_idx: {self.global_op_idx} ({idx}/{num_nodes}): {op_info} {error}",
+            flush=True,
+        )
+
     def compile_op(self, node, *inputs, **kwargs):
         # get_stablehlo_graph is a method implemented in inheriting classes
         module, op = self.get_stable_hlo_graph(node, inputs, **kwargs)
 
         if module is None or op is None:
-            return None, None
+            return None, None, None
 
         sender = mp.Queue()
         receiver = mp.Queue()
@@ -386,6 +399,8 @@ class OpByOpExecutor(Executor):
         sender.put(obj)
         start = time.time()
         binary = None
+        msg = None
+        timeout_exceeded = False
         while True:
             try:
                 result = receiver.get_nowait()
@@ -411,13 +426,19 @@ class OpByOpExecutor(Executor):
                 raise e
             if time.time() - start > self.compiler_config.single_op_timeout:
                 process.terminate()
+                timeout_exceeded = True
                 break
             if not process.is_alive():
                 break
             time.sleep(0.01)
         process.join()
-        print(f"json len {len(op.json)}")
-        return binary, op
+
+        if timeout_exceeded:
+            msg = f"Timeout exceeded for op during compile after {self.compiler_config.single_op_timeout} seconds."
+            print(msg, flush=True)
+            binary = None
+
+        return binary, op, msg
 
     def run_op(self, binary, *inputs):
         inputs = self.pre_process_inputs(*inputs)
@@ -509,7 +530,7 @@ class OpByOpExecutor(Executor):
 
             # If timeout is exceeded and stderr empty, add message and print to stdout.
             if timeout_exceeded and not stderr_data:
-                stderr_data = f"Timeout exceeded for op after {self.compiler_config.single_op_timeout} seconds."
+                stderr_data = f"Timeout exceeded for op during run after {self.compiler_config.single_op_timeout} seconds."
                 print(stderr_data, flush=True)
 
         return outputs, stderr_data

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -369,7 +369,14 @@ class OpByOpExecutor(Executor):
     def set_runtime_stack_dump(self, error, op):
         if op is None:
             return
-        self.compiler_config.unique_ops[op.unique_key()].runtime_stack_dump = str(error)
+
+        # Handle both implementations of unique_key (method or attribute)
+        key = (
+            op.unique_key()
+            if callable(getattr(op, "unique_key", None))
+            else op.unique_key
+        )
+        self.compiler_config.unique_ops[key].runtime_stack_dump = str(error)
 
     # Helper function to print markers
     def print_marker(self, msg, idx, num_nodes, op_info, error=""):

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -342,12 +342,16 @@ class StablehloExecutor(OpByOpExecutor):
         calculated = None
         num_ops = len(self.sub_ops)
         for idx, op in enumerate(self.sub_ops):
-            print(f"Compiling {idx}/{num_ops}: {op.op_name}")
+            self.print_marker("\nProcessing", idx, num_ops, op.op_name)
+
             try:
-                binary, op = self.compile_op(op, None, None)
+                self.print_marker("Compiling", idx, num_ops, op.op_name)
+                binary, op, msg = self.compile_op(op, None, None)
+                self.set_runtime_stack_dump(msg, op)
             except Exception as e:
                 binary = None
-                print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
+                self.print_marker("Failed to compile", idx, num_nodes, node.target, e)
+
             if (
                 self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
                 and binary is not None
@@ -355,16 +359,15 @@ class StablehloExecutor(OpByOpExecutor):
                 try:
                     inputs = generate_random_inputs_for_shlo(op.stable_hlo_graph)
                     inputs = self.typecast_inputs(inputs)
+                    self.print_marker("Running", idx, num_ops, op.op_name)
                     calculated, runtime_stack_dump = self.run_op(binary, *inputs)
-                    self.compiler_config.unique_ops[
-                        op.unique_key
-                    ].runtime_stack_dump = runtime_stack_dump
-                    print(f"Ran: {idx}/{num_ops}: {op.op_name}")
+                    self.set_runtime_stack_dump(runtime_stack_dump, op)
                     if calculated is None:
                         raise ValueError("Failed to execute")
                     op.compilation_status = OpCompilationStatus.EXECUTED
                 except Exception as e:
-                    print(f"Failed to execute {idx}/{num_ops}: {op.op_name}: {e}")
+                    self.print_marker("Failed to execute", idx, num_ops, op.op_name, e)
+            self.global_op_idx += 1
         self.binary = binary
         self.compiler_config.save_unique_ops()
         if self.execute_process is not None:

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -207,6 +207,8 @@ class TorchExecutor(OpByOpExecutor):
 
         op = Op(name, input_shapes_and_constants, self.compiler_config.model_name)
         if op.unique_key() not in self.compiler_config.unique_ops:
+            op.global_op_idx = self.global_op_idx
+            op.model_group = self.compiler_config.model_group
             self.compiler_config.unique_ops[op.unique_key()] = op
         else:
             self.compiler_config.unique_ops[op.unique_key()].num_ops += 1

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -296,8 +296,24 @@ class TorchExecutor(OpByOpExecutor):
         outputs = []
         num_nodes = len(self.program.graph_module.graph.nodes)
         out_degree = {}
+
+        # Debug mode to run only specific op given global_op_idx
+        run_global_op_idx = os.getenv("RUN_GLOBAL_OP_IDX")
+        run_global_op_idx = (
+            None if run_global_op_idx is None else int(run_global_op_idx)
+        )
+
         for idx, node in enumerate(self.program.graph_module.graph.nodes):
-            print(f"Compiling {idx}/{num_nodes}: {node.target}")
+            self.print_marker("\nProcessing", idx, num_nodes, node.target)
+
+            test_this_op = (
+                True
+                if run_global_op_idx is None
+                else (self.global_op_idx == run_global_op_idx)
+            )
+            # Another useful debug method:
+            # test_this_op = str(node.target) == "aten.gelu.default"
+
             out_degree[node] = len(node.users)
             if node.op == "placeholder":
                 node_to_tensor[node] = inputs[input_index]
@@ -323,26 +339,33 @@ class TorchExecutor(OpByOpExecutor):
                         )
                     else:
                         args.append(arg)
-                try:
-                    binary, op = self.compile_op(node, *args, **node.kwargs)
-                except Exception as e:
-                    binary = None
-                    print(f"Failed to compile {idx}/{num_nodes}: {node.target}: {e}")
+
+                binary = None
+                op = None
+
+                if test_this_op:
+                    try:
+                        self.print_marker("Compiling", idx, num_nodes, node.target)
+                        binary, op, msg = self.compile_op(node, *args, **node.kwargs)
+                        self.set_runtime_stack_dump(msg, op)
+
+                    except Exception as e:
+                        binary = None
+                        self.print_marker(
+                            "Failed to compile", idx, num_nodes, node.target, e
+                        )
 
                 if (
                     self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
                     and binary is not None
                 ):
+
                     try:
                         typecast_args = self.typecast_inputs(args)
-                        calculated, runtime_stack_dump = self.run_op(
-                            binary, *typecast_args
-                        )
-                        self.compiler_config.unique_ops[
-                            op.unique_key()
-                        ].runtime_stack_dump = runtime_stack_dump
+                        self.print_marker("Running", idx, num_nodes, node.target)
+                        calculated, stderr = self.run_op(binary, *typecast_args)
+                        self.set_runtime_stack_dump(stderr, op)
 
-                        print(f"Ran: {idx}/{num_nodes}: {node.target}")
                         if calculated is None:
                             raise ValueError("Failed to execute")
                         op.compilation_status = OpCompilationStatus.EXECUTED
@@ -357,12 +380,13 @@ class TorchExecutor(OpByOpExecutor):
                             if pcc < self.required_pcc:
                                 print(f"pcc too low for {idx}: {pcc}")
                     except Exception as e:
-                        print(
-                            f"Failed to execute {idx}/{num_nodes}: {node.target}: {e}"
+                        self.print_marker(
+                            "Failed to execute", idx, num_nodes, node.target, e
                         )
                         tensor = node.target(*args, **node.kwargs)
                 else:
                     tensor = node.target(*args, **node.kwargs)
+
                 node_to_tensor[node] = tensor
             elif node.op == "output":
                 args = node.args[0]
@@ -378,6 +402,9 @@ class TorchExecutor(OpByOpExecutor):
                     if out_degree[arg] == 0 and arg.op != "output":
                         del node_to_tensor[arg]
                         out_degree.pop(arg)
+
+            # Finished handling this op, increment global op index
+            self.global_op_idx += 1
 
         self.compiler_config.save_unique_ops()
         if self.execute_process is not None:

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -108,6 +108,8 @@ class Op:
         self.output_shapes = []
         self.output_tensors = []
         self.frontend = "tt-torch"
+        self.model_group = ""
+        self.global_op_idx = 0
 
         self.torch_ir_graph = ""
         self.stable_hlo_graph = ""
@@ -209,6 +211,8 @@ class Op:
             "torch_name": self.framework_op_name,  # For backward compatibility
             "frontend": self.frontend,
             "model_name": self.model_name,
+            "model_group": self.model_group,
+            "global_op_idx": self.global_op_idx,
             "input_shapes": self.print_shapes(self.input_shapes),
             "input_tensors": [tensor.to_dict() for tensor in self.input_tensors],
             "output_shapes": self.print_shapes(self.output_shapes),
@@ -260,6 +264,7 @@ class CompilerConfig:
         self.unique_ops = {}
         self.stable_hlo_ops = []
         self.model_name = ""
+        self.model_group = ""
         self.results_path = "results/models/"
         self.single_op_timeout = 30
         self.op_by_op_backend = OpByOpBackend.TORCH
@@ -427,6 +432,7 @@ class CompilerConfig:
             "unique_ops": self.unique_ops,
             "stable_hlo_ops": self.stable_hlo_ops,
             "model_name": self.model_name,
+            "model_group": self.model_group,
             "results_path": self.results_path,
             "single_op_timeout": self.single_op_timeout,
             "enable_consteval": self.enable_consteval,


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Reproducing op-by-op flow failures can be tedious, need a way to jump to failing op when re-running.
 - Generated XLS could contain more info to aid in debug
 - Compile timeouts aren't captured and reported well

### What's changed
 - Add global_op_idx that prints out via op-by-op flow and can now be used as debug aid to compile + run specific ops via RUN_GLOBAL_OP_IDX=123, greatly reducing local repro time.
- Record/capture when compile hits timeout (recent bug, fixed now) and propagate it to .json/.xls files via runtime_stack_dump like was recently done for runtime/execute timeouts.
- A few helper functions, and slight tweak to prints during op-by-op flow to make it easier to follow what is going on. Line break between each new ops visited.
- Capture model_group, global_op_idx in .json files and generated xls. Handled similarly to model_name in .json file create via backend. The XLS prints model_group on summary sheet and global_op_idx on per model sheets. 
- Sort by model_group, model_name on summary sheet. Freeze headers in XLS sheets so they always are visible
- Use "compile depth", not "compile status" in script, this is different and more accurate to what is being reported.
- Add a legend of OpCompilationStatus values 0-7 on summary sheet and print total ops per OpCompilationStatus on AllOps sheets
- Unrelated, remove empty bert group in run-op-by-op-model-tests-nightly.yml that was wasting a CI runner briefly.
- Unrelated, Increase run-full-model-execution-tests-nightly.yml timeout to 240 minutes for mamba

### Checklist
- [x] New/Existing tests provide coverage for changes. Ran op-by-op on branch with subset of tests here, generated XLS looks good. https://github.com/tenstorrent/tt-torch/actions/runs/14562133143
- [x] Also tried locally with handful of tests that will benefit from these changes in torch_op_by_op (and mnist in stablehlo_op_by_op), will include screenshots in PR.
