### PR TITLE
Promote vit l/b 32 models from COMPILE to EXECUTE based on Apr20 benchmarks

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -27,8 +27,6 @@ jobs:
             runs-on: wormhole_b0, name: "compile_2", tests: "
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-regnet_y_128gf]
-                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_l_32]
-                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_b_32]
                   tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
                   tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
                   tests/models/vilt/test_vilt.py::test_vilt[full-eval]

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -47,6 +47,8 @@ jobs:
                   tests/models/distilbert/test_distilbert.py::test_distilbert_multiloop[full-distilbert-base-uncased-eval-64]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_l_16]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_b_16]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_l_32]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_b_32]
             "
           },
           {


### PR DESCRIPTION
### Ticket
None

### Problem description
None

### What's changed
Based on benchmarks from Apr 20, promote vit_l_32 and vit_b_32. These caused a hang in a previous week due to metal conv regression, but this has resolved and these models are now promotable from COMPILE to EXECUTE.

### Checklist
- [x] Tested in the onPR job for this PR