### PR TITLE
Cache golden values for unique ops, and re-use them next time

### DIFF
--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -66,6 +66,7 @@ def test_RMBG(record_property, mode, op_by_op):
     if mode == "eval":
         predictions = results[-1].sigmoid()
         pred = predictions[0].squeeze()
+        pred = pred.to(torch.float32)
         pred_pil = transforms.ToPILImage()(pred)
         mask = pred_pil.resize(tester.image.size)
         tester.image.putalpha(mask)

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -15,7 +15,7 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 class ThisTester(ModelTester):
     def _load_model(self):
         model = AutoModelForImageSegmentation.from_pretrained(
-            "briaai/RMBG-2.0", torch_dtype=torch.float32, trust_remote_code=True
+            "briaai/RMBG-2.0", torch_dtype=torch.bfloat16, trust_remote_code=True
         )
         torch.set_float32_matmul_precision(["high", "highest"][0])
         image_size = (1024, 1024)
@@ -31,7 +31,7 @@ class ThisTester(ModelTester):
     def _load_inputs(self):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(url, stream=True).raw)
-        inputs = self.transform_image(self.image).unsqueeze(0).to(dtype=torch.float32)
+        inputs = self.transform_image(self.image).unsqueeze(0).to(dtype=torch.bfloat16)
         return inputs
 
 

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -12,7 +12,9 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 class ThisTester(ModelTester):
     def _load_model(self):
         model_id = "CompVis/stable-diffusion-v1-4"
-        pipe = StableDiffusionPipeline.from_pretrained(model_id)
+        pipe = StableDiffusionPipeline.from_pretrained(
+            model_id, torch_dtype=torch.bfloat16
+        )
         return pipe
 
     def _load_inputs(self):
@@ -30,9 +32,6 @@ class ThisTester(ModelTester):
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
-)
-@pytest.mark.xfail(
-    reason="Fails due to pt2 compile issue when finishing generation, but we can still generate a graph"
 )
 def test_stable_diffusion(record_property, mode, op_by_op):
     model_name = "Stable Diffusion"

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -81,7 +81,6 @@ def test_yolov10(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
-    cc.verify_op_by_op = True
     tester = ThisTester(
         model_name,
         mode,

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 import os
+import warnings
 
 import tt_mlir
 import sys
@@ -187,6 +188,7 @@ def _base_backend(gm, example_inputs, compiler_config, device):
 
 @tt_torch_error_message
 def backend(gm, example_inputs, options=None):
+    warnings.filterwarnings("ignore", message="Failed to fetch module*")
     assert isinstance(gm, torch.fx.GraphModule), "Backend only supports torch graphs"
 
     if options is None:

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -344,6 +344,9 @@ class OpByOpExecutor(Executor):
     # across graph breaks, and for running just a specific op.
     global_op_idx = 0
     run_global_op_idx = None
+    compiling_time = 0.0
+    running_time = 0.0
+    golden_time = 0.0
 
     def __init__(
         self,
@@ -453,9 +456,9 @@ class OpByOpExecutor(Executor):
         self.compiler_config.unique_ops[key].runtime_stack_dump = str(error)
 
     # Helper function to print markers
-    def print_marker(self, msg, idx, num_nodes, op_info, error=""):
+    def print_marker(self, msg, idx, num_nodes, op_info, error="", time=0.0):
         print(
-            f"{msg:<10} global_op_idx: {OpByOpExecutor.global_op_idx} ({idx}/{num_nodes}): {op_info} {error}",
+            f"{msg:<10} global_op_idx: {OpByOpExecutor.global_op_idx} ({idx}/{num_nodes}): {op_info} | time: {time:.4f} s | {error}",
             flush=True,
         )
 

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -7,6 +7,7 @@ import tt_mlir
 import torch_mlir
 import os
 import re
+import time
 import ml_dtypes
 import numpy as np
 from torch_mlir.dialects import torch as torch_dialect
@@ -158,6 +159,27 @@ def lower_to_stable_hlo(module, op=None, enable_ir_printing=False):
 ##################################################################
 # TorchExecutor covers all CompileDepth options except for EXECUTE
 ##################################################################
+
+
+def cast_ios_and_run(node, args, kwargs):
+    try:
+        out_df = node.meta["tensor_meta"].dtype
+        out_df_known = True
+    except Exception:
+        out_df_known = False
+
+    if out_df_known:
+        cast_args = [
+            arg.to(torch.float32)
+            if isinstance(arg, torch.Tensor) and torch.is_floating_point(arg)
+            else arg
+            for arg in args
+        ]
+        golden = node.target(*cast_args, **kwargs)
+        golden = golden.to(out_df)
+    else:
+        golden = node.target(*args, **kwargs)
+    return golden
 
 
 class TorchExecutor(OpByOpExecutor):
@@ -343,8 +365,14 @@ class TorchExecutor(OpByOpExecutor):
 
                 if test_this_op:
                     try:
-                        self.print_marker("Compiling", idx, num_nodes, node.target)
+                        start = time.time()
                         binary, op, msg = self.compile_op(node, *args, **node.kwargs)
+                        end = time.time()
+                        self.print_marker(
+                            "Compiling", idx, num_nodes, node.target, time=(end - start)
+                        )
+                        OpByOpExecutor.compiling_time += end - start
+
                         self.set_runtime_stack_dump(msg, op)
 
                     except Exception as e:
@@ -353,6 +381,13 @@ class TorchExecutor(OpByOpExecutor):
                             "Failed to compile", idx, num_nodes, node.target, e
                         )
 
+                start = time.time()
+                golden = cast_ios_and_run(node, args, node.kwargs)
+                end = time.time()
+                self.print_marker(
+                    "Golden", idx, num_nodes, node.target, time=(end - start)
+                )
+                OpByOpExecutor.golden_time += end - start
                 if (
                     self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
                     and binary is not None
@@ -360,20 +395,24 @@ class TorchExecutor(OpByOpExecutor):
 
                     try:
                         typecast_args = self.typecast_inputs(args)
-                        self.print_marker("Running", idx, num_nodes, node.target)
+                        start = time.time()
                         calculated, stderr = self.run_op(binary, *typecast_args)
+                        end = time.time()
+                        self.print_marker(
+                            "Running", idx, num_nodes, node.target, time=(end - start)
+                        )
+                        OpByOpExecutor.running_time += end - start
                         self.set_runtime_stack_dump(stderr, op)
 
                         if calculated is None:
                             raise ValueError("Failed to execute")
                         op.compilation_status = OpCompilationStatus.EXECUTED
-                        tensor = node.target(*args, **node.kwargs)
                         if self.compiler_config.verify_op_by_op:
-                            atol = calculate_atol(calculated, tensor)
+                            atol = calculate_atol(calculated, golden)
                             op.atol = atol
                             if atol > self.required_atol:
                                 print(f"atol too high for {idx}: {atol}")
-                            pcc = calculate_pcc(calculated, tensor)
+                            pcc = calculate_pcc(calculated, golden)
                             op.pcc = pcc
                             if pcc < self.required_pcc:
                                 print(f"pcc too low for {idx}: {pcc}")
@@ -381,15 +420,13 @@ class TorchExecutor(OpByOpExecutor):
                         self.print_marker(
                             "Failed to execute", idx, num_nodes, node.target, e
                         )
-                        tensor = node.target(*args, **node.kwargs)
-                else:
-                    tensor = node.target(*args, **node.kwargs)
 
-                node_to_tensor[node] = tensor
+                node_to_tensor[node] = golden
             elif node.op == "output":
                 args = node.args[0]
                 output_tensors = [node_to_tensor[arg] for arg in args]
                 outputs = output_tensors
+
             args_set = set()
             for arg in node.args:
                 if arg in args_set:
@@ -411,6 +448,9 @@ class TorchExecutor(OpByOpExecutor):
         if self.stderror_redirected:
             os.unlink(self.file_stderr.name)
             self.stderror_redirected = False
+        print(
+            f"Compiling time: {OpByOpExecutor.compiling_time}, Running time: {OpByOpExecutor.running_time}, Golden time: {OpByOpExecutor.golden_time}"
+        )
         return outputs
 
     def __call__(self, *inputs):


### PR DESCRIPTION
### Problem description
Op-by-op tests were taking too long. This was especially true in diffusion/generative tests where models needed to be run in a loop, and total ops >> unique ops. 

### What's changed
Instead of calculating the golden values of ops each time (allowing us to verify e2e) we cache golden values of each unique op and propagate it. I believe this is safer than the empty tensor change @jazpurTT proposed since we should see fewer runtime errors than with just processing unbounded random tensors, but let's discuss. 

I did some additional testing, it's only calculating the goldens in bfp16 that's problematic. For a single iteration of stable diffusion UNET, calculating goldens in bf16 takes ~20 minutes and calculating them in fp32 takes 3 seconds!  Updated PR to calculate goldens in fp32. 

Change RMBG, and StableDiffusion tests to use bfloat16 to reduce memory footprint especially for conv2d now that they run fast.

### Checklist
- [x] New/Existing tests provide coverage for changes
