### PR TITLE
Fix data parallel demo by creating a new instance of the `options` 

### DIFF
--- a/demos/resnet/README.md
+++ b/demos/resnet/README.md
@@ -47,12 +47,15 @@ from tt_torch.tools.device_manager import DeviceManager
 ...
 def main():
     ...
-    options = {}
-    options["compiler_config"] = cc
     # Acquires all available devices and returns them in a list
     parent, devices = DeviceManager.acquire_available_devices()
     tt_models = []
     for device in devices:
+        # It is important that each `options` map being passed to `torch.compile`
+        # is a new object.
+        # Otherwise the "device" key will get overwritten for all previous devices.
+        options = {}
+        options["compiler_config"] = cc
         options["device"] = device # Explicitly compile the model for a specific device
         tt_models.append(
             torch.compile(model, backend=backend, dynamic=False, options=options)

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -78,8 +78,6 @@ def main(use_simplified_manager):
     cc.enable_consteval = True
     cc.consteval_parameters = True
 
-    options = {}
-    options["compiler_config"] = cc
     num_devices = DeviceManager.get_num_available_devices()
     if use_simplified_manager:
         print("Using simplified device manager")
@@ -99,6 +97,8 @@ def main(use_simplified_manager):
 
     tt_models = []
     for device in devices:
+        options = {}
+        options["compiler_config"] = cc
         options["device"] = device
         # Compile the model for each device
         tt_models.append(


### PR DESCRIPTION
### Problem description
In the initial multi-device [PR](https://github.com/tenstorrent/tt-torch/pull/572) that added the data parallel demo, there was a bug that caused the models to only compile for the last device in the acquired `devices` list. This was due to the options map being passed by reference to each torch.compile call. This is fixed now by creating a fresh map for each iteration.

### Checklist
- [x] New/Existing tests provide coverage for changes
