### PR TITLE
A couple parse_op_by_op_results.py bugfixes and torch_backend print tweaks

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -399,8 +399,9 @@ def create_summary_worksheet(workbook, models_info):
         worksheet.write(row, 17, executing_formula)
         worksheet.set_column(17, 17, 15)
 
-        # Determine how many ops for model hit unknown error (column M is "Compile error")
-        unknown_errors_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!N:N"), "Error message not extracted.")'
+        # Determine how many ops for model hit unknown error.
+        col_id = "N"  # Compile Error column
+        unknown_errors_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!{col_id}:{col_id}"), "Error message not extracted.")'
         worksheet.set_column(18, 18, 2)
         worksheet.set_column(19, 19, 13)
         worksheet.write(2, 19, "Unknown Errors")
@@ -408,8 +409,9 @@ def create_summary_worksheet(workbook, models_info):
         worksheet.set_column(20, 20, 2)
         apply_non_zero_conditional_format(worksheet, row, 19, 6, color_formats)
 
-        # Determine how many ops for model hit timeout error
-        timeout_errors_formula = f'=COUNTIFS(INDIRECT("\'" & "{model_name}" & "\'!N:N"), "*Timeout exceeded for op*")'
+        # Determine how many ops for model hit timeout error.
+        col_id = "N"  # Compile Error column
+        timeout_errors_formula = f'=COUNTIFS(INDIRECT("\'" & "{model_name}" & "\'!{col_id}:{col_id}"), "*Timeout exceeded for op*")'
         worksheet.set_column(21, 21, 13)
         worksheet.write(2, 21, "Timeouts")
         worksheet.write(row, 21, timeout_errors_formula)

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -28,6 +28,9 @@ OP_STATUS_NAMES = [
     "EXECUTED",
 ]
 
+# xlswriter limit, neighbor cells corrupted if exceeded.
+MAX_CELL_LEN = 32767
+
 # Function to get git branch and commit
 def get_git_info():
     try:
@@ -397,7 +400,7 @@ def create_summary_worksheet(workbook, models_info):
         worksheet.set_column(17, 17, 15)
 
         # Determine how many ops for model hit unknown error (column M is "Compile error")
-        unknown_errors_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!M:M"), "Error message not extracted.")'
+        unknown_errors_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!N:N"), "Error message not extracted.")'
         worksheet.set_column(18, 18, 2)
         worksheet.set_column(19, 19, 13)
         worksheet.write(2, 19, "Unknown Errors")
@@ -406,7 +409,7 @@ def create_summary_worksheet(workbook, models_info):
         apply_non_zero_conditional_format(worksheet, row, 19, 6, color_formats)
 
         # Determine how many ops for model hit timeout error
-        timeout_errors_formula = f'=COUNTIFS(INDIRECT("\'" & "{model_name}" & "\'!M:M"), "*Timeout exceeded for op*")'
+        timeout_errors_formula = f'=COUNTIFS(INDIRECT("\'" & "{model_name}" & "\'!N:N"), "*Timeout exceeded for op*")'
         worksheet.set_column(21, 21, 13)
         worksheet.write(2, 21, "Timeouts")
         worksheet.write(row, 21, timeout_errors_formula)
@@ -520,14 +523,14 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
                 "status": value["compilation_status"],
                 "pcc": value["pcc"],
                 "atol": value["atol"],
-                "torch_ir_graph": value["torch_ir_graph"],
-                "stable_hlo_graph": value["stable_hlo_graph"],
+                "torch_ir_graph": value["torch_ir_graph"][:MAX_CELL_LEN],
+                "stable_hlo_graph": value["stable_hlo_graph"][:MAX_CELL_LEN],
                 "ops": value["stable_hlo_ops"],
-                "ttir_graph": value["ttir_graph"],
-                "ttnn_graph": value["ttnn_graph"],
-                "compiled_json": value["compiled_json"],
+                "ttir_graph": value["ttir_graph"][:MAX_CELL_LEN],
+                "ttnn_graph": value["ttnn_graph"][:MAX_CELL_LEN],
+                "compiled_json": value["compiled_json"][:MAX_CELL_LEN],
                 "error": value["error"],
-                "trace_dump": value["trace_dump"],
+                "trace_dump": value["trace_dump"][:MAX_CELL_LEN],
                 "model_names": value["model_names"],
             }
         )
@@ -738,13 +741,13 @@ def generate_op_reports_xlsx():
                     "output_shapes": value["output_shapes"],
                     "num_ops": value["num_ops"],
                     "status": value["compilation_status"],
-                    "torch_ir_graph": value["torch_ir_graph"],
-                    "stable_hlo_graph": value["stable_hlo_graph"],
+                    "torch_ir_graph": value["torch_ir_graph"][:MAX_CELL_LEN],
+                    "stable_hlo_graph": value["stable_hlo_graph"][:MAX_CELL_LEN],
                     "ops": value["stable_hlo_ops"],
-                    "ttir_graph": value["ttir_graph"],
-                    "ttnn_graph": value["ttnn_graph"],
-                    "compiled_json": value["compiled_json"],
-                    "runtime_stack_error": value["runtime_stack_dump"],
+                    "ttir_graph": value["ttir_graph"][:MAX_CELL_LEN],
+                    "ttnn_graph": value["ttnn_graph"][:MAX_CELL_LEN],
+                    "compiled_json": value["compiled_json"][:MAX_CELL_LEN],
+                    "runtime_stack_error": value["runtime_stack_dump"][:MAX_CELL_LEN],
                     "key": key,
                     "pcc": value["pcc"],
                     "atol": value["atol"],

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -449,7 +449,7 @@ class TorchExecutor(OpByOpExecutor):
             os.unlink(self.file_stderr.name)
             self.stderror_redirected = False
         print(
-            f"Total Time. Compiling: {OpByOpExecutor.compiling_time:.2f} s, Running: {OpByOpExecutor.running_time:.2f} s, Golden: {OpByOpExecutor.golden_time:.2f} s"
+            f"Total Time - Compiling: {OpByOpExecutor.compiling_time:.2f} s, Running: {OpByOpExecutor.running_time:.2f} s, Golden: {OpByOpExecutor.golden_time:.2f} s"
         )
         return outputs
 

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -449,7 +449,7 @@ class TorchExecutor(OpByOpExecutor):
             os.unlink(self.file_stderr.name)
             self.stderror_redirected = False
         print(
-            f"Compiling time: {OpByOpExecutor.compiling_time}, Running time: {OpByOpExecutor.running_time}, Golden time: {OpByOpExecutor.golden_time}"
+            f"Total Time. Compiling: {OpByOpExecutor.compiling_time:.2f} s, Running: {OpByOpExecutor.running_time:.2f} s, Golden: {OpByOpExecutor.golden_time:.2f} s"
         )
         return outputs
 

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -6,6 +6,7 @@ import json
 import numpy as np
 from enum import Enum, IntEnum
 from collections.abc import Iterable
+import datetime
 
 from pathlib import Path
 import os
@@ -380,7 +381,8 @@ class CompilerConfig:
         for key, op in self.unique_ops.items():
             unique_op_dict[key] = op.to_dict()
         output_file = Path(f"{self.results_path}{pytest_test}_unique_ops.json")
-        print(f"#####  Saving unique ops to {output_file}#####  ")
+        date_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f"#####  Saving unique ops to {output_file} at {date_str} #####")
         output_file.parent.mkdir(exist_ok=True, parents=True)
         with open(output_file, "w") as f:
             json.dump(unique_op_dict, f)


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Fix simple bug in parse_op_by_op_results.py where timeout/unknown errors parsed from wrong column since recent change
 - Fix sneaky bug in parse_op_by_op_results.py where long cells exceeding xlswriter limit will make rendering corrupted, making cells appear empty in same row. Some ops hitting this with huge IRs, noticed when going through compile errors.
 - A couple minor changes to op_by_op flow debug prints to add date/time when saving unique_ops.json and limit compiling/running/golden time to 2 decimal places. Another ticket exists to reduce verbosity of prints may change this.

### Checklist
- [x] Tested script changes on last night's nightly regression .json files to generate new xlsx