### PR TITLE
Slight tweak to compiler error parsing in parse_op_by_op_results.py

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -614,7 +614,7 @@ def parse_error_output(stderr):
     stderr_lines = stderr.strip().splitlines()
 
     # Find the first real error line (MLIR format)
-    error = next((line for line in stderr_lines if ": error:" in line), None)
+    error = next((line for line in stderr_lines if "error:" in line), None)
 
     # If no error line found, look for crash indicators
     if not error:
@@ -627,6 +627,10 @@ def parse_error_output(stderr):
             ),
             None,
         )
+
+    # Fall back to previous behavior if no matches above found.
+    if stderr and not error:
+        error = stderr.split("\n")[0]
 
     return (error, stderr)
 


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Some instances of "error: failed to legalize operation 'torch.constant.bool'" were being not captured in TTIR to SHLO conversion after e8bdcf9

### What's changed
 - Remove colon before error keyword and add fallback logic to previous behavior

### Checklist
- [x] Tested by regenerating nightly xls using .json files from Apr23 nightly.
