### PR TITLE
Create dynamic timeout logic for benchmarks

### DIFF
--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   tests:
-    timeout-minutes: 500
+    timeout-minutes: 550
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -104,6 +104,7 @@ jobs:
         ls -l ${{ steps.strings.outputs.work-dir }}
 
     - name: Run Execution Benchmark Tests
+      timeout-minutes: ${{matrix.group.t-o}}
       env:
         HF_HOME: ${{ env.DOCKER_CACHE_ROOT }}/huggingface
         TORCH_HOME: ${{ env.DOCKER_CACHE_ROOT }}/torch
@@ -114,7 +115,7 @@ jobs:
         set +e
         mkdir -p ${{ steps.strings.outputs.work-dir }}/pytest-logs
 
-        echo "Matrix group ${{ matrix.group.name }} runs-on ${{ matrix.group.runs-on }} with index ${{ matrix.group.group-id }}"
+        echo "Matrix group ${{ matrix.group.name }} runs-on ${{ matrix.group.runs-on }} with index ${{ matrix.group.group-id }} and timeout ${{ matrix.group.t-o }} minutes."
 
         # Read the JSON file and extract the per-matrix testlist assigned to this runner (from its group-id)
         testlist=$(cat ${{ steps.strings.outputs.matrix-json }} | jq ".[${{ matrix.group.group-id }}]")


### PR DESCRIPTION
### Ticket
None

### Problem description
Individual pytests are run in isolated runners in weekly depth benchmarks. Due to runner count limitations, enough hanging tests can create a runner bottleneck, and statistical simulation suggests a small probability of benchmarks running for >10h. Most recent benchmark tests have run for 9h30m or so which comes close.

### What's changed
Setup a 3 stage timeout and infra to dynamically set that timeout based on known test timings.
1.  If there is no known duration for the test, set the timeout to a reasonable default of 2 hours
2.  If a test is expected to take less than 30 minutes, set the timeout to 1 hour.
3.  If the expected duration exceeds 30 minutes, set it to the MAX_TIMEOUT of 500m 

### Checklist
- [x] Partial benchmark tests have been run to check that the timeout is calculated, passed and processed correctly, and that the timeout killer works  
