### PR TITLE
Add tt-torch profile.py documentation, port and fix an obscure profiling deadlock

### DIFF
--- a/docs/generate_summary.py
+++ b/docs/generate_summary.py
@@ -18,6 +18,7 @@ def generate_summary(docs_dir):
     summary_lines.append("- [Testing](test.md)")
     summary_lines.append("- [Controlling Compiler](controlling.md)")
     summary_lines.append("- [Pre-commit](pre_commit.md)")
+    summary_lines.append("- [Profiling](profiling.md)")
     summary_lines.append("\n\n# Models and Operations")
     summary_lines.append("- [Supported Models](models/supported_models.md)")
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,6 +2,7 @@
 - [Introduction](overview.md)
 - [Getting Started](getting_started.md)
 
+<<<<<<< HEAD
 
 # User guide
 - [Building](build.md)
@@ -12,6 +13,8 @@
 
 # Models and Operations
 - [Supported Models](models/supported_models.md)
+=======
+>>>>>>> 522331f (Add clarifying statements to docs)
 - [Operations](ops/README.md)
   - [StableHLO Operations](ops/stablehlo/README.md)
     - [Arith Constant](ops/stablehlo/arith.constant.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,19 +2,17 @@
 - [Introduction](overview.md)
 - [Getting Started](getting_started.md)
 
-<<<<<<< HEAD
 
 # User guide
 - [Building](build.md)
 - [Testing](test.md)
 - [Controlling Compiler](controlling.md)
 - [Pre-commit](pre_commit.md)
+- [Profiling](profiling.md)
 
 
 # Models and Operations
 - [Supported Models](models/supported_models.md)
-=======
->>>>>>> 522331f (Add clarifying statements to docs)
 - [Operations](ops/README.md)
   - [StableHLO Operations](ops/stablehlo/README.md)
     - [Arith Constant](ops/stablehlo/arith.constant.md)

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -74,4 +74,4 @@ Run a basic test to verify:
 pytest tests/torch/test_basic.py
 ```
 
-[^profiling_note]: For a profiling build, cmake build files should be generated with an extra directive, as `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`. Refer to [profiling docs](./profiling.md) for more information. 
+[^profiling_note]: For a profiling build, cmake build files should be generated with an extra directive, as `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`. Refer to [profiling docs](./profiling.md) for more information.

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -60,7 +60,7 @@ For more information see [tt-mlir build steps](https://docs.tenstorrent.com/tt-m
 
 ## Compile Steps:
 
-Run the following commands to compile:
+Run the following commands to compile. Profiling builds require an extra step[^profiling_note]:
 ```bash
 source env/activate
 cmake -G Ninja -B build
@@ -68,7 +68,10 @@ cmake --build build
 cmake --install build
 ```
 
+
 Run a basic test to verify:
 ```bash
 pytest tests/torch/test_basic.py
 ```
+
+[^profiling_note]: For a profiling build, cmake build files should be generated with an extra directive, as `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`. Refer to [profiling docs](./profiling.md) for more information. 

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -8,6 +8,7 @@ tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a singl
 
 - In the tt-torch building step ([Building](./build.md)), it is required to configure your cmake build with the additional cmake directive `TT_RUNTIME_ENABLE_PERF_TRACE=ON`.
     - i.e. run: `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`
+- Paths in this document are given relative to the repo root.
 
 ## Usage
 
@@ -19,25 +20,24 @@ profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
 **Note: The `test_command` must be quoted!**
 
 
-As a minimal example, this will run and profile the mnist test:
+As a minimal example, this will run and profile the MNIST test:
 ```
 python tt_torch/tools/profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]"
 ```
 
-The following reports will be produced by default:
-1. `results/perf/device_ops_perf_trace.csv`: A report correlating operations and hardware timing, including how long individual ops took to run on device.
-2. `install/tt-metal/generated/profiler/.logs/tracy_profile_log_host.tracy`: A `.tracy` file that can be consumed by the Tracy GUI and produce visual profiling traces of host and device activity.
-
+It generates the following report: `results/perf/device_ops_perf_trace.csv`. This report displays a table of operations executed on device and rich timing and configuration data associated with them.
 
 ## Limitations
 
-- Tracy is a single process profiler and will not work with multiprocessed workflows. This includes tests parameterized by `op_by_op_shlo` and `op_by_op_torch`, which run individual ops in isolated processes
+- Tracy is a single process profiler and will not work with multiprocessed workflows. This includes tests parameterized by `op_by_op_shlo` and `op_by_op_torch`, which run individual ops in isolated processes.
+- To view traces, you can use `install/tt-metal/generated/profiler/.logs/tracy_profile_log_host.tracy`.
+    - This is a `.tracy` file that can be consumed by the tt-metal Tracy GUI and produce visual profiling traces of host and device activity.
+    - You must use the tt-metal Tracy GUI to view this file. Refer to the [GUI section](https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tools/tracy_profiler.html#gui) in the tt-metal profiling documentation. Other sections are not applicable to tt-torch profiling.
 
 ## Troubleshooting
 
 - `tt-torch/install/tt-metal/tools/profiler/bin/capture-release -o tracy_profile_log_host.tracy -f -p 8086' timed out after X seconds`
     - Tracy uses a client-server model to communicate profiling data between the Tracy capture server and the client being profiled.
     - Communication between client and server is done on a given port (default: 8086) as specified with the `-p` option.
-    - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupy port 8086, there may be contention and unexpected behaviour including capture server timeouts
-    - This may be addressed by manually specifying an unused port with the -p option to `profile.py`
-    - Network analysis tools like `ss -ltps` can identify which processes have opened which ports
+    - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupying port 8086, there may be contention and unexpected behaviour including capture server timeouts.
+    - This may be addressed by manually specifying an unused port with the -p option to `profile.py`.

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -1,0 +1,19 @@
+# Profiling
+
+## Introduction
+
+tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and device operations. 
+
+## Prerequisites
+
+## Limitations
+
+
+
+## Troubleshooting
+
+- `tt-torch/install/tt-metal/tools/profiler/bin/capture-release -o tracy_profile_log_host.tracy -f -p 8086' timed out after X seconds`
+    - Tracy uses a client-server model to communicate profiling data between the Tracy capture server and the client being profiled. 
+    - Communication between client and server is done on a given port (default: 8086) as specified with the `-p` option.
+    - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupy port 8086, there may be contention and unexpected behaviour including capture server timeouts
+    - This may be addressed by manually specifying an unused port with the -p option to `profile.py`

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -2,13 +2,36 @@
 
 ## Introduction
 
-tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and device operations.
+tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and on-device operations. tt-torch implements a wrapper called `profile.py` with custom orchestration logic to handle the spawning of the Tracy capture server and the client workload to be profiled, as well as report generation and data postprocessing functionality.
 
 ## Prerequisites
 
+- In the tt-torch building step ([Building](./build.md)), it is required to configure your cmake build with the additional cmake directive `TT_RUNTIME_ENABLE_PERF_TRACE=ON`.
+    - i.e. run: `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`
+
+## Usage
+
+The `profile.py` tool is the recommended entrypoint for profiling workloads in tt-torch.
+
+```
+profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
+```
+**Note: The `test_command` must be quoted!**
+
+
+As a minimal example, this will run and profile the mnist test:
+```
+python tt_torch/tools/profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]"
+```
+
+The following reports will be produced by default:
+1. `results/perf/device_ops_perf_trace.csv`: A report correlating operations and hardware timing, including how long individual ops took to run on device.
+2. `install/tt-metal/generated/profiler/.logs/tracy_profile_log_host.tracy`: A `.tracy` file that can be consumed by the Tracy GUI and produce visual profiling traces of host and device activity.
+
+
 ## Limitations
 
-
+- Tracy is a single process profiler and will not work with multiprocessed workflows. This includes tests parameterized by `op_by_op_shlo` and `op_by_op_torch`, which run individual ops in isolated processes
 
 ## Troubleshooting
 
@@ -17,3 +40,4 @@ tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a singl
     - Communication between client and server is done on a given port (default: 8086) as specified with the `-p` option.
     - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupy port 8086, there may be contention and unexpected behaviour including capture server timeouts
     - This may be addressed by manually specifying an unused port with the -p option to `profile.py`
+    - Network analysis tools like `ss -ltps` can identify which processes have opened which ports

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -2,13 +2,15 @@
 
 ## Introduction
 
-tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and on-device operations. tt-torch implements a wrapper called `profile.py` with custom orchestration logic to handle the spawning of the Tracy capture server and the client workload to be profiled, as well as report generation and data postprocessing functionality.
+tt-torch uses the [tt-metal Tracy fork](https://github.com/tenstorrent-metal/tracy) to collect profiling data. Tracy is a single process profiler, and uses a client-server model to trace both host calls and on-device operation performance. tt-torch implements a wrapper called `profile.py` with custom orchestration logic to handle the spawning of the Tracy capture server and the client workload to be profiled, as well as report generation and data postprocessing functionality.
+
+The output of `profile.py` is a CSV report displaying a table of operations executed on device and rich timing, memory usage and configuration data associated with them.
+
+Note: Paths in this document are given relative to the repo root.
 
 ## Prerequisites
 
-- In the tt-torch building step ([Building](./build.md)), it is required to configure your cmake build with the additional cmake directive `TT_RUNTIME_ENABLE_PERF_TRACE=ON`.
-    - i.e. run: `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`
-- Paths in this document are given relative to the repo root.
+In the tt-torch building step ([Building](./build.md)), it is required to configure your cmake build with the additional cmake directive `TT_RUNTIME_ENABLE_PERF_TRACE=ON` (i.e. run: `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`).
 
 ## Usage
 
@@ -20,16 +22,17 @@ profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
 **Note: The `test_command` must be quoted!**
 
 
-As a minimal example, this will run and profile the MNIST test:
+As a minimal example, the following command will run and profile the MNIST test:
 ```
 python tt_torch/tools/profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]"
 ```
 
-It generates the following report: `results/perf/device_ops_perf_trace.csv`. This report displays a table of operations executed on device and rich timing and configuration data associated with them.
+The report is created at `results/perf/device_ops_perf_trace.csv` by default, unless an output path is specified.
+
 
 ## Limitations
 
-- Tracy is a single process profiler and will not work with multiprocessed workflows. This includes tests parameterized by `op_by_op_shlo` and `op_by_op_torch`, which run individual ops in isolated processes.
+- Tracy is a single process profiler and will not work with multiprocessed workflows. This includes tests parameterized by `op_by_op_shlo` and `op_by_op_torch`, which break down a model into individual ops and run them serially in separate processes.
 - To view traces, you can use `install/tt-metal/generated/profiler/.logs/tracy_profile_log_host.tracy`.
     - This is a `.tracy` file that can be consumed by the tt-metal Tracy GUI and produce visual profiling traces of host and device activity.
     - You must use the tt-metal Tracy GUI to view this file. Refer to the [GUI section](https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/tools/tracy_profiler.html#gui) in the tt-metal profiling documentation. Other sections are not applicable to tt-torch profiling.

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and device operations. 
+tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a single process profiler, and uses a client-server model to perform performance tracing on both host calls and device operations.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ tt-torch uses the tt-metal Tracy fork to manage a Tracy server. Tracy is a singl
 ## Troubleshooting
 
 - `tt-torch/install/tt-metal/tools/profiler/bin/capture-release -o tracy_profile_log_host.tracy -f -p 8086' timed out after X seconds`
-    - Tracy uses a client-server model to communicate profiling data between the Tracy capture server and the client being profiled. 
+    - Tracy uses a client-server model to communicate profiling data between the Tracy capture server and the client being profiled.
     - Communication between client and server is done on a given port (default: 8086) as specified with the `-p` option.
     - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupy port 8086, there may be contention and unexpected behaviour including capture server timeouts
     - This may be addressed by manually specifying an unused port with the -p option to `profile.py`

--- a/tests/tools/test_intermediate_verification.py
+++ b/tests/tools/test_intermediate_verification.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import tt_torch.tools.ci_verification as ci_tools
 import subprocess
-from tt_torch.tools.utils import FileManager
+from tt_torch.tools.filemanager import FileManager
 import pandas as pd
 import os
 

--- a/tt_torch/tools/filemanager.py
+++ b/tt_torch/tools/filemanager.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+import os
+
+# This should be in its own file to prevent a rare deadlock condition due to ttmlir input with tracy
+
+
+class FileManager:
+    @staticmethod
+    def create_file(file_path):
+        try:
+            if not FileManager.check_directory_exists(os.path.dirname(file_path)):
+                FileManager.create_directory(os.path.dirname(file_path))
+            with open(file_path, "w") as file:
+                file.write("")
+        except OSError as e:
+            raise OSError(f"error creating file: {e}")
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+    @staticmethod
+    def create_directory(directory_path, exist_ok=False):
+        try:
+            os.makedirs(directory_path, exist_ok=exist_ok)
+        except FileExistsError as e:
+            raise FileExistsError(f"directory '{directory_path}' already exists")
+        except OSError as e:
+            raise OSError(f"error creating directory: {e}")
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+    @staticmethod
+    def remove_file(file_path):
+        try:
+            os.remove(file_path)
+        except FileNotFoundError:
+            print(f"directory '{file_path}' not found - cannot remove")
+        except PermissionError:
+            raise PermissionError(
+                f"insufficient permissions to remove file '{file_path}'"
+            )
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+    @staticmethod
+    def remove_directory(directory_path):
+
+        try:
+            shutil.rmtree(directory_path)
+        except FileNotFoundError:
+            print(f"directory '{directory_path}' not found - cannot remove")
+        except PermissionError:
+            raise PermissionError(
+                f"insufficient permissions to remove directory '{directory_path}'"
+            )
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+    @staticmethod
+    def copy_file(dest_file_path, src_file_path):
+        try:
+            shutil.copy2(src_file_path, dest_file_path)
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"the source file does not exist: '{src_file_path}'"
+            )
+        except PermissionError as e:
+            raise PermissionError(
+                f"permission denied: '{src_file_path}' or '{dest_file_path}'"
+            )
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+    @staticmethod
+    def check_file_exists(file_path):
+        exists = False
+        try:
+            if os.path.exists(file_path):
+                exists = True
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+        return exists
+
+    @staticmethod
+    def check_directory_exists(directory_path):
+        exists = False
+        try:
+            if os.path.isdir(directory_path):
+                exists = True
+        except Exception as e:
+            raise Exception(f"an unexpected error occurred: {e}")
+
+        return exists

--- a/tt_torch/tools/profile.py
+++ b/tt_torch/tools/profile.py
@@ -31,7 +31,7 @@ def profile(
     env_vars["TT_METAL_DEVICE_PROFILER"] = "1"
     env_vars["TT_METAL_CLEAR_L1"] = "1"
     env_vars["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
-    env_vars["TT_METAL_PROFILER_SYNC"] = "1"  # fix desync between host and device calls
+    # env_vars["TT_METAL_PROFILER_SYNC"] = "1"  # fix desync between host and device calls - disabled due to CI issue
 
     testProcess = subprocess.Popen(
         [test_command], shell=True, env=env_vars, preexec_fn=os.setsid

--- a/tt_torch/tools/profile.py
+++ b/tt_torch/tools/profile.py
@@ -10,11 +10,13 @@ import sys
 from argparse import ArgumentParser
 
 
-def profile(test_command: str, output_filename: str = Profiler.DEFAULT_OUTPUT_FILENAME):
-    profiler = Profiler(output_filename)
+def profile(test_command: str, output_filename: str = Profiler.DEFAULT_OUTPUT_FILENAME, port: int = 8086):
+    profiler = Profiler(output_filename, port)
     profiler.assert_perf_build()
     profiler.setup_tracy_server()
 
+    import time 
+    time.sleep(10)
     # Test process must not run in main process, (i.e. via pytest.main) or else tracy capture will deadlock with main
     testProcess = subprocess.Popen(
         [test_command], shell=True, env=os.environ.copy(), preexec_fn=os.setsid
@@ -62,7 +64,15 @@ if __name__ == "__main__":
         type=str,
         default=Profiler.DEFAULT_OUTPUT_FILENAME,
     )
+    parser.add_argument(
+        "-p",
+        "--port",
+        help="Output file path",
+        type=int,
+        default=8086, # tracy client default port
+    )
+
 
     args = parser.parse_args()
 
-    profile(args.test_command, args.output_path)
+    profile(args.test_command, args.output_path, args.port)

--- a/tt_torch/tools/profile.py
+++ b/tt_torch/tools/profile.py
@@ -10,12 +10,17 @@ import sys
 from argparse import ArgumentParser
 
 
-def profile(test_command: str, output_filename: str = Profiler.DEFAULT_OUTPUT_FILENAME, port: int = 8086):
+def profile(
+    test_command: str,
+    output_filename: str = Profiler.DEFAULT_OUTPUT_FILENAME,
+    port: int = 8086,
+):
     profiler = Profiler(output_filename, port)
     profiler.assert_perf_build()
     profiler.setup_tracy_server()
 
-    import time 
+    import time
+
     time.sleep(10)
     # Test process must not run in main process, (i.e. via pytest.main) or else tracy capture will deadlock with main
     testProcess = subprocess.Popen(
@@ -69,9 +74,8 @@ if __name__ == "__main__":
         "--port",
         help="Output file path",
         type=int,
-        default=8086, # tracy client default port
+        default=8086,  # tracy client default port
     )
-
 
     args = parser.parse_args()
 

--- a/tt_torch/tools/profile.py
+++ b/tt_torch/tools/profile.py
@@ -31,6 +31,7 @@ def profile(
     env_vars["TT_METAL_DEVICE_PROFILER"] = "1"
     env_vars["TT_METAL_CLEAR_L1"] = "1"
     env_vars["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+    env_vars["TT_METAL_PROFILER_SYNC"] = "1"  # fix desync between host and device calls
 
     testProcess = subprocess.Popen(
         [test_command], shell=True, env=env_vars, preexec_fn=os.setsid

--- a/tt_torch/tools/profile_util.py
+++ b/tt_torch/tools/profile_util.py
@@ -12,11 +12,13 @@ import shutil
 from tt_torch.tools.utils import FileManager
 import csv
 import json
+import re
 
 
 class Profiler:
     DEFAULT_OUTPUT_FILENAME = "device_ops_perf_trace.csv"
-
+    port = 8086
+    
     @staticmethod
     def get_ttmetal_home_path():
         return os.environ.get(
@@ -24,7 +26,7 @@ class Profiler:
             "third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal",
         )
 
-    def __init__(self, output_filename: str = DEFAULT_OUTPUT_FILENAME):
+    def __init__(self, output_filename: str = DEFAULT_OUTPUT_FILENAME, port:int = 8086):
         self.tracy_capture_tool_path = (
             f"{self.get_ttmetal_home_path()}/tools/profiler/bin/capture-release"
         )
@@ -52,6 +54,8 @@ class Profiler:
 
         FileManager.remove_file(self.tracy_ops_times_file_path)
         FileManager.remove_file(self.tracy_ops_data_file_path)
+        
+        self.port = port
 
     def check_install_tt_metal_tool_binaries(self):
         this_dir = os.path.dirname(__file__)
@@ -137,18 +141,31 @@ class Profiler:
         def get_available_port():
             ip = socket.gethostbyname(socket.gethostname())
 
-            for port in range(8086, 8500):
+            def try_bind(port, do_raise=False):
                 try:
-                    serv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    serv.bind((ip, port))
-                    return str(port)
-                except PermissionError as e:
-                    pass
-                except OSError as e:
-                    pass
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as serv:
+                        serv.bind((ip, port))
+                        return str(port)
+                except (PermissionError, OSError) as e:
+                    if do_raise:
+                        raise e
+                    return None
+
+            # Check default port range if self.port not overridden
+            if self.port == 8086:
+                for port in range(8086, 8500):
+                    result = try_bind(port)
+                    if result:
+                        return result
+                    
+            # Try binding to the specified port
+            else:
+                return try_bind(self.port, do_raise=True)
+
             return None
 
         port = get_available_port()
+        # port = "8087"
 
         if not port:
             raise Exception("No available port found")
@@ -156,10 +173,14 @@ class Profiler:
         os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
         os.environ["TT_METAL_CLEAR_L1"] = "1"
         os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
+        
+        env_vars = dict(os.environ)
+        env_vars["TRACY_PORT"] = port
 
         tracy_capture_tool_command = (
             f"{self.tracy_capture_tool_path} -o {self.tracy_file_path} -f -p {port}"
         )
+        
         self.tracy_capture_tool_process = subprocess.Popen(
             tracy_capture_tool_command, shell=True  # ,env=os.environ.copy()
         )
@@ -170,12 +191,14 @@ class Profiler:
         try:
             # block until tracy capture tool exits with T/O limit.
             # this should not take long as the client should have exited and the capture tool just needs to write out the tracedump
-            self.tracy_capture_tool_process.communicate(timeout=5)
+            tracy_exit_start_time = time.time() 
+            self.tracy_capture_tool_process.communicate(timeout=60)
+            print(f"Tracy capture tool has exited after {time.time() - tracy_exit_start_time} seconds.")
         except subprocess.TimeoutExpired as e:
             self.tracy_capture_tool_process.terminate()
             self.tracy_capture_tool_process.communicate()
             raise Exception(
-                f"No profiling data could be captured. Please make sure you are on the correct build"
+                f"No profiling data could be captured. Please make sure you are on the correct build and specify a port that is not in use."
             )
 
     def process_csvexport(self):
@@ -220,9 +243,12 @@ class Profiler:
 
     def post_process_ops(self):
         # Add post-processing steps to insert location data into the ops_perf data file
+        
+        loc_pattern = r'loc\(fused\[.*?, "([^"]+)"\]\)'
+        
         with open(self.profiler_report_csv_path, "r") as perf_file:
             perf_reader = csv.DictReader(perf_file)
-            headers = list(perf_reader.fieldnames) + ["LOC"]
+            headers = ["LOC"] + list(perf_reader.fieldnames) + ["Raw LOC"]
             perf_data = list(perf_reader)
 
         with open(self.profiler_report_csv_path, "w+") as perf_file, open(
@@ -241,12 +267,16 @@ class Profiler:
                     if prev:
                         # Get the location data from the previous message and add it as new data for the perf_data (as a new col)
                         if len(perf_data) > ops_index:
-                            perf_data[ops_index]["LOC"] = prev
+                            perf_data[ops_index]["Raw LOC"] = prev
+                            
+                            loc_match = re.search(loc_pattern, prev)
+                            perf_data[ops_index]["LOC"] = loc_match.group(1) if loc_match else "Unknown"
                             ops_index += 1
                 else:
                     prev = message
             perf_writer = csv.DictWriter(perf_file, fieldnames=headers)
             perf_writer.writeheader()
+            
             for row in perf_data:
                 perf_writer.writerow(row)
 
@@ -258,12 +288,11 @@ class Profiler:
         ) as report_file:
             perf_reader = csv.DictReader(perf_file)
             headers = perf_reader.fieldnames
-            headers = [headers[-1]] + headers[:-1]  # move LOC to first column
-
+                                    
             ops_writer = csv.DictWriter(report_file, headers)
             ops_writer.writeheader()
             for row in perf_reader:
-                if "loc" in row["LOC"]:
+                if "loc" in row["Raw LOC"]:
                     ops_writer.writerow(row)
 
         print(f"Wrote report to {self.profile_ops_perf_report}")

--- a/tt_torch/tools/profile_util.py
+++ b/tt_torch/tools/profile_util.py
@@ -9,10 +9,10 @@ import socket
 import signal
 import sys
 import shutil
-from tt_torch.tools.utils import FileManager
 import csv
 import json
 import re
+from tt_torch.tools.filemanager import FileManager
 
 
 class Profiler:
@@ -182,6 +182,8 @@ class Profiler:
         tracy_capture_tool_command = (
             f"{self.tracy_capture_tool_path} -o {self.tracy_file_path} -f -p {port}"
         )
+
+        print("Starting capture tool with command:", tracy_capture_tool_command)
 
         self.tracy_capture_tool_process = subprocess.Popen(
             tracy_capture_tool_command, shell=True  # ,env=os.environ.copy()

--- a/tt_torch/tools/profile_util.py
+++ b/tt_torch/tools/profile_util.py
@@ -167,17 +167,9 @@ class Profiler:
             return None
 
         port = get_available_port()
-        # port = "8087"
 
         if not port:
             raise Exception("No available port found")
-
-        os.environ["TT_METAL_DEVICE_PROFILER"] = "1"
-        os.environ["TT_METAL_CLEAR_L1"] = "1"
-        os.environ["TT_METAL_DEVICE_PROFILER_DISPATCH"] = "0"
-
-        env_vars = dict(os.environ)
-        env_vars["TRACY_PORT"] = port
 
         tracy_capture_tool_command = (
             f"{self.tracy_capture_tool_path} -o {self.tracy_file_path} -f -p {port}"
@@ -188,6 +180,8 @@ class Profiler:
         self.tracy_capture_tool_process = subprocess.Popen(
             tracy_capture_tool_command, shell=True  # ,env=os.environ.copy()
         )
+
+        return port
 
     def close_capture_tool_process(self):
         if self.tracy_capture_tool_process is None:

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
 import re
 import json
 import numpy as np
@@ -664,95 +665,6 @@ def calculate_pcc(tensor, golden_tensor):
 
 def serialize_enum(enum_value):
     return f"{enum_value.__class__.__name__}.{enum_value.name}"
-
-
-class FileManager:
-    @staticmethod
-    def create_file(file_path):
-        try:
-            if not FileManager.check_directory_exists(os.path.dirname(file_path)):
-                FileManager.create_directory(os.path.dirname(file_path))
-            with open(file_path, "w") as file:
-                file.write("")
-        except OSError as e:
-            raise OSError(f"error creating file: {e}")
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-    @staticmethod
-    def create_directory(directory_path, exist_ok=False):
-        try:
-            os.makedirs(directory_path, exist_ok=exist_ok)
-        except FileExistsError as e:
-            raise FileExistsError(f"directory '{directory_path}' already exists")
-        except OSError as e:
-            raise OSError(f"error creating directory: {e}")
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-    @staticmethod
-    def remove_file(file_path):
-        try:
-            os.remove(file_path)
-        except FileNotFoundError:
-            print(f"directory '{file_path}' not found - cannot remove")
-        except PermissionError:
-            raise PermissionError(
-                f"insufficient permissions to remove file '{file_path}'"
-            )
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-    @staticmethod
-    def remove_directory(directory_path):
-
-        try:
-            shutil.rmtree(directory_path)
-        except FileNotFoundError:
-            print(f"directory '{directory_path}' not found - cannot remove")
-        except PermissionError:
-            raise PermissionError(
-                f"insufficient permissions to remove directory '{directory_path}'"
-            )
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-    @staticmethod
-    def copy_file(dest_file_path, src_file_path):
-        try:
-            shutil.copy2(src_file_path, dest_file_path)
-        except FileNotFoundError as e:
-            raise FileNotFoundError(
-                f"the source file does not exist: '{src_file_path}'"
-            )
-        except PermissionError as e:
-            raise PermissionError(
-                f"permission denied: '{src_file_path}' or '{dest_file_path}'"
-            )
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-    @staticmethod
-    def check_file_exists(file_path):
-        exists = False
-        try:
-            if os.path.exists(file_path):
-                exists = True
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-        return exists
-
-    @staticmethod
-    def check_directory_exists(directory_path):
-        exists = False
-        try:
-            if os.path.isdir(directory_path):
-                exists = True
-        except Exception as e:
-            raise Exception(f"an unexpected error occurred: {e}")
-
-        return exists
 
 
 def tt_torch_error_message(func):


### PR DESCRIPTION
### Ticket
#651 

### Problem description
- There is no documentation on perf tracing in tt-torch
- A rare capture server deadlock scenario can occur due to recursive imports and pybind mechanics causing something in tt-metal or tt-mlir to report that the orchestrator process is a tracy client
- Port number cannot be specified for tracy client/server pair

### What's changed
- Add documentation file describing prerequisites, usage, limitations, debugging tips
- Move filemanager to its own file, to avoid anything in the import path from importing the tt_mlir bindings which creates a potential deadlock
- Add port specification option -p to profile.py
- Add location stripping to get torchfx node name in LOC column and preserve line numbered locations in the last column

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] (Todo) - Check for full op coverage in llama3 test 
