### PR TITLE
Replace EfficientNet onnx e2e tests with pytorch tests

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -40,7 +40,6 @@ jobs:
             runs-on: wormhole_b0, name: "eval_2", tests: "
                   tests/models/mnist/test_mnist.py::test_mnist_train[full-eval]
                   tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2[full-eval]
-                  tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2_onnx[full-eval]
                   tests/models/openpose/test_openpose_v2.py::test_openpose_v2[full-eval]
                   tests/models/resnet/test_resnet.py::test_resnet[full-eval]
                   tests/models/resnet50/test_resnet50.py::test_resnet[full-eval]
@@ -93,16 +92,17 @@ jobs:
                 tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-wide_resnet101_2]
             "
           },
+          # Takes ~40 minutes
           {
             runs-on: wormhole_b0, name: "eval_6", tests: "
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b0-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b1-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b2-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b3-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b4-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b5-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b6-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b7-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
 
             "
           },

--- a/tests/models/EfficientNet/test_EfficientNet_onnx.py
+++ b/tests/models/EfficientNet/test_EfficientNet_onnx.py
@@ -68,7 +68,6 @@ class ThisTester(OnnxModelTester):
 )
 def test_EfficientNet_onnx(record_property, model_name, mode, op_by_op):
     cc = CompilerConfig()
-    cc.compile_depth = CompileDepth.STABLEHLO
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = OpByOpBackend.STABLEHLO

--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -44,7 +44,6 @@ class ThisTester(OnnxModelTester):
 def test_MobileNetV2_onnx(record_property, mode, op_by_op):
     model_name = "MobileNetV2_onnx"
     cc = CompilerConfig()
-    cc.compile_depth = CompileDepth.STABLEHLO
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 


### PR DESCRIPTION
Remove MobileNetV2 onnx end-to end test since it runs until stablehlo. @kmabeeTT is working on an op-by-op-stablehlo workflow, where MobileNetV2 and EfficientNet will go to.