### PR TITLE
Uplift torch-mlir

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,9 @@
 #
 
 set(TT_MLIR_VERSION "807f0e8df976a77363247ba6034a4579e9f2c0e0")
-set(TORCH_MLIR_VERSION "a265d283357f572c5437f9217ea85fa9770d374c")
+# torch-mlir is using branch tt_torch/main
+# see issue https://github.com/tenstorrent/tt-torch/issues/671
+set(TORCH_MLIR_VERSION "7c86f6d21de6d548c41cc56ebf0d799e1eadc626")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)


### PR DESCRIPTION
This uplift fixes the following
- AtenAnyDimsOp (torch-mlir support + conversion to shlo)
- AtenRoundDecimalsOp (torch-mlir support + conversion to shlo)
- Add `ceilMode` support for max_pool2d op in torch-mlir->shlo conversion 

**Torch-mlir PRs**
- torch-mlir PR to add support for missing ops (AtenAnyDimsOp, AtenRoundDecimalsOp) https://github.com/tenstorrent/llvm-torch-mlir/pull/7
- torch-mlir PR to to fix max_pool2d op https://github.com/tenstorrent/llvm-torch-mlir/pull/5

Issue page for more information about torch-mlir uplift https://github.com/tenstorrent/tt-torch/issues/671