### PR TITLE
Promote 4 models to full-model-execute and 1 model to e2e compile list

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -32,6 +32,7 @@ jobs:
                   tests/models/vilt/test_vilt.py::test_vilt[full-eval]
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
                   tests/models/mistral/test_mistral_7b.py::test_mistral_7b[full-eval]
+                  tests/models/falcon/test_falcon.py::test_falcon[full-eval]
             "
           }
         ]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         build: [
           {
-            # Approximately 50 minutes.
+            # Approximately 70 minutes.
             runs-on: wormhole_b0, name: "eval_1", tests: "
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vgg19]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vgg19_bn]
@@ -70,7 +70,7 @@ jobs:
             "
           },
           {
-            # Approximately 60 minutes.
+            # Approximately 65 minutes.
             runs-on: wormhole_b0, name: "eval_2", tests: "
                   tests/models/bloom/test_bloom.py::test_bloom[full-eval]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-hrnet_w18.ms_aug_in1k]
@@ -81,29 +81,33 @@ jobs:
                   tests/models/yolov5/test_yolov5.py::test_yolov5[full-eval]
                   tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[full-twmkn9/albert-base-v2-squad2-eval]
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1-eval]
+                  tests/models/clip/test_clip.py::test_clip[full-eval]
+                  tests/models/gpt2/test_gpt2.py::test_gpt2[full-eval]
+                  tests/models/xglm/test_xglm.py::test_xglm[full-eval]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-swin_b]
             "
           },
           {
-            # Approximately 40 minutes.
+            # Approximately 45 minutes.
             runs-on: wormhole_b0, name: "eval_3", tests: "
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1.5-eval]
             "
           },
           {
-            # Approximately 80 minutes.
+            # Approximately 50 minutes.
             runs-on: wormhole_b0, name: "eval_5", tests: "
                   tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-Qwen/Qwen2.5-1.5B-eval]
                   tests/models/opt/test_opt.py::test_opt[full-eval]
             "
           },
           {
-            # Approximately 60 minutes.
+            # Approximately 40 minutes.
             runs-on: wormhole_b0, name: "eval_6", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
             "
           },
           {
-            # Approximately 60 minutes.
+            # Approximately 5 minutes.
             runs-on: wormhole_b0, name: "eval_7_bert_qrtn", tests: "
                   tests/models/bert/test_bert.py::test_bert[full-eval]
             "

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -40,18 +40,12 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "gpt", tests: "
-              tests/models/gpt2/test_gpt2.py::test_gpt2
               tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo
               "
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
               tests/models/llama/test_llama_7b.py::test_llama_7b
-              "
-          },
-          {
-            runs-on: wormhole_b0, name: "xglm", tests: "
-              tests/models/xglm/test_xglm.py::test_xglm
               "
           },
           {
@@ -84,11 +78,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "clip", tests: "
-              tests/models/clip/test_clip.py::test_clip
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "timm", tests: "
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-ghostnetv2_100.in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-inception_v4.tf_in1k]
@@ -112,7 +101,6 @@ jobs:
             runs-on: wormhole_b0, name: "torchvision_1", tests: "
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-googlenet]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-densenet201]
-              tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[op_by_op_torch-eval-swin_b]
               "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -54,6 +54,11 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "gpt", tests: "
+              tests/models/gpt2/test_gpt2.py::test_gpt2
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "llama", tests: "
               tests/models/llama/test_llama_3b.py::test_llama_3b
               "
@@ -86,6 +91,11 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "clip", tests: "
+              tests/models/clip/test_clip.py::test_clip
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "timm", tests: "
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-hrnet_w18.ms_aug_in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-dla34.in1k]
@@ -98,6 +108,11 @@ jobs:
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-tf_efficientnet_lite3.in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-tf_efficientnet_lite4.in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-mixer_b16_224.goog_in21k]
+              "
+          },
+          {
+            runs-on: wormhole_b0, name: "xglm", tests: "
+              tests/models/xglm/test_xglm.py::test_xglm
               "
           },
           {
@@ -165,6 +180,7 @@ jobs:
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-wide_resnet101_2]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-regnet_y_32gf]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-regnet_x_32gf]
+              tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[op_by_op_torch-eval-swin_b]
               "
           },
           {

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -114,16 +114,18 @@ def run_torchvision_image_classification_test(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/491
+    # TODO Enable checking (vit_h_14) - https://github.com/tenstorrent/tt-torch/issues/491
+    # TODO Enable checking (swin_b) - https://github.com/tenstorrent/tt-torch/issues/663
     model_name = model_info[0]
-    assert_pcc = False if model_name in ["vit_h_14"] else True
+    assert_pcc = False if model_name in ["vit_h_14", "swin_b"] else True
+    assert_atol = False if model_name in ["swin_b"] else True
 
     tester = ThisTester(
         model_info,
         mode,
         required_pcc=0.97,
         assert_pcc=assert_pcc,
-        assert_atol=False,
+        assert_atol=assert_atol,
         compiler_config=cc,
         record_property_handle=record_property,
         model_group=model_group,


### PR DESCRIPTION
### Ticket
None

### What's changed

- Passing after tt-mlir update which brought some compiler fixes/workarounds
- Promote falcon to e2e compile list
- Promote CLIP, GPT2, XGLM, swin_b to full model execute
- Adjust some times of test groups based on recent nightly regressions

### Checklist
- [x] tested on branch : https://github.com/tenstorrent/tt-torch/actions/runs/14675856301
