### PR TITLE
Put assert_atol=False back for vit_h_14 accidentally enabled last commit

### DIFF
--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -118,7 +118,7 @@ def run_torchvision_image_classification_test(
     # TODO Enable checking (swin_b) - https://github.com/tenstorrent/tt-torch/issues/663
     model_name = model_info[0]
     assert_pcc = False if model_name in ["vit_h_14", "swin_b"] else True
-    assert_atol = False if model_name in ["swin_b"] else True
+    assert_atol = False if model_name in ["vit_h_14", "swin_b"] else True
 
     tester = ThisTester(
         model_info,


### PR DESCRIPTION
### Ticket
None

### What's changed
- Change to assert_atol in previous commit efa96cd was intended to disable for swin_b only
- But it was already disabled by default so change wasn't actually necessary, and accidentally enabled for other models, whoops.
- Turns out it passes for all models except vit_h_14, so put assert_atol=False back for vit_h_14 

### Checklist
- [x] Run on branch
