### PR TITLE
Change op-by-op nightly back to not printing on screen, too verbose

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -226,7 +226,7 @@ jobs:
           counter=$((counter + 1))
 
           echo "====== BEGIN LOG: $test_case ======" >> pytest.log
-          pytest -svv "$test_case" --op_by_op_torch 2>&1 | tee -a pytest.log
+          pytest -svv "$test_case" --op_by_op_torch >> pytest.log 2>&1
           exit_code=$?
 
           echo "====== END LOG: $test_case ========" >> pytest.log


### PR DESCRIPTION
### Ticket
None

### Problem description
- Recent change f28104c introduced pytest.log but made op-by-op-flow also write to stdout in CI which is too much text and makes it impossible to read output, and exceeds CI output log length often

### What's changed
- Small change to prevent output from being printed to screen again, similar to previous behavior, but while still keeping it in pytest.log

### Checklist
- [x] Tested on branch https://github.com/tenstorrent/tt-torch/actions/runs/14697916675
