### PR TITLE
Various infra changes to improve op_by_op_stablehlo and support in same CI job as op_by_op_torch models

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -117,6 +117,19 @@ jobs:
             runs-on: wormhole_b0, name: "eval_8", tests: "
                   tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-790m-hf-eval]
             "
+          },
+          # Approximately 40 minutes.
+          {
+            runs-on: wormhole_b0, name: "eval_9", tests: "
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
+            "
           }
         ]
     runs-on:

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -92,20 +92,6 @@ jobs:
                 tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-wide_resnet101_2]
             "
           },
-          # Takes ~40 minutes
-          {
-            runs-on: wormhole_b0, name: "eval_6", tests: "
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
-
-            "
-          },
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -24,57 +24,59 @@ jobs:
         build: [
           {
             runs-on: wormhole_b0, name: "qwen", tests: "
-              tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification
+              tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[op_by_op_torch-Qwen/Qwen2-7B-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "autoencoder", tests: "
-              tests/models/autoencoder_conv/test_autoencoder_conv.py::test_autoencoder_conv
-              tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2
+              tests/models/autoencoder_conv/test_autoencoder_conv.py::test_autoencoder_conv[op_by_op_torch-eval]
+              tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "falcon", tests: "
-              tests/models/falcon/test_falcon.py::test_falcon
+              tests/models/falcon/test_falcon.py::test_falcon[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "gpt", tests: "
-              tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo
+              tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
-              tests/models/llama/test_llama_7b.py::test_llama_7b
+              tests/models/llama/test_llama_7b.py::test_llama_7b[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "openpose", tests: "
-              tests/models/openpose/test_openpose.py::test_openpose
+              tests/models/openpose/test_openpose.py::test_openpose[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "stable-diffusion-pipe", tests: "
-              tests/models/stable_diffusion/test_stable_diffusion.py::test_stable_diffusion
+              tests/models/stable_diffusion/test_stable_diffusion.py::test_stable_diffusion[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "t5", tests: "
-              tests/models/t5/test_t5.py::test_t5
-              tests/models/flan_t5/test_flan_t5.py::test_flan_t5
-              tests/models/speecht5_tts/test_speecht5_tts.py::test_speecht5_tts
+              tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-small-eval]
+              tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-base-eval]
+              tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-large-eval]
+              tests/models/flan_t5/test_flan_t5.py::test_flan_t5[op_by_op_torch-eval]
+              tests/models/speecht5_tts/test_speecht5_tts.py::test_speecht5_tts[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "unet", tests: "
-              tests/models/unet/test_unet.py::test_unet
-              tests/models/unet_brain/test_unet_brain.py::test_unet_brain
-              tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana
+              tests/models/unet/test_unet.py::test_unet[op_by_op_torch-eval]
+              tests/models/unet_brain/test_unet_brain.py::test_unet_brain[op_by_op_torch-eval]
+              tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "RMBG", tests: "
-              tests/models/RMBG/test_RMBG.py::test_RMBG
+              tests/models/RMBG/test_RMBG.py::test_RMBG[op_by_op_torch-eval]
               "
           },
           {
@@ -86,15 +88,15 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "vision-misc", tests: "
-              tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti
-              tests/models/hand_landmark/test_hand_landmark.py::test_hand_landmark
-              tests/models/segment_anything/test_segment_anything.py::test_segment_anything
-              tests/models/vilt/test_vilt.py::test_vilt
+              tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[op_by_op_torch-eval]
+              tests/models/hand_landmark/test_hand_landmark.py::test_hand_landmark[op_by_op_torch-eval]
+              tests/models/segment_anything/test_segment_anything.py::test_segment_anything[op_by_op_torch-eval]
+              tests/models/vilt/test_vilt.py::test_vilt[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "codegen", tests: "
-              tests/models/codegen/test_codegen.py::test_codegen
+              tests/models/codegen/test_codegen.py::test_codegen[op_by_op_torch-eval]
               "
           },
           {
@@ -105,13 +107,13 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "mistral", tests: "
-              tests/models/mistral/test_mistral_7b.py::test_mistral_7b
+              tests/models/mistral/test_mistral_7b.py::test_mistral_7b[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "deepseek", tests: "
-              tests/models/deepseek/test_deepseek.py::test_deepseek
-              tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen
+              tests/models/deepseek/test_deepseek.py::test_deepseek[op_by_op_torch-deepseek-ai/DeepSeek-V3-eval]
+              tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[op_by_op_torch-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
               "
           },
           {
@@ -226,7 +228,7 @@ jobs:
           counter=$((counter + 1))
 
           echo "====== BEGIN LOG: $test_case ======" >> pytest.log
-          pytest -svv "$test_case" --op_by_op_torch >> pytest.log 2>&1
+          pytest -svv "$test_case" >> pytest.log 2>&1
           exit_code=$?
 
           echo "====== END LOG: $test_case ========" >> pytest.log

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -35,7 +35,7 @@ jobs:
               tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[op_by_op_torch-albert/albert-xxlarge-v2-eval]
               tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[op_by_op_torch-albert/albert-base-v2-eval]
               tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[op_by_op_torch-textattack/albert-base-v2-imdb-eval]
-              tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[op_by_op_torch-twmbkn9/albert-base-v2-squad2-eval]
+              tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[op_by_op_torch-twmkn9/albert-base-v2-squad2-eval]
               "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -24,43 +24,46 @@ jobs:
         build: [
           {
             runs-on: wormhole_b0, name: "qwen", tests: "
-              tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm
+              tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[op_by_op_torch-Qwen/Qwen2.5-1.5B-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "albert", tests: "
-              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm
-              tests/models/albert/test_albert_token_classification.py::test_albert_token_classification
-              tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification
-              tests/models/albert/test_albert_question_answering.py::test_albert_question_answering
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[op_by_op_torch-albert/albert-base-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[op_by_op_torch-albert/albert-large-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[op_by_op_torch-albert/albert-xlarge-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[op_by_op_torch-albert/albert-xxlarge-v2-eval]
+              tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[op_by_op_torch-albert/albert-base-v2-eval]
+              tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[op_by_op_torch-textattack/albert-base-v2-imdb-eval]
+              tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[op_by_op_torch-twmbkn9/albert-base-v2-squad2-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "autoencoder", tests: "
-              tests/models/autoencoder_linear/test_autoencoder_linear.py::test_autoencoder_linear
+              tests/models/autoencoder_linear/test_autoencoder_linear.py::test_autoencoder_linear[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "bert", tests: "
-              tests/models/distilbert/test_distilbert.py::test_distilbert
-              tests/models/bert/test_bert.py::test_bert
-              tests/models/bert/test_bert_turkish.py::test_bert_turkish
-              tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert
+              tests/models/distilbert/test_distilbert.py::test_distilbert[op_by_op_torch-distilbert-base-uncased-eval]
+              tests/models/bert/test_bert.py::test_bert[op_by_op_torch-eval]
+              tests/models/bert/test_bert_turkish.py::test_bert_turkish[op_by_op_torch-eval]
+              tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "bloom", tests: "
-              tests/models/bloom/test_bloom.py::test_bloom
+              tests/models/bloom/test_bloom.py::test_bloom[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "gpt", tests: "
-              tests/models/gpt2/test_gpt2.py::test_gpt2
+              tests/models/gpt2/test_gpt2.py::test_gpt2[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
-              tests/models/llama/test_llama_3b.py::test_llama_3b
+              tests/models/llama/test_llama_3b.py::test_llama_3b[op_by_op_torch-meta-llama/Llama-3.2-3B-eval]
               "
           },
           {
@@ -76,23 +79,23 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "openpose", tests: "
-              tests/models/openpose/test_openpose_v2.py::test_openpose_v2
+              tests/models/openpose/test_openpose_v2.py::test_openpose_v2[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "resnet", tests: "
-              tests/models/resnet50/test_resnet50.py::test_resnet
-              tests/models/resnet/test_resnet.py::test_resnet
+              tests/models/resnet50/test_resnet50.py::test_resnet[op_by_op_torch-eval]
+              tests/models/resnet/test_resnet.py::test_resnet[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "opt", tests: "
-              tests/models/opt/test_opt.py::test_opt
+              tests/models/opt/test_opt.py::test_opt[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "clip", tests: "
-              tests/models/clip/test_clip.py::test_clip
+              tests/models/clip/test_clip.py::test_clip[op_by_op_torch-eval]
               "
           },
           {
@@ -112,56 +115,57 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "xglm", tests: "
-              tests/models/xglm/test_xglm.py::test_xglm
+              tests/models/xglm/test_xglm.py::test_xglm[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "vision-misc", tests: "
-              tests/models/perceiver_io/test_perceiver_io.py::test_perceiver_io
-              tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer
-              tests/models/mnist/test_mnist.py::test_mnist_train
-              tests/models/hardnet/test_hardnet.py::test_hardnet
+              tests/models/perceiver_io/test_perceiver_io.py::test_perceiver_io[op_by_op_torch-eval]
+              tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[op_by_op_torch-eval]
+              tests/models/mnist/test_mnist.py::test_mnist_train[op_by_op_torch-eval]
+              tests/models/hardnet/test_hardnet.py::test_hardnet[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "vision-transformers", tests: "
-              tests/models/segformer/test_segformer.py::test_segformer
-              tests/models/deit/test_deit.py::test_deit
-              tests/models/beit/test_beit_image_classification.py::test_beit_image_classification
-              tests/models/detr/test_detr.py::test_detr
+              tests/models/segformer/test_segformer.py::test_segformer[op_by_op_torch-eval]
+              tests/models/deit/test_deit.py::test_deit[op_by_op_torch-facebook/deit-base-patch16-224-eval]
+              tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[op_by_op_torch-microsoft/beit-base-patch16-224-eval]
+              tests/models/beit/test_beit_image_classification.py::test_beit_image_classification[op_by_op_torch-microsoft/beit-large-patch16-224-eval]
+              tests/models/detr/test_detr.py::test_detr[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "yolo", tests: "
-              tests/models/yolov3/test_yolov3.py::test_yolov3
-              tests/models/yolov4/test_yolov4.py::test_yolov4
-              tests/models/yolov5/test_yolov5.py::test_yolov5
-              tests/models/yolos/test_yolos.py::test_yolos
+              tests/models/yolov3/test_yolov3.py::test_yolov3[op_by_op_torch-eval]
+              tests/models/yolov4/test_yolov4.py::test_yolov4[op_by_op_torch-eval]
+              tests/models/yolov5/test_yolov5.py::test_yolov5[op_by_op_torch-eval]
+              tests/models/yolos/test_yolos.py::test_yolos[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "mgp-str", tests: "
-              tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base
+              tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "musicgen_small", tests: "
-              tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small
+              tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "dpr", tests: "
-              tests/models/dpr/test_dpr.py::test_dpr
+              tests/models/dpr/test_dpr.py::test_dpr[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "roberta", tests: "
-              tests/models/roberta/test_roberta.py::test_roberta
+              tests/models/roberta/test_roberta.py::test_roberta[op_by_op_torch-eval]
               "
           },
           {
             runs-on: wormhole_b0, name: "whisper", tests: "
-              tests/models/whisper/test_whisper.py::test_whisper
+              tests/models/whisper/test_whisper.py::test_whisper[op_by_op_torch-eval]
               "
           },
           {
@@ -196,7 +200,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "stable-diffusion-unet", tests: "
-              tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet
+              tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[op_by_op_torch-eval]
               "
           },
           {
@@ -290,7 +294,7 @@ jobs:
 
           pytest_log="test_${counter}.log"
 
-          pytest -svv "$test_case" --op_by_op_torch > "$pytest_log" 2>&1
+          pytest -svv "$test_case" > "$pytest_log" 2>&1
           exit_code=$?
 
           echo "====== BEGIN LOG: $test_case ======" >> full_job_output.log

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -288,7 +288,7 @@ def apply_non_zero_conditional_format(worksheet, row, col, compile_status, forma
 
 
 # Create summary worksheet with per-model compilation status.
-# models_info - list of tuples containing (model_name, model_group)
+# models_info - list of tuples containing (model_name, model_group, backend)
 def create_summary_worksheet(workbook, models_info):
 
     print(f"Creating summary for {len(models_info)} models")
@@ -311,7 +311,7 @@ def create_summary_worksheet(workbook, models_info):
     worksheet.write_row(
         2,
         0,
-        ["Model / Compilation Status", "Group", 0, 1, 2, 3, 4, 5, 6, 7],
+        ["Model / Compilation Status", "Group", "Backend", 0, 1, 2, 3, 4, 5, 6, 7],
         bold_format,
     )
     worksheet.freeze_panes(3, 0)  # Freeze rows 0,1,2
@@ -330,43 +330,48 @@ def create_summary_worksheet(workbook, models_info):
 
     # Merge headers for columns that will be populated per model.
     worksheet.merge_range(
-        2, 13, 2, 14, "Compiled to TTNN (Status 6,7)", centered_format
+        2, 14, 2, 15, "Compiled to TTNN (Status 6,7)", centered_format
     )
     worksheet.merge_range(
-        2, 16, 2, 17, "Executed on Device (Status 7)", centered_format
+        2, 17, 2, 18, "Executed on Device (Status 7)", centered_format
     )
 
     row = 3
-    for model_name, model_group in models_info:
+    for model_name, model_group, backend in models_info:
 
+        # Get backend from model sheet
         worksheet.write(row, 1, model_group)
         worksheet.set_column(1, 1, 10)
 
+        worksheet.write(row, 2, backend)
+        worksheet.set_column(2, 2, 10)
+
+        col_id = "G"  # Compile Status column
         for compile_status in range(0, 8):
             # baking dynamic references
-            compile_status_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!F:F"), {compile_status})'
-            worksheet.write(row, 2 + compile_status, compile_status_formula)
+            compile_status_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!{col_id}:{col_id}"), {compile_status})'
+            worksheet.write(row, 3 + compile_status, compile_status_formula)
             apply_non_zero_conditional_format(
-                worksheet, row, 2 + compile_status, compile_status, color_formats
+                worksheet, row, 3 + compile_status, compile_status, color_formats
             )
 
-        # Calculate Total Ops for the current row by summing compilation status columns (B to I)
+        # Calculate Total Ops for the current row by summing compilation status columns (D to K)
         start_cell = xl_rowcol_to_cell(
-            row, 2
+            row, 3
         )  # first compilation status cell for current row
         end_cell = xl_rowcol_to_cell(
-            row, 10
+            row, 11
         )  # last compilation status cell for current row
         total_ops_formula = f"=SUM({start_cell}:{end_cell})"
-        worksheet.write(2, 11, "Total Ops Per Model")
-        worksheet.write(row, 11, total_ops_formula)
-        worksheet.set_column(11, 11, 15)
-        worksheet.set_column(12, 12, 2)
+        worksheet.write(2, 12, "Total Ops Per Model")
+        worksheet.write(row, 12, total_ops_formula)
+        worksheet.set_column(12, 12, 15)
+        worksheet.set_column(13, 13, 2)
 
         # Compute a summary of ops compiling to TTNN per model
-        compile_status_6_cell = xl_rowcol_to_cell(row, 8)
-        compile_status_7_cell = xl_rowcol_to_cell(row, 9)
-        total_ops_cell = xl_rowcol_to_cell(row, 11)
+        compile_status_6_cell = xl_rowcol_to_cell(row, 9)
+        compile_status_7_cell = xl_rowcol_to_cell(row, 10)
+        total_ops_cell = xl_rowcol_to_cell(row, 12)
         compiling_formula_percentage = (
             f"=SUM({compile_status_6_cell}:{compile_status_7_cell})/{total_ops_cell}"
         )
@@ -376,16 +381,16 @@ def create_summary_worksheet(workbook, models_info):
             f'TEXT(SUM({compile_status_6_cell}:{compile_status_7_cell}) - {total_ops_cell},"0") & ") "'
         )
         worksheet.write_formula(
-            row, 13, compiling_formula_percentage, percentage_format
+            row, 14, compiling_formula_percentage, percentage_format
         )
-        worksheet.set_column(13, 13, 12)
-        worksheet.write(row, 14, compiling_formula)
-        worksheet.set_column(14, 14, 15)
-        worksheet.set_column(15, 15, 2)
+        worksheet.set_column(14, 14, 12)
+        worksheet.write(row, 15, compiling_formula)
+        worksheet.set_column(15, 15, 15)
+        worksheet.set_column(16, 16, 2)
 
         # Compute a summary of ops executing on silicon per model
-        compile_status_7_cell = xl_rowcol_to_cell(row, 9)
-        total_ops_cell = xl_rowcol_to_cell(row, 11)
+        compile_status_7_cell = xl_rowcol_to_cell(row, 10)
+        total_ops_cell = xl_rowcol_to_cell(row, 12)
         executing_formula_percentage = f"={compile_status_7_cell}/{total_ops_cell}"
         executing_formula = (
             f'=TEXT({compile_status_7_cell},"0") & "/" & '
@@ -393,34 +398,34 @@ def create_summary_worksheet(workbook, models_info):
             f'TEXT({compile_status_7_cell} - {total_ops_cell},"0") & ") "'
         )
         worksheet.write_formula(
-            row, 16, executing_formula_percentage, percentage_format
+            row, 17, executing_formula_percentage, percentage_format
         )
-        worksheet.set_column(16, 16, 12)
-        worksheet.write(row, 17, executing_formula)
-        worksheet.set_column(17, 17, 15)
+        worksheet.set_column(17, 17, 12)
+        worksheet.write(row, 18, executing_formula)
+        worksheet.set_column(18, 18, 15)
 
         # Determine how many ops for model hit unknown error.
-        col_id = "N"  # Compile Error column
+        col_id = "O"  # Compile Error column
         unknown_errors_formula = f'=COUNTIF(INDIRECT("\'" & "{model_name}" & "\'!{col_id}:{col_id}"), "Error message not extracted.")'
-        worksheet.set_column(18, 18, 2)
-        worksheet.set_column(19, 19, 13)
-        worksheet.write(2, 19, "Unknown Errors")
-        worksheet.write(row, 19, unknown_errors_formula)
-        worksheet.set_column(20, 20, 2)
-        apply_non_zero_conditional_format(worksheet, row, 19, 6, color_formats)
+        worksheet.set_column(19, 19, 2)
+        worksheet.set_column(20, 20, 13)
+        worksheet.write(2, 20, "Unknown Errors")
+        worksheet.write(row, 20, unknown_errors_formula)
+        worksheet.set_column(21, 21, 2)
+        apply_non_zero_conditional_format(worksheet, row, 20, 6, color_formats)
 
         # Determine how many ops for model hit timeout error.
-        col_id = "N"  # Compile Error column
+        col_id = "O"  # Compile Error column
         timeout_errors_formula = f'=COUNTIFS(INDIRECT("\'" & "{model_name}" & "\'!{col_id}:{col_id}"), "*Timeout exceeded for op*")'
-        worksheet.set_column(21, 21, 13)
-        worksheet.write(2, 21, "Timeouts")
-        worksheet.write(row, 21, timeout_errors_formula)
-        worksheet.set_column(22, 22, 2)
-        apply_non_zero_conditional_format(worksheet, row, 21, 6, color_formats)
+        worksheet.set_column(22, 22, 13)
+        worksheet.write(2, 22, "Timeouts")
+        worksheet.write(row, 22, timeout_errors_formula)
+        worksheet.set_column(23, 23, 2)
+        apply_non_zero_conditional_format(worksheet, row, 22, 6, color_formats)
 
         # Apply conditional formatting to the percentage columns per model.
-        apply_percentage_conditional_format(worksheet, row, 13, color_formats, True)
-        apply_percentage_conditional_format(worksheet, row, 16, color_formats, True)
+        apply_percentage_conditional_format(worksheet, row, 14, color_formats, True)
+        apply_percentage_conditional_format(worksheet, row, 17, color_formats, True)
 
         # Finished the per-model row now, move to the next.
         row += 1
@@ -431,37 +436,37 @@ def create_summary_worksheet(workbook, models_info):
     row += 1
     worksheet.write(row, 0, "Total Ops per Compile Status")
     for compile_status in range(0, 8):
-        col = 2 + compile_status
+        col = 3 + compile_status
         total_formula = f"=SUM({xl_rowcol_to_cell(data_start_row, col)}:{xl_rowcol_to_cell(data_end_row, col)})"
         worksheet.write(row, col, total_formula)
 
     # Add totals for unknown errors and timeouts
-    total_formula = f"=SUM({xl_rowcol_to_cell(data_start_row, 19)}:{xl_rowcol_to_cell(data_end_row, 19)})"
-    worksheet.write(row, 19, total_formula)
-    total_formula = f"=SUM({xl_rowcol_to_cell(data_start_row, 21)}:{xl_rowcol_to_cell(data_end_row, 21)})"
-    worksheet.write(row, 21, total_formula)
+    total_formula = f"=SUM({xl_rowcol_to_cell(data_start_row, 20)}:{xl_rowcol_to_cell(data_end_row, 20)})"
+    worksheet.write(row, 20, total_formula)
+    total_formula = f"=SUM({xl_rowcol_to_cell(data_start_row, 22)}:{xl_rowcol_to_cell(data_end_row, 22)})"
+    worksheet.write(row, 22, total_formula)
 
     # Add more top-level summaries to the right of existing data
-    worksheet.set_column(23, 23, 25)
-    worksheet.write(2, 23, "Models Total:")
-    worksheet.write(2, 24, len(model_names))
-    worksheet.write(3, 23, "Models Fully Compiling to TTNN:")
+    worksheet.set_column(24, 24, 25)
+    worksheet.write(2, 24, "Models Total:")
+    worksheet.write(2, 25, len(model_names))
+    worksheet.write(3, 24, "Models Fully Compiling to TTNN:")
     worksheet.write_formula(
         3,
-        24,
-        f"=COUNTIF({xl_rowcol_to_cell(3, 13)}:{xl_rowcol_to_cell(3+len(model_names)-1, 13)}, 100%)",
+        25,
+        f"=COUNTIF({xl_rowcol_to_cell(3, 14)}:{xl_rowcol_to_cell(3+len(model_names)-1, 14)}, 100%)",
     )
-    worksheet.write(4, 23, "Models Fully Executing on Device:")
+    worksheet.write(4, 24, "Models Fully Executing on Device:")
     worksheet.write_formula(
         4,
-        24,
-        f"=COUNTIF({xl_rowcol_to_cell(3, 16)}:{xl_rowcol_to_cell(3+len(model_names)-1, 16)}, 100%)",
+        25,
+        f"=COUNTIF({xl_rowcol_to_cell(3, 17)}:{xl_rowcol_to_cell(3+len(model_names)-1, 17)}, 100%)",
     )
 
     # Print the OpCompilationStatus legend to the summary worksheet
-    worksheet.write(6, 23, "OpCompilationStatus Legend")
+    worksheet.write(6, 24, "OpCompilationStatus Legend")
     for status_code, status_name in enumerate(OP_STATUS_NAMES):
-        worksheet.write(8 + status_code, 23, f"{status_code}: {status_name}")
+        worksheet.write(8 + status_code, 24, f"{status_code}: {status_name}")
 
 
 # Generate All Ops summary worksheets (all and those not making it to execute)
@@ -472,7 +477,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
     # xlsxwriter fails to write anything after 'Compiled Json' field; so it is
     # being written to the last column.
     header = (
-        "Torch Name",
+        "Torch/SHLO Name",
         "Input Shapes",
         "Output Shapes",
         "NumOps",
@@ -493,7 +498,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
     worksheet.freeze_panes(1, 0)
 
     # Set some reasonable column widths for quick visual scanning.
-    worksheet.set_column(0, 0, 37)  # Torch Name
+    worksheet.set_column(0, 0, 37)  # Torch/SHLO Name
     worksheet.set_column(1, 1, 50)  # Input Shapes
     worksheet.set_column(2, 2, 20)  # Output Shapes
     worksheet.set_column(5, 5, 50)  # Models
@@ -694,11 +699,14 @@ def generate_op_reports_xlsx():
             model_name = test_name + f"_{id}"
             id += 1
 
+        backend = first_value.get("backend", "torch")
+        name_col = "Torch Name" if backend == "torch" else "StableHLO Name"
+
         print(
             f"Processing json ({json_idx}/{total_json_files}) {model_name}", flush=True
         )
 
-        model_list.append((model_name, model_group))
+        model_list.append((model_name, model_group, backend))
         worksheet = workbook.add_worksheet(model_name)
         keys = list(data.keys())
         keys.sort()
@@ -706,9 +714,10 @@ def generate_op_reports_xlsx():
         # xlsxwriter fails to write anything after 'Compiled Json' field; so it
         # is being written to the last column.
         header = (
-            "Torch Name",
+            name_col,
             "Input Shapes",
             "Output Shapes",
+            "Backend",
             "Global Op Idx",
             "NumOps",
             "Status",
@@ -743,6 +752,7 @@ def generate_op_reports_xlsx():
             torch_ops[value["torch_name"]].append(
                 {
                     "torch_name": value["torch_name"],
+                    "backend": value["backend"],
                     "input_shapes": value["input_shapes"],
                     "output_shapes": value["output_shapes"],
                     "num_ops": value["num_ops"],
@@ -861,6 +871,7 @@ def generate_op_reports_xlsx():
                     name,
                     input_shapes,
                     output_shapes,
+                    op["backend"],
                     global_op_idx,
                     num_ops,
                     status,

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -480,6 +480,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
         "Torch/SHLO Name",
         "Input Shapes",
         "Output Shapes",
+        "Backend",
         "NumOps",
         "Status",
         "Models",
@@ -501,8 +502,8 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
     worksheet.set_column(0, 0, 37)  # Torch/SHLO Name
     worksheet.set_column(1, 1, 50)  # Input Shapes
     worksheet.set_column(2, 2, 20)  # Output Shapes
-    worksheet.set_column(5, 5, 50)  # Models
-    worksheet.set_column(13, 13, 250)  # Compile Error
+    worksheet.set_column(6, 6, 50)  # Models
+    worksheet.set_column(14, 14, 250)  # Compile Error
 
     row += 1
     torch_ops = {}
@@ -526,6 +527,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
                 "torch_name": value["torch_name"],
                 "input_shapes": value["input_shapes"],
                 "output_shapes": value["output_shapes"],
+                "backend": value["backend"],
                 "num_ops": value["num_ops"],
                 "status": value["compilation_status"],
                 "pcc": value["pcc"],
@@ -548,6 +550,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
             num_ops = op["num_ops"]
             input_shapes = extract_shape(op["input_shapes"])
             output_shapes = extract_shape(op["output_shapes"])
+            backend = op["backend"]
             status = op["status"]
             pcc = op["pcc"]
             atol = op["atol"]
@@ -572,6 +575,7 @@ def generate_all_ops_worksheet(worksheet, bold, all_ops, not_executing_only=Fals
                 name,
                 input_shapes,
                 output_shapes,
+                backend,
                 num_ops,
                 status,
                 models_str,

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -151,6 +151,7 @@ class StablehloOp(Op):
         self.op_id = op_id
         self.compilation_status = OpCompilationStatus.CREATED_GRAPH
         self.original_shlo = original_shlo
+        self.backend = "stablehlo"
         self.op_name = self._extract_op_name()
         self.input_shapes = self._extract_input_shapes()
         self.unique_key = ""
@@ -197,6 +198,7 @@ class StablehloOp(Op):
 
         return {
             "frontend": self.frontend,
+            "backend": self.backend,
             "model_name": self.model_name,
             "model_group": self.model_group,
             "global_op_idx": self.global_op_idx,

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -43,7 +43,7 @@ def generate_random_inputs_for_shlo(module_str):
     args_str = func_match.group(1)
 
     # Match the function arguments
-    args = re.findall(r"%arg\d+:\s+tensor<([^>]+)>", args_str)
+    args = re.findall(r"%arg\d+:\s*tensor<([^>]+)>", args_str)
 
     inputs = []
     for shape_str in args:
@@ -54,7 +54,7 @@ def generate_random_inputs_for_shlo(module_str):
             # If it matches the pattern of dimensions and data type (like 1x784xf32)
             shape_str, dtype_str = shape_dtype_match.groups()
 
-            dims = [int(dim) for dim in shape_str.split("x")]
+            dims = [int(dim) for dim in shape_str.split("x") if dim]
 
             if dtype_str == "f32":
                 inputs.append(torch.randn(dims, dtype=torch.float32))
@@ -154,6 +154,7 @@ class StablehloOp(Op):
         self.backend = "stablehlo"
         self.op_name = self._extract_op_name()
         self.input_shapes = self._extract_input_shapes()
+        self.output_shapes = self._extract_output_shapes()
         self.unique_key = ""
         self.set_unique_key()
 
@@ -163,14 +164,61 @@ class StablehloOp(Op):
         return match.group(0) if match else "unknown_op"
 
     def _extract_input_shapes(self):
-        # Extract shapes handling both f32 and i64 types
+        # Extract shapes handling all data types (f32, i64, bf16, etc.)
         shapes = []
-        # Look for tensor patterns with various types
-        shape_patterns = re.findall(r"tensor<([0-9x]+)x[fi][0-9]+>", self.original_shlo)
+
+        # First check for scalar tensors (no dimensions)
+        scalar_patterns = re.findall(r"tensor<([a-z][a-z0-9]+)>", self.original_shlo)
+        if scalar_patterns:
+            # Found scalar tensors (0D)
+            shapes.append(tuple())  # Empty tuple for scalar
+
+        # Look for tensor patterns with dimensions + any data type
+        shape_patterns = re.findall(
+            r"tensor<([0-9x]+)x[a-z][a-z0-9]+>", self.original_shlo
+        )
+
         for shape_str in shape_patterns:
             # Convert each dimension to int, handling both single and multi-dimensional cases
-            shape = tuple(int(dim) for dim in shape_str.split("x"))
+            shape = tuple(int(dim) for dim in shape_str.split("x") if dim)
             shapes.append(shape)
+        return shapes
+
+    def _extract_output_shapes(self):
+        # Extract output shapes from StableHLO operations
+        shapes = []
+
+        # First strategy: Find tensor shapes with output arrow notation
+        arrow_shapes = re.findall(
+            r"->\s*tensor<([0-9x]*)x?([a-z][a-z0-9]+)>", self.original_shlo
+        )
+        if arrow_shapes:
+            # Found shapes in arrow notation (highest priority)
+            dims_str, dtype = arrow_shapes[0]  # Take first match
+            if dims_str:
+                shape = tuple(int(dim) for dim in dims_str.split("x") if dim)
+                shapes.append(shape)
+            else:
+                # Scalar tensor (no dimensions specified)
+                shapes.append(tuple())
+            return shapes
+
+        # Second strategy: Extract tensor shape from the entire StableHLO string
+        # This will work for all cases where there's a tensor<...> specification
+        tensor_shapes = re.findall(
+            r"tensor<([0-9x]*)x?([a-z][a-z0-9]+)>", self.original_shlo
+        )
+
+        if tensor_shapes:
+            # For StableHLO operations, the last tensor is typically the output
+            dims_str, dtype = tensor_shapes[-1]
+            if dims_str:
+                shape = tuple(int(dim) for dim in dims_str.split("x") if dim)
+                shapes.append(shape)
+            else:
+                # Scalar tensor
+                shapes.append(tuple())
+
         return shapes
 
     def set_unique_key(self):
@@ -208,16 +256,17 @@ class StablehloOp(Op):
             "output_tensors": [tensor.to_dict() for tensor in self.output_tensors],
             "num_ops": self.num_ops,
             "compilation_status": self.compilation_status,
-            # "parsed_stable_hlo_ops": self.parsed_stable_hlo_ops,
-            # "torch_ir_graph": self.torch_ir_graph,
+            "parsed_stable_hlo_ops": self.parsed_stable_hlo_ops,
+            "torch_ir_graph": self.torch_ir_graph or "",
             "stable_hlo_graph": self.stable_hlo_graph,
-            # "stable_hlo_ops": self.stable_hlo_ops,
+            "stable_hlo_ops": self.stable_hlo_ops or [],
             "ttir_graph": self.ttir_graph,
             "ttnn_graph": self.ttnn_graph,
             "runtime_stack_dump": self.runtime_stack_dump,
             "pcc": pcc,
             "atol": atol,
             "compiled_json": self.json,
+            "torch_name": self.op_name,
         }
 
 

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -111,6 +111,7 @@ class Op:
         self.output_shapes = []
         self.output_tensors = []
         self.frontend = "tt-torch"
+        self.backend = "torch"
         self.model_group = ""
         self.global_op_idx = 0
 
@@ -213,6 +214,7 @@ class Op:
             "framework_op_name": self.framework_op_name,
             "torch_name": self.framework_op_name,  # For backward compatibility
             "frontend": self.frontend,
+            "backend": self.backend,
             "model_name": self.model_name,
             "model_group": self.model_group,
             "global_op_idx": self.global_op_idx,


### PR DESCRIPTION
### Ticket
None

### Problem description
- Models can run in op_by_op_torch or op_by_op_stablehlo but we could not run op_by_op_stablehlo on CI because parse_op_by_op_results.py would choke (missing fields in .json) and CI was hardcoded to use pytest --op_by_op_torch
- Also, not all unique ops in op_by_op_stablehlo were run becuase input shape were not captured properly.

### What's changed
 - Export backend (torch/stablehlo) in unique_ops .json file and XLS to display which backend model tests use. Show as new column in XLS model and summary sheets.
 - Update shlo_backend.py for missing fields in .json for shlo, and empty input/output shapes. Output shapes extraction was completely missing and input shapes extraction was missing some dtypes like bf16, scalars. Apply similar fix to generate_random_inputs_for_shlo()
- Remove hardcoded --op_by_op_torch in op-by-op nightly/weekly yamls and use explicit pytest params
- Unrelated, move group of 8 EfficientNet tests, accidentally was added to push instead of nightly full-model execute list

### Checklist
- [x] Tested locally combining torch/stablehlo op by op tests in same report, and now all input/output shapes captured for mnist.
