### PR TITLE
 Add memory sampling for GPTNEO oom-killer debug

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -146,7 +146,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb --pid=host
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -177,6 +177,12 @@ jobs:
         echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "test-output-dir=$(pwd)/results/models/tests/" >> "$GITHUB_OUTPUT"
+
+    - name: Sample memory
+      shell: bash
+      run: |
+        echo "Memory sample at $(date)"
+        ps -aux --sort -%mem | head -n 10
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}


### PR DESCRIPTION
### Ticket
#540 

### Problem description
GPT Neo runs out of memory intermittently but we're not sure why. 

### What's changed
- Create test container with visibility into host VM address space
- Print memory usage of top 10 memory hungry procs on host or device at the start of op by op nightly tests, to see if there's significant variation in initial conditions (eg. host process memory contention with container)

### Checklist
- [x] New/Existing tests provide coverage for changes
