### PR TITLE
Add vgg19_unet #599 and other model changes (test_vit, mobilenet_v2)

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -61,7 +61,7 @@ jobs:
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-mixer_b16_224.goog_in21k]
                   tests/models/mgp-str-base/test_mgp_str_base.py::test_mgp_str_base[full-eval]
                   tests/models/detr/test_detr.py::test_detr[full-eval]
-                  tests/models/vit/test_vit.py::test_vit[full-eval]
+                  tests/models/vit/test_vit_onnx.py::test_vit_onnx[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-vit_h_14]
                   tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small[full-eval]
                   tests/models/yolos/test_yolos.py::test_yolos[full-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -49,6 +49,11 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "mobilenet", tests: "
+              tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2_onnx[op_by_op_stablehlo-eval]
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "openpose", tests: "
               tests/models/openpose/test_openpose.py::test_openpose[op_by_op_torch-eval]
               "

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -69,6 +69,7 @@ jobs:
               tests/models/unet/test_unet.py::test_unet[op_by_op_torch-eval]
               tests/models/unet_brain/test_unet_brain.py::test_unet_brain[op_by_op_torch-eval]
               tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[op_by_op_torch-eval]
+              tests/models/vgg19_unet/test_vgg19_unet.py::test_vgg19_unet[op_by_op_torch-eval]
               "
           },
           {

--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -40,7 +40,7 @@ class ThisTester(OnnxModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op_stablehlo", "full"])
 def test_MobileNetV2_onnx(record_property, mode, op_by_op):
     model_name = "MobileNetV2_onnx"
     cc = CompilerConfig()

--- a/tests/models/oft/test_oft_onnx.py
+++ b/tests/models/oft/test_oft_onnx.py
@@ -45,7 +45,7 @@ class ThisTester(OnnxModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op", "full"])
+@pytest.mark.parametrize("op_by_op", [True, False], ids=["op_by_op_stablehlo", "full"])
 def test_oft_onnx(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()

--- a/tests/models/vgg19_unet/src/vgg19_unet.py
+++ b/tests/models/vgg19_unet/src/vgg19_unet.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# This PyTorch implementation is based on: https://github.com/nikhilroxtomar/Semantic-Segmentation-Architecture/blob/main/TensorFlow/vgg19_unet.py
+
+import torch
+import torch.nn as nn
+import torchvision.models as models
+
+
+class ConvBlock(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super(ConvBlock, self).__init__()
+        self.conv = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=3, padding=1),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1),
+            nn.BatchNorm2d(out_channels),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x):
+        return self.conv(x)
+
+
+class DecoderBlock(nn.Module):
+    def __init__(self, in_channels, skip_channels, out_channels):
+        super(DecoderBlock, self).__init__()
+        self.upsample = nn.ConvTranspose2d(
+            in_channels, out_channels, kernel_size=2, stride=2, padding=0
+        )
+        self.conv_block = ConvBlock(out_channels + skip_channels, out_channels)
+
+    def forward(self, x, skip):
+        x = self.upsample(x)
+        x = torch.cat([x, skip], dim=1)
+        return self.conv_block(x)
+
+
+class VGG19UNet(nn.Module):
+    def __init__(self, input_shape=(3, 512, 512), out_channels=1):
+        super(VGG19UNet, self).__init__()
+
+        # Load pre-trained VGG19 model
+        vgg19 = models.vgg19(weights="IMAGENET1K_V1")
+
+        # Encoder (VGG19 feature layers)
+        self.encoder1 = vgg19.features[:4]  # block1_conv2
+        self.encoder2 = vgg19.features[4:9]  # block2_conv2
+        self.encoder3 = vgg19.features[9:18]  # block3_conv4
+        self.encoder4 = vgg19.features[18:27]  # block4_conv4
+        self.bridge = vgg19.features[27:36]  # block5_conv4
+
+        # Freeze encoder weights
+        for param in self.encoder1.parameters():
+            param.requires_grad = False
+        for param in self.encoder2.parameters():
+            param.requires_grad = False
+        for param in self.encoder3.parameters():
+            param.requires_grad = False
+        for param in self.encoder4.parameters():
+            param.requires_grad = False
+        for param in self.bridge.parameters():
+            param.requires_grad = False
+
+        # Decoder
+        self.decoder1 = DecoderBlock(512, 512, 512)  # (64x64)
+        self.decoder2 = DecoderBlock(512, 256, 256)  # (128x128)
+        self.decoder3 = DecoderBlock(256, 128, 128)  # (256x256)
+        self.decoder4 = DecoderBlock(128, 64, 64)  # (512x512)
+
+        # Output layer
+        self.output = nn.Conv2d(64, out_channels, kernel_size=1, padding=0)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x):
+        # Encoder
+        e1 = self.encoder1(x)
+        e2 = self.encoder2(e1)
+        e3 = self.encoder3(e2)
+        e4 = self.encoder4(e3)
+
+        # Bridge
+        b = self.bridge(e4)
+
+        # Decoder
+        d1 = self.decoder1(b, e4)
+        d2 = self.decoder2(d1, e3)
+        d3 = self.decoder3(d2, e2)
+        d4 = self.decoder4(d3, e1)
+
+        # Output
+        outputs = self.sigmoid(self.output(d4))
+
+        return outputs

--- a/tests/models/vgg19_unet/test_vgg19_unet.py
+++ b/tests/models/vgg19_unet/test_vgg19_unet.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from tests.models.vgg19_unet.src.vgg19_unet import VGG19UNet
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        self.input_shape = (3, 512, 512)
+        model = VGG19UNet(input_shape=self.input_shape, out_channels=1)
+        return model
+
+    def _load_inputs(self):
+        inputs = torch.rand(1, *self.input_shape)
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_vgg19_unet(record_property, mode, op_by_op):
+    if mode == "train":
+        pytest.skip()
+    model_name = "VGG19-Unet"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group="red",
+    )
+
+    with torch.no_grad():
+        results = tester.test_model()
+    tester.finalize()


### PR DESCRIPTION
Source:
https://github.com/nikhilroxtomar/Semantic-Segmentation-Architecture/blob/main/TensorFlow/vgg19_unet.py Converted from tensorflow to PyTorch

### Ticket
#599 

### Problem description
Convert [vgg19_unet](https://github.com/nikhilroxtomar/Semantic-Segmentation-Architecture/blob/main/TensorFlow/vgg19_unet.py) to PyTorch and add

### Additional Changes
- Add test_vit_onnx.py passing full-model-execute replace torch version #347
- Add test_MobileNetV2_onnx to op-by-op nightly, some ops failing #346
- Use op_by_op_stablehlo instead of op_by_op as param in oft, mobilenetv2 onnx tests for consistency

### Checklist
- [X] Created tests/models/vgg19_unet/test_vgg19_unet.py
- [X] Added source files for vgg19 unet model under tests/models/vgg19_unet/src
- [X] Added to nightly test (full-eval is failing)