### PR TITLE
#670 Create system descriptor less often

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ import socket
 import os
 import json
 import shutil
+import tt_mlir
 
 global junitxml_path
 junitxml_path = None
@@ -35,6 +36,21 @@ def manage_dependencies(request):
     subprocess.check_call(
         [sys.executable, "-m", "pip", "uninstall", "-y"] + dependencies
     )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def create_system_descriptor(request):
+    try:
+        tt_mlir.create_system_desc()
+    except Exception as e:
+        print(f"Failed to create system descriptor: {e}")
+
+    yield
+
+    try:
+        os.remove(os.getenv("SYSTEM_DESC_PATH"))
+    except OSError:
+        pass
 
 
 def pytest_addoption(parser):

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -3,6 +3,19 @@ list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
+# Get git commit hash for tt-mlir currently built
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/tt-mlir
+    OUTPUT_VARIABLE TT_MLIR_GIT_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/tt_mlir_version.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/tt_mlir_version.h
+)
+
 
 add_library(TT_TORCH_MLIR "tt-mlir-interface.cpp")
 
@@ -16,6 +29,7 @@ set_target_properties(TT_TORCH_MLIR PROPERTIES COMPILE_FLAGS "-fno-rtti")
 install (TARGETS TT_TORCH_MLIR LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 target_include_directories(TT_TORCH_MLIR PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/include
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir-build/include/ttmlir/Target/Common
     ${PROJECT_SOURCE_DIR}/third_party/tt-mlir/src/tt-mlir/include

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -247,7 +247,7 @@ std::vector<at::Tensor> run_end_to_end(std::vector<at::Tensor> &inputs,
 
   tt::runtime::Device device = tt::runtime::openMeshDevice({1, 1});
 
-  int program_idx = 0;
+  const int program_idx = 0;
 
   std::vector<tt::runtime::Tensor> rt_inputs =
       preprocess_inputs(device, inputs, binary, program_idx, 0);
@@ -356,6 +356,8 @@ PYBIND11_MODULE(tt_mlir, m) {
         "Convert the bytestream to json");
   m.def("create_binary_from_bytestream", &create_binary_from_bytestream,
         "Create a binary from bytestream");
+  m.def("create_system_desc", &tt::torch::create_system_desc,
+        py::arg("device") = py::none(), "Create a system description");
 
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
   py::class_<tt::runtime::CallbackContext>(m, "CallbackContext");

--- a/tt_torch/csrc/tt-mlir-interface.hpp
+++ b/tt_torch/csrc/tt-mlir-interface.hpp
@@ -14,4 +14,6 @@ std::string compileStableHLOToTTIR(std::string_view code);
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code,
                   std::optional<tt::runtime::Device> device = std::nullopt);
+void create_system_desc(
+    std::optional<tt::runtime::Device> device = std::nullopt);
 } // namespace tt::torch

--- a/tt_torch/csrc/tt_mlir_version.h.in
+++ b/tt_torch/csrc/tt_mlir_version.h.in
@@ -1,0 +1,2 @@
+#pragma once
+#define TT_MLIR_GIT_COMMIT "@TT_MLIR_GIT_COMMIT@"


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/670

### Problem description
Creating system descriptor at every compilation slows down op by op flow.

### What's changed
- Create system descriptor before each test session
- Only create new one if a recent valid one does not already exist

### Checklist
- [ ] New/Existing tests provide coverage for changes
- [x] Test against op by op on CI
    - [Run 3 op by op tests on main](https://github.com/tenstorrent/tt-torch/actions/runs/14756236486)
    - [Run 3 op by op tests with change](https://github.com/tenstorrent/tt-torch/actions/runs/14752764458)
