### PR TITLE
Create a separate pipeline for LLMbox-specific smoketests

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -40,6 +40,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  llmbox-tests:
+    needs: [build, docker-build]
+    uses: ./.github/workflows/run-multidevice-tests.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
   full-model-test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-full-model-execution-tests.yml

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -40,12 +40,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  llmbox-tests:
-    needs: [build, docker-build]
-    uses: ./.github/workflows/run-multidevice-tests.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  # llmbox-tests:
+  #   needs: [build, docker-build]
+  #   uses: ./.github/workflows/run-multidevice-tests.yml
+  #   secrets: inherit
+  #   with:
+  #     docker-image: ${{ needs.docker-build.outputs.docker-image }}
   full-model-test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-full-model-execution-tests.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -28,6 +28,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  llmbox-tests:
+    needs: [build, docker-build]
+    uses: ./.github/workflows/run-multidevice-tests.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
   full-model-test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-full-model-execution-tests.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -28,12 +28,12 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-  llmbox-tests:
-    needs: [build, docker-build]
-    uses: ./.github/workflows/run-multidevice-tests.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  # llmbox-tests:
+  #   needs: [build, docker-build]
+  #   uses: ./.github/workflows/run-multidevice-tests.yml
+  #   secrets: inherit
+  #   with:
+  #     docker-image: ${{ needs.docker-build.outputs.docker-image }}
   full-model-test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-full-model-execution-tests.yml

--- a/.github/workflows/run-multidevice-tests.yml
+++ b/.github/workflows/run-multidevice-tests.yml
@@ -95,4 +95,4 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        pytest --durations=0 -v tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval] 2>&1
+        pytest --durations=0 -svv tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]

--- a/.github/workflows/run-multidevice-tests.yml
+++ b/.github/workflows/run-multidevice-tests.yml
@@ -1,0 +1,98 @@
+name: Run Multidevice Tests
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
+      build-artifact-key:
+        description: 'Key to use for artifact download'
+        required: false
+        type: string
+  workflow_run:
+    workflows: [Build] # build debug?
+    types: [completed]
+
+jobs:
+  tests:
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [
+          {runs-on: llmbox, name: "run", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
+        ]
+
+    name: tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})
+    runs-on:
+      - ${{ matrix.build.runs-on }}
+
+    container:
+      image: ${{ inputs.docker-image }}
+      options: --user root ${{ matrix.build.container-options }} --shm-size=2gb
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        lfs: true
+
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "${{ github.job }} (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})"
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      env:
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
+        echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
+        echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_torch=report_torch_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_check_all_ops_execute=report_check_all_ops_execute_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "test_report_path_onnx=report_onnx_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+
+    - name: Git safe dir
+      run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+    - name: Use build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: install-artifacts${{ inputs.build-artifact-key }}
+        path: ${{ steps.strings.outputs.install-dir }}
+
+    - name: 'Untar install directory'
+      shell: bash
+      working-directory: ${{ steps.strings.outputs.install-dir }}
+      run: |
+        tar xvf artifact.tar
+        mkdir -p ${{ steps.strings.outputs.dist-dir }}
+        mv wheels/* ${{ steps.strings.outputs.dist-dir }}
+
+    - name: install tt-torch
+      shell: bash
+      run: |
+        source env/activate
+        pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
+
+    - name: Run Llama-7B tests
+      shell: bash
+      run: |
+        source env/activate
+        pytest --durations=0 -v tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval] 2>&1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,6 @@ jobs:
       matrix:
         build: [
           {runs-on: wormhole_b0, name: "run", container-options: "--device /dev/tenstorrent/0"},
-          {runs-on: llmbox, name: "run", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
         ]
 
     name: tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})


### PR DESCRIPTION
### Ticket
None 

### Problem description
Current llmbox tests run a 30 minute test suite onPR, which risks bottlenecking of PR check workflows and queue time spikes. 

### What's changed
Create and add new pipeline for shorter llmbox testset onPR and onPush. The only test run here is Jackson's recent llama7b pipeline parallel test introduced in #679 with a 5m overhead. 

### Checklist
- [x] New/Existing tests provide coverage for changes
