### PR TITLE
Fix false positive assert pcc / atol reporting

### DIFF
--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -142,7 +142,7 @@ def verify_against_golden(
 
     # Now that all tensors are checked, print the final message
     if assert_pcc and assert_atol:
-        if not passed_pcc and passed_atol:
+        if not passed_pcc or not passed_atol:
             assert False, err_msg
     elif not assert_pcc and assert_atol:
         print("Ignoring PCC check\n")


### PR DESCRIPTION
### Ticket
None

### Problem description
When inverting the logic of verify_against_golden I messed up and now this common entry point to all our test verification is throwing false positives in some cases.

### What's changed
Correctly invert logic for not(A AND B). Thanks @jazpurTT for catching this!

### Checklist
- [-] New/Existing tests provide coverage for changes 
