### PR TITLE
Add Falcon 3 1B, 3B, 7B, 10B to torch op-by-op #597

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -149,6 +149,14 @@ jobs:
           {
             runs-on: wormhole_b0, name: "pixtral", tests: "
               tests/models/mistral/test_pixtral.py::test_pixtral[op_by_op_torch-eval]
+            "
+          },
+          {
+            runs-on: wormhole_b0, name: "falcon3", tests: "
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-1B-Base-eval]
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-3B-Base-eval]
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-7B-Base-eval]
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-10B-Base-eval]
               "
           },
           {

--- a/tests/models/falcon/test_falcon3.py
+++ b/tests/models/falcon/test_falcon3.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name, padding_side="left", torch_dtype=torch.bfloat16
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_name, torch_dtype=torch.bfloat16
+        )
+        return model.generate
+
+    def _load_inputs(self):
+        self.prompt = "Hey, are you conscious? Can you talk to me?"
+        inputs = self.tokenizer(
+            self.prompt, return_tensors="pt", return_token_type_ids=False
+        )
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "tiiuae/Falcon3-1B-Base",
+        "tiiuae/Falcon3-3B-Base",
+        "tiiuae/Falcon3-7B-Base",
+        "tiiuae/Falcon3-10B-Base",
+        "tiiuae/Falcon3-1B-Instruct",
+        "tiiuae/Falcon3-3B-Instruct",
+        "tiiuae/Falcon3-7B-Instruct",
+        "tiiuae/Falcon3-10B-Instruct",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_falcon(record_property, model_name, mode, op_by_op):
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    # consteval_parameters is disabled because it results in a memory related crash
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        assert_pcc=False,
+        assert_atol=False,
+        model_group="red",
+    )
+    results = tester.test_model()
+
+    if mode == "eval":
+        output = tester.tokenizer.batch_decode(
+            results, skip_special_tokens=True, clean_up_tokenization_spaces=False
+        )[0]
+
+    tester.finalize()


### PR DESCRIPTION
### Ticket
#597 

### Problem description
Add Falcon3 1B, 3B, 7B, 10B Base

### What's changed
- Added Falcon3 1B, 3B, 7B, 10B Base models to torch op-by-op flow. Instruct mode is also available under model names, can run torch op-by-op but not added to nightly runs.
Note: `consteval_parameters` is disabled because it results in a memory related crash

### Checklist
- [X] Create `tests/models/falcon/test_falcon3.py`
- [X] Add `test_falcon3` to op-by-op nightly tests
