### PR TITLE
Promote 2 models (densenet201, ghostnetv2_100.in1k) after tt-mlir avg_pool2d e2e support change

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -35,6 +35,7 @@ jobs:
                   tests/models/codegen/test_codegen.py::test_codegen[full-eval]
                   tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-googlenet]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[op_by_op_torch-eval-ghostnetv2_100.in1k]
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
                   tests/models/mistral/test_pixtral.py::test_pixtral[full-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -70,7 +70,7 @@ jobs:
             "
           },
           {
-            # Approximately 65 minutes.
+            # Approximately 70 minutes.
             runs-on: wormhole_b0, name: "eval_2", tests: "
                   tests/models/bloom/test_bloom.py::test_bloom[full-eval]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_generality[full-eval-hrnet_w18.ms_aug_in1k]
@@ -85,6 +85,7 @@ jobs:
                   tests/models/gpt2/test_gpt2.py::test_gpt2[full-eval]
                   tests/models/xglm/test_xglm.py::test_xglm[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_red[full-eval-swin_b]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-densenet201]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification_red[full-eval-ese_vovnet19b_dw.ra_in1k]
             "
           },

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -105,7 +105,6 @@ jobs:
           {
             runs-on: wormhole_b0, name: "torchvision_1", tests: "
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-googlenet]
-              tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-densenet201]
               "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -183,6 +183,7 @@ jobs:
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-resnet152]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-resnext101_64x4d]
               tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-vit_h_14]
+              tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[op_by_op_torch-eval-densenet201]
               "
           },
           {


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Error signature previously hit "error: failed to legalize operation 'stablehlo.reduce_window'" is solved after https://github.com/tenstorrent/tt-mlir/pull/3030 which just got merged to tt-torch
 - densenet201 to full-model-execute (passes)
 - ghostnetv2_100.in1k to e2e compile 

### Checklist
- [x] Tested on branch https://github.com/tenstorrent/tt-torch/actions/runs/14763644099
