### PR TITLE
Promote Falcon3-1B to full-model-execute, 3B, 7B to e2e-compile

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -23,7 +23,14 @@ jobs:
       matrix:
         build: [
           {
-            # Approximately 65 minutes.
+            # Approximately 50 minutes.
+            runs-on: wormhole_b0, name: "compile_1", tests: "
+              tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
+              tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
+            "
+          },
+          {
+            # Approximately 180 minutes.
             runs-on: wormhole_b0, name: "compile_2", tests: "
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification_generality[full-eval-regnet_y_128gf]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -90,9 +90,10 @@ jobs:
             "
           },
           {
-            # Approximately 45 minutes.
+            # Approximately 65 minutes.
             runs-on: wormhole_b0, name: "eval_3", tests: "
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1.5-eval]
+                  tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-1B-Base-eval]
             "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -153,7 +153,6 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "falcon3", tests: "
-              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-1B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-3B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-7B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-10B-Base-eval]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -221,6 +221,11 @@ jobs:
             runs-on: wormhole_b0, name: "mistral", tests: "
               tests/models/mistral/test_mistral.py::test_mistral[op_by_op_torch-ministral3b-eval]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "falcon3", tests: "
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-1B-Base-eval]
+              "
           }
         ]
     runs-on:


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Move tests around. 1B can run, 3B, 7B currently don't fit on device
 - Skip adding 10B to e2e-compile because it's very long (2+ hours)

### Checklist
- [x] Ran on branch already to test https://github.com/tenstorrent/tt-torch/actions/runs/14781099445
