### PR TITLE
Remove enable_async_ttnn option

### DIFF
--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -81,9 +81,7 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
     cc.consteval_parameters = True
     cc.cache_preprocessed_constants = True
 
-    device = DeviceManager.create_parent_mesh_device(
-        mesh_shape=[1, 1], enable_async_ttnn=True
-    )
+    device = DeviceManager.create_parent_mesh_device(mesh_shape=[1, 1])
 
     tester = ThisTester(
         model_name,

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -291,8 +291,6 @@ PYBIND11_MODULE(tt_mlir, m) {
       .def_readwrite("mesh_offset", &tt::runtime::MeshDeviceOptions::meshOffset)
       .def_readwrite("device_ids", &tt::runtime::MeshDeviceOptions::deviceIds)
       .def_readwrite("num_hw_cqs", &tt::runtime::MeshDeviceOptions::numHWCQs)
-      .def_readwrite("enable_async_ttnn",
-                     &tt::runtime::MeshDeviceOptions::enableAsyncTTNN)
       .def_readwrite("enable_program_cache",
                      &tt::runtime::MeshDeviceOptions::enableProgramCache)
       .def_property(

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -18,7 +18,6 @@ class DeviceManager:
     def _get_parent_mesh_options(
         device_ids=None,
         num_hw_cqs=None,
-        enable_async_ttnn=None,
         enable_program_cache=None,
         l1_small_size=None,
         dispatch_core_type=None,
@@ -28,8 +27,6 @@ class DeviceManager:
             options.device_ids = device_ids
         if num_hw_cqs is not None:
             options.num_hw_cqs = num_hw_cqs
-        if enable_async_ttnn is not None:
-            options.enable_async_ttnn = enable_async_ttnn
         if enable_program_cache is not None:
             options.enable_program_cache = enable_program_cache
         if l1_small_size is not None:
@@ -51,7 +48,6 @@ class DeviceManager:
         mesh_shape,
         device_ids=None,
         num_hw_cqs=None,
-        enable_async_ttnn=None,
         enable_program_cache=None,
         l1_small_size=None,
         dispatch_core_type=None,
@@ -69,7 +65,6 @@ class DeviceManager:
         options = cls._get_parent_mesh_options(
             device_ids,
             num_hw_cqs,
-            enable_async_ttnn,
             enable_program_cache,
             l1_small_size,
             dispatch_core_type,
@@ -190,7 +185,6 @@ class DeviceManager:
         num_devices=None,
         device_ids=None,
         num_hw_cqs=None,
-        enable_async_ttnn=None,
         enable_program_cache=None,
         l1_small_size=None,
         dispatch_core_type=None,
@@ -210,7 +204,6 @@ class DeviceManager:
             mesh_shape,
             device_ids,
             num_hw_cqs,
-            enable_async_ttnn,
             enable_program_cache,
             l1_small_size,
             dispatch_core_type,


### PR DESCRIPTION
### Ticket
None

### Problem description
The `enable_async_ttnn` param should have no affect after the tt-mesh metal commit 3623ec5739 landed.

### What's changed
Removing no-op param since it will be removed upstream soon as well.

### Checklist
- [x] New/Existing tests provide coverage for changes
