### PR TITLE
Add summary at end of full execute tests

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -214,6 +214,7 @@ jobs:
         set +e
 
         failure=0
+        summary=""
 
         # Split the test string into individual tests and run them one by one
         while read -r test; do
@@ -223,18 +224,32 @@ jobs:
 
             echo "JUnitXML logged to $report_file"
 
+            start_time=$(date +%s)
+
             pytest --durations=0 -v "$test" \
               --junit-xml="$report_file" \
               --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append \
               2>&1 | tee -a pytest.log
+
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
+
             # Check the return code of pytest
             if [[ $? -ne 0 ]]; then
               echo "Test failed: $test"
+              summary+="$test\tFAILED\tin ${duration}s\n"
               failure=1
+            else
+              echo "Test passed: $test"
+              summary+="$test\tPASSED\tin ${duration}s\n"
             fi
           fi
         # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved
         done < <(echo "${{ matrix.build.tests }}" | tr ' ' '\n')
+
+        # Print the summary at the end
+        echo -e "\nTest Execution Summary:"
+        echo -e "$summary"
 
         set -e
 

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -237,11 +237,11 @@ jobs:
             # Check the return code of pytest
             if [[ $? -ne 0 ]]; then
               echo "Test failed: $test"
-              summary+="$test\tFAILED\tin ${duration}s\n"
+              summary+="$test\t\033[31mFAILED\033[0m\tin ${duration}s\n" # Red for FAILED
               failure=1
             else
               echo "Test passed: $test"
-              summary+="$test\tPASSED\tin ${duration}s\n"
+              summary+="$test\t\033[32mPASSED\033[0m\tin ${duration}s\n" # Green for PASSED
             fi
           fi
         # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -197,11 +197,11 @@ jobs:
             # Check the return code of pytest
             if [[ $? -ne 0 ]]; then
               echo "Test failed: $test"
-              summary+="$test\tFAILED\tin ${duration}s\n"
+              summary+="$test\t\033[31mFAILED\033[0m\tin ${duration}s\n" # Red for FAILED
               failure=1
             else
               echo "Test passed: $test"
-              summary+="$test\tPASSED\tin ${duration}s\n"
+              summary+="$test\t\033[32mPASSED\033[0m\tin ${duration}s\n" # Green for PASSED
             fi
           fi
         # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -175,8 +175,7 @@ jobs:
         set +e
 
         failure=0
-
-        ec=0
+        summary=""
 
         # Split the test string into individual tests and run them one by one
         while read -r test; do
@@ -185,20 +184,32 @@ jobs:
             report_file="${{ steps.strings.outputs.test_report_dir }}/$(echo $test | tr '/' '_' | tr ':' '_')__${{ steps.strings.outputs.test_report_path_models }}"
             echo "JUnitXML will be logged to $report_file"
 
+            start_time=$(date +%s)
+
             pytest --durations=0 -v "$test" \
               --junit-xml="$report_file" \
               --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append \
               2>&1 | tee -a pytest.log
 
+            end_time=$(date +%s)
+            duration=$((end_time - start_time))
 
             # Check the return code of pytest
             if [[ $? -ne 0 ]]; then
               echo "Test failed: $test"
+              summary+="$test\tFAILED\tin ${duration}s\n"
               failure=1
+            else
+              echo "Test passed: $test"
+              summary+="$test\tPASSED\tin ${duration}s\n"
             fi
           fi
         # execute while loop with process substitution so it doesn't run in a subshell and value of $failure is preserved
         done < <(echo "${{ matrix.build.tests }}" | tr ' ' '\n')
+
+        # Print the summary at the end
+        echo -e "\nTest Execution Summary:"
+        echo -e "$summary"
 
         set -e
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Process-isolating full model pytests prevents false negative report dropping if an earlier test in a group segfaults. However, it causes a test result summary to not be cleanly generated at the end of the test.

### What's changed
Add a test summary at end of full model execute and full model execute nightly tests showing testname, passing status and duration.

### Checklist
- [x] New/Existing tests provide coverage for changes
