### PR TITLE
test_xglm - Slight reduction in atol due to lack of promotion to fp32

### DIFF
--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -55,7 +55,7 @@ def test_xglm(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        relative_atol=0.02,
+        relative_atol=0.045,
         compiler_config=cc,
         record_property_handle=record_property,
     )


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Need to increase atol threshold in this test a bit higher than 0.04, like few others yesterday
 - Solves "E: ATOL of output 49: 0.2773, threshold: 0.13625 (calculated using relative_atol: 0.02)"

### Checklist
- [x] Tested locally, test passes again
