### PR TITLE
Enable IR,NN fusing option for tt-mlir

### DIFF
--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -61,7 +61,7 @@ def test_beit_image_classification(record_property, model_name, mode, op_by_op):
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     required_atol = 0.032 if model_name == "microsoft/beit-base-patch16-224" else 0.065
-    do_assert = True if model_name == "microsoft/beit-base-patch16-224" else False
+    do_assert = True
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -42,14 +42,13 @@ def test_opt(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/592
     tester = ThisTester(
         model_name,
         mode,
         compiler_config=cc,
         record_property_handle=record_property,
         relative_atol=0.015,
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
     )
     tester.test_model(assert_eval_token_mismatch=False)

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -195,6 +195,8 @@ compileTTIRToTTNN(std::string_view code,
   if (consteval && std::string(consteval) == "1") {
     options.enableConstEval = true;
   }
+  options.enableFusing = true;
+
   if (len_activations > 0 || len_graph_constants > 0) {
     llvm::SmallVector<mlir::tt::ArgumentType> argTypes;
     for (size_t i = 0; i < len_graph_constants; ++i) {


### PR DESCRIPTION
### Ticket
NA

### Problem description
Since [patch in mlir](https://github.com/tenstorrent/tt-mlir/commit/f5c92c4c5069d2c53c875046b039b66246528fee), the IR, NN fusing option in tt-mlir is no longer enabled by default. This change led to a regression where two previously passing models began failing due to the missing optimization.

### What's changed
- Explicitly enabled IRFusing via `options.enableFusing = True` to restore expected behavior.
- Re-enabled PCC assertions for the two affected models(beit-large-patch16-224, opt) to ensure accuracy checks remain in place. These changes fix the regression and ensure future changes do not silently bypass PCC checks.

 
