### PR TITLE
Enable consteval by default

### DIFF
--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -190,11 +190,7 @@ compileTTIRToTTNN(std::string_view code,
 
   mlir::tt::ttnn::TTIRToTTNNBackendPipelineOptions options;
 
-  // boolean env var to override consteval
-  const char *consteval = std::getenv("TT_TORCH_CONSTEVAL");
-  if (consteval && std::string(consteval) == "1") {
-    options.enableConstEval = true;
-  }
+  options.enableConstEval = true;
   options.enableFusing = true;
 
   if (len_activations > 0 || len_graph_constants > 0) {


### PR DESCRIPTION
### What's changed
Enable consteval pass in tt-mlir by default. 

### Checklist
- [x] New/Existing tests provide coverage for changes
