### PR TITLE
Jzx/efficientnet unmark

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -127,14 +127,14 @@ jobs:
           # Approximately 40 minutes.
           {
             runs-on: wormhole_b0, name: "eval_9", tests: "
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_red[full-efficientnet-b0-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b1-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b2-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b3-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b4-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b5-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b6-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_generality[full-efficientnet-b7-eval]
             "
           }
         ]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -214,7 +214,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "EfficientNetb0", tests: "
-              tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[op_by_op_torch-efficientnet-b0-eval]
+              tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet_red[op_by_op_torch-efficientnet-b0-eval]
               "
           },
           {

--- a/tests/models/EfficientNet/test_EfficientNet.py
+++ b/tests/models/EfficientNet/test_EfficientNet.py
@@ -37,29 +37,7 @@ class ThisTester(ModelTester):
         return tfms(img).unsqueeze(0)
 
 
-@pytest.mark.parametrize(
-    "mode",
-    ["train", "eval"],
-)
-@pytest.mark.parametrize(
-    "model_name",
-    [
-        "efficientnet-b0",
-        "efficientnet-b1",
-        "efficientnet-b2",
-        "efficientnet-b3",
-        "efficientnet-b4",
-        "efficientnet-b5",
-        "efficientnet-b6",
-        "efficientnet-b7",
-    ],
-)
-@pytest.mark.parametrize(
-    "op_by_op",
-    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
-    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
-)
-def test_EfficientNet(record_property, model_name, mode, op_by_op):
+def run_EfficientNet_base(record_property, model_name, mode, op_by_op, _model_group):
     if mode == "train":
         pytest.skip()
     cc = CompilerConfig()
@@ -77,7 +55,7 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group="red",
+        model_group=_model_group,
     )
 
     results = tester.test_model()
@@ -94,3 +72,47 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
             prob = torch.softmax(results, dim=1)[0, idx].item()
             print("{label:<75} ({p:.2f}%)".format(label=labels_map[idx], p=prob * 100))
     tester.finalize()
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "efficientnet-b0",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_EfficientNet_red(record_property, model_name, mode, op_by_op):
+    run_EfficientNet_base(record_property, model_name, mode, op_by_op, "red")
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "efficientnet-b1",
+        "efficientnet-b2",
+        "efficientnet-b3",
+        "efficientnet-b4",
+        "efficientnet-b5",
+        "efficientnet-b6",
+        "efficientnet-b7",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_EfficientNet_generality(record_property, model_name, mode, op_by_op):
+    run_EfficientNet_base(record_property, model_name, mode, op_by_op, "generality")


### PR DESCRIPTION
### Ticket
None

### Problem description
All efficientnet variants are marked as red, where only the b0 variant should be considered as such.

### What's changed
Split red/generality models into different modules.

### Checklist
- [x] New/Existing tests provide coverage for changes
