### PR TITLE
Add helper function to fetch files from S3 bucket

### DIFF
--- a/docs/src/adding_models.md
+++ b/docs/src/adding_models.md
@@ -289,17 +289,17 @@ tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-large-eval]
 
 - If your model is reported in `results/models_op_per_op.xlsx` as being able to compile all ops successfully (ie. all ops can compile to status `6: CONVERTED_TO_TTNN`, but some hit runtime `7: EXECUTE` failures) then it should also be added to "nightly e2e compile list" in `.github/workflows/run-e2e-compile-tests.yml` which stops before executing the model via `TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest ...`
 
-## How to load test files into/from S3 bucket
+## How to load test files into/from Large File System (LFS)
 
-We have set up access to a AWS S3 bucket to be able to load and access model related files for testing. We can load files into our S3 bucket and access them from the tester scripts. You will need access to S3 bucket portal to add/load files. **If you don't have an AWS account or access to the S3 bucket please reach out to the tt-torch community leader.**
+We have set up access to a AWS S3 bucket to be able to load and access model related files for testing. We can load files into our S3 bucket and access them from the tester scripts. You will need access to S3 bucket portal to add files. **If you don't have an AWS account or access to the S3 bucket please reach out to the tt-torch community leader.** Then, depending on if the test is running on CI or locally we will be able to load the files from the CI/IRD LFS caches that automatically sync up with contents in S3 bucket.
 
 ### Load files into S3 bucket
 
-Access S3 bucket portal and load file from local dir. Please add files following this structure:
+Access S3 bucket portal, **if you don't have access to the S3 bucket please reach out to the tt-torch community leader**, and load file from local dir. Please add files following this structure:
 
 ```
 test_files
-├── torch
+├── pytorch
 |   ├── huggingface
 |   |   ├── meta-llama
 │   |   |   ├── Llama-3.1-70B
@@ -337,16 +337,13 @@ class ThisTester(ModelTester):
 
 ```
 
-The `s3_path` arg should be the path of the file in the S3 bucket. The `get_file()` helper will handle files differently if we are loading them from CI or locally.
+The `s3_path` arg should be the full path of the file in the S3 bucket.
 
 #### Loading files locally
 
-Locally `get_file()` will pull files directly from S3 bucket, so we will need to set up our environment to have access to it.
+Locally `get_file()` will pull files directly from an IRD LFS cache. The IRD LFS cache is set up to sync up with S3 bucket every 5-10 minutes. You will need to set the `IRD_LF_CACHE` environment variable to the appropriate address. **Contact tt-torch community leader for IRD LF cache address.**
 
-1. Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_DEFAULT_REGION` environment variables to enable authorization access to S3 bucket. The values can be found under your AWS account. **If you don't have one please reach out to tt-torch community leader.** Authorization will be temporary (8 hours from first access), and you will have to renew values after it expires.
-2. Set up `S3_BUCKET` env variable with the name of the S3 bucket.
-
-The file/s will be downloaded into a local cache so next time we want to access the same file we won't have to access S3 bucket. The default location for the cache is `~/.cache/`. If you want to redirect files to a custom cache path set the `TT_TORCH_CACHE` env variable to the desired path.
+The file/s will be downloaded into a local cache so next time you want to access the same file we won't have to access the IRD cache. The default location for the local cache is `~/.cache/`. If you want to redirect files to a custom cache path set the `LOCAL_LF_CACHE` env variable to the desired path.
 
 #### Loading files from CI
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ seaborn
 gliner
 ultralytics
 efficientnet_pytorch
+boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,3 @@ seaborn
 gliner
 ultralytics
 efficientnet_pytorch
-boto3

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -16,7 +16,7 @@ from ultralytics import YOLO
 class ThisTester(ModelTester):
     def _load_model(self):
         # Reference: https://github.com/THU-MIG/yolov10
-        file = get_file("test_files/pytorch/yolov10/yolov10n.pt")
+        file = get_file("test_files/pytorch/yolov10/yolov_10n.pt")
         model = YOLO(file)
         return model.model
 

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -8,7 +8,7 @@ import pytest
 import os
 from pathlib import Path
 import requests
-from tests.utils import ModelTester, skip_full_eval_test
+from tests.utils import ModelTester, get_file, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from ultralytics import YOLO
 
@@ -16,24 +16,9 @@ from ultralytics import YOLO
 class ThisTester(ModelTester):
     def _load_model(self):
         # Reference: https://github.com/THU-MIG/yolov10
-        url = "https://github.com/THU-MIG/yolov10/releases/download/v1.1/yolov10n.pt"
-
-        if (
-            "DOCKER_CACHE_ROOT" in os.environ
-            and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
-        ):
-            download_dir = Path(os.environ["DOCKER_CACHE_ROOT"]) / "yolov10_weights"
-        else:
-            download_dir = Path.home() / ".cache/yolov10_weights"
-        download_dir.mkdir(parents=True, exist_ok=True)
-
-        load_path = download_dir / url.split("/")[-1]
-        if not load_path.exists():
-            response = requests.get(url, stream=True)
-            with open(str(load_path), "wb") as f:
-                f.write(response.content)
-
-        model = YOLO(load_path)
+        file = get_file("yolov_10n.pt")
+        model = YOLO(file)
+        print("Successfully loaded model")
         return model.model
 
     def _load_inputs(self):

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -16,9 +16,8 @@ from ultralytics import YOLO
 class ThisTester(ModelTester):
     def _load_model(self):
         # Reference: https://github.com/THU-MIG/yolov10
-        file = get_file("yolov_10n.pt")
+        file = get_file("test_files/pytorch/yolov10/yolov10n.pt")
         model = YOLO(file)
-        print("Successfully loaded model")
         return model.model
 
     def _load_inputs(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -675,14 +675,10 @@ class OnnxModelTester(ModelTester):
 
 @staticmethod
 def get_file(s3_path):
+    """
+    Please refer to documentation /tt-torch/docs/src/adding_models.md for details on how to add models to S3 bucket and how to use this function to load models locally or from CI.
+    """
     rel_dir, file_name = os.path.split(s3_path)
-
-    """
-    Get Cache directory based on environment variables in the following order:
-    1. DOCKER_CACHE_ROOT: meant for CI tests
-    2. TT_TORCH_CACHE: if user wants to set up a custom cache directory in their local machine
-    3. ~/.cache/tt-torch-test-models: default cache directory
-    """
     if (
         "DOCKER_CACHE_ROOT" in os.environ
         and Path(os.environ["DOCKER_CACHE_ROOT"]).exists()
@@ -693,11 +689,9 @@ def get_file(s3_path):
             / rel_dir
         )
     elif "TT_TORCH_CACHE" in os.environ and Path(os.environ["TT_TORCH_CACHE"]).exists():
-        cache_dir = (
-            Path(os.environ["TT_TORCH_CACHE"]) / "models/tt-ci-models-private" / rel_dir
-        )
+        cache_dir = Path(os.environ["TT_TORCH_CACHE"]) / "S3" / rel_dir
     else:
-        cache_dir = Path.home() / ".cache/models/tt-ci-models-private" / rel_dir
+        cache_dir = Path.home() / ".cache/S3" / rel_dir
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     # Check if file already exists in cache, dowload into cache if not
@@ -708,11 +702,6 @@ def get_file(s3_path):
                 f"File {file_path} is not available, check S3 path. If path is correct, DOCKER_CACHE_ROOT syncs automatically with S3 bucket every hour so please wait for the next sync."
             )
         else:
-            """
-            If we are running tests locally we can access S3 bucket content via boto3.
-            In order to do so user has to set up AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
-            and AWS_DEFAULT_REGION environment variables.
-            """
             if "S3_BUCKET" not in os.environ:
                 raise ValueError(
                     "S3_BUCKET environment variable is not set. Please set it to the name of the S3 bucket."


### PR DESCRIPTION
### Ticket
#595 
### Problem description
Set up function to get files from S3 bucket.

### What's changed
Added static function under utils to get file that's been loaded to S3 bucket, we don't want to pull directly from S3 bucket so logic will:
1.   If in CI pull from docker cache that has been set up to sync with S3 bucket every hour
2.  If running local test:
     - Check if file is in local cache, pull from there if so
     - else, download file from IRD LFS cache (syncs up with S3 bucket) into local cache

### Checklist
- [x] New/Existing tests provide coverage for changes
