### PR TITLE
Add helper to tag+skip red model tests not yet running e2e and report on them in nightly full-model-execute

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -136,7 +136,28 @@ jobs:
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
             "
-          }
+          },
+          {
+            # These are WIP model_group=red models, marked w/ pytest.skip with reasons, run here for reporting.
+            runs-on: wormhole_b0, name: "skip_tests_red_models", tests: "
+                tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-lstm]
+                tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-gru]
+                tests/models/oft/test_oft.py::test_oft[full-eval]
+                tests/models/vgg19_unet/test_vgg19_unet.py::test_vgg19_unet[full-eval]
+                tests/models/yolov10/test_yolov10.py::test_yolov10[full-eval]
+                tests/models/flux/test_flux.py::test_flux[full-flux_schnell-eval]
+                tests/models/flux/test_flux.py::test_flux[full-flux_dev-eval]
+                tests/models/gliner/test_gliner.py::test_gliner[full-eval]
+                tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
+                tests/models/mistral/test_pixtral.py::test_pixtral[full-eval]
+                tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]
+                tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]
+                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
+                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
+                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-10B-Base-eval]
+                tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
+            "
+          },
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -4,7 +4,7 @@
 import torch
 import pytest
 from gliner import GLiNER
-from tests.utils import ModelTester
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
@@ -33,6 +33,7 @@ class ThisTester(ModelTester):
 )
 def test_gliner(record_property, mode, op_by_op):
     model_name = "gliner-v2"
+    model_group = "red"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -49,8 +50,18 @@ def test_gliner(record_property, mode, op_by_op):
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group="red",
+        model_group=model_group,
     )
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_TTMLIR_COMPILATION",
+        reason="moreh_softmax_device_operation.cpp Inputs must be of bfloat16 or bfloat8_b type - https://github.com/tenstorrent/tt-torch/issues/732",
+        model_group=model_group,
+    )
+
     entities = tester.test_model()
     if mode == "eval":
         for entity in entities:

--- a/tests/models/mistral/test_pixtral.py
+++ b/tests/models/mistral/test_pixtral.py
@@ -4,7 +4,7 @@
 import torch
 import pytest
 from transformers import AutoProcessor, LlavaForConditionalGeneration
-from tests.utils import ModelTester
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
@@ -53,18 +53,28 @@ class ThisTester(ModelTester):
 )
 def test_pixtral(record_property, mode, op_by_op):
     model_name = "mistral-community/pixtral-12b"
+    model_group = "red"
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Model is too large to fit on single device during execution.",
+        model_group=model_group,
+    )
+
     tester = ThisTester(
         model_name,
         mode,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group="red",
+        model_group=model_group,
         assert_pcc=False,
         assert_atol=False,
     )

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from tests.models.oft.src.oftnet import OftNet  # OftNet imports OFT
 
@@ -48,6 +48,7 @@ def test_oft(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "OFT"
+    model_group = "red"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -57,13 +58,22 @@ def test_oft(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Out of Memory: Not enough space to allocate 2902982656 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-torch/issues/727",
+        model_group=model_group,
+    )
+
     tester = ThisTester(
         model_name,
         mode,
         compiler_config=cc,
         assert_atol=False,
         record_property_handle=record_property,
-        model_group="red",
+        model_group=model_group,
     )
 
     results = tester.test_model()

--- a/tests/models/oft/test_oft_onnx.py
+++ b/tests/models/oft/test_oft_onnx.py
@@ -52,9 +52,7 @@ def test_oft_onnx(record_property, mode, op_by_op):
     model_name = "OFT"
 
     cc = CompilerConfig()
-    cc.compile_depth = CompileDepth.STABLEHLO
-    if op_by_op:
-        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/phi/test_phi_1_1p5_2.py
+++ b/tests/models/phi/test_phi_1_1p5_2.py
@@ -9,7 +9,7 @@ import torch
 import pytest
 
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 
@@ -46,11 +46,22 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_phi(record_property, model_name, mode, op_by_op):
+    model_group = "red"
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Cannot get the device from a tensor without an allocated buffer - https://github.com/tenstorrent/tt-torch/issues/733",
+        model_group=model_group,
+        model_name_filter="microsoft/phi-2",
+    )
 
     tester = ThisTester(
         model_name,
@@ -58,7 +69,7 @@ def test_phi(record_property, model_name, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         is_token_output=True,
-        model_group="red",
+        model_group=model_group,
     )
 
     # TODO - Enable checking - https://github.com/tenstorrent/tt-torch/issues/528

--- a/tests/models/vgg19_unet/test_vgg19_unet.py
+++ b/tests/models/vgg19_unet/test_vgg19_unet.py
@@ -4,7 +4,7 @@
 
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from tests.models.vgg19_unet.src.vgg19_unet import VGG19UNet
 
@@ -33,6 +33,7 @@ def test_vgg19_unet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
     model_name = "VGG19-Unet"
+    model_group = "red"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -42,12 +43,21 @@ def test_vgg19_unet(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Out of Memory: Not enough space to allocate 84213760 B L1 buffer across 64 banks, where each bank needs to store 1315840 B - https://github.com/tenstorrent/tt-torch/issues/729",
+        model_group=model_group,
+    )
+
     tester = ThisTester(
         model_name,
         mode,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group="red",
+        model_group=model_group,
     )
 
     with torch.no_grad():


### PR DESCRIPTION
### Ticket
None

### Problem description
- @staylorTT (TPM!) yearns for status on models that are not running e2e but failing on earlier frontend, compiler, runtime issues but since we do not run them in full-model-execute nightly results are not reported on.

### What's changed
 - Add helper skip_full_eval_test() to update tags with reasons pointing to tickets opened for each failure and pytest.skips them
- Add the existing WIP red model group tests to full model execute list for reporting purposes
- Unrelated - Remove hardcoded cc.compile_depth = CompileDepth.STABLEHLO in test_oft_onnx.py
 
### Checklist
- [x] Tested tests locally and on CI https://github.com/tenstorrent/tt-torch/actions/runs/14897456449
