### PR TITLE
Fix Model Group insertion location

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -131,6 +131,7 @@ class ModelTester:
             compiler_config = CompilerConfig()
         self.compiler_config = compiler_config
         self.compiler_config.model_name = model_name
+        self.compiler_config.model_group = model_group
 
         self.record_property = record_property_handle
         self.compiler_config.record_property = record_property_handle

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,9 +71,10 @@ def skip_full_eval_test(
             {
                 "bringup_status": bringup_status,
                 "model_name": model_name,
-                "model_group": model_group,
             },
         )
+        record_property("group", model_group)
+
         pytest.skip(reason=reason)
         return True
     return False
@@ -130,7 +131,6 @@ class ModelTester:
             compiler_config = CompilerConfig()
         self.compiler_config = compiler_config
         self.compiler_config.model_name = model_name
-        self.compiler_config.model_group = model_group
 
         self.record_property = record_property_handle
         self.compiler_config.record_property = record_property_handle
@@ -160,7 +160,7 @@ class ModelTester:
         # configs should be set at test start, so they can be flushed immediately
         self.record_property(
             "config",
-            {"model_group": model_group, "compiler_config": compiler_config.to_dict()},
+            {"compiler_config": compiler_config.to_dict()},
         )
 
     def _load_model(self):

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -423,7 +423,6 @@ class CompilerConfig:
             "unique_ops": self.unique_ops,
             "stable_hlo_ops": self.stable_hlo_ops,
             "model_name": self.model_name,
-            "model_group": self.model_group,
             "results_path": self.results_path,
             "single_op_timeout": self.single_op_timeout,
             "enable_consteval": self.enable_consteval,


### PR DESCRIPTION
### Ticket
None

### Problem description
Group field is not correctly exported so it can be read by db query, and it is also, redundantly, thrice exported into the XML report

### What's changed
- remove redundant model group recording in config, as it's valid but circumvents the db schema
- unify model_group reporting in top-level `group` field
- remove model_group recording in config.compiler_config, which was accidentally included

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Reported op by op jsons still can access model group from their own serialization
- [x] Model group is only written out once in any execute report, including skipped 
