### PR TITLE
Generate MLIR dumps and upload as nightly artifacts

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -88,6 +88,7 @@ jobs:
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       run-codecov: 'false'
+      run-dump-mlir: 'false'
   check-all-green:
     if: always()
     needs:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -41,3 +41,4 @@ jobs:
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       run-codecov: 'false'
+      run-dump-mlir: 'false'

--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -8,6 +8,11 @@ on:
         description: 'Docker image to use for build'
         required: true
         type: string
+      run-dump-mlir:
+        description: 'Dump MLIR files'
+        required: false
+        type: string
+        default: 'true'
   workflow_run:
     workflows: [Build]
     types: [completed]
@@ -89,6 +94,7 @@ jobs:
         echo "test_report_path_torch=report_torch_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_onnx=report_onnx_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "mlir_dir=$(pwd)/model_mlir" >> "$GITHUB_OUTPUT" # Define the model_mlir directory
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -122,7 +128,7 @@ jobs:
       run: |
         source env/activate
 
-        TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf ${{matrix.build.tests}} \
           --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
           2>&1 | tee pytest.log
 
@@ -139,3 +145,23 @@ jobs:
       with:
         name: test-reports-models-${{ matrix.build.runs-on }}-${{ matrix.build.name }}
         path: ${{ steps.strings.outputs.test_report_path_models }}
+
+    - name: Upload MLIR files
+      uses: actions/upload-artifact@v4
+      if: ${{ (success() || failure()) && inputs.run-dump-mlir == 'true' }}
+      with:
+        name: model-mlir-compile-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.mlir_dir }}
+
+  merge_mlir_artifacts:
+    needs: [tests]
+    if: ${{ inputs.run-dump-mlir == 'true' }}
+    runs-on: ubuntu-latest
+    name: Merge MLIR Artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: model-mlir-compile
+          pattern: model-mlir-compile-*
+          delete-merged: true

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string # properly a boolean but autocast to string when passed in using 'with' inputs
         default: 'true'
+      run-dump-mlir:
+        description: 'Dump MLIR files'
+        required: false
+        type: string
+        default: 'true'
   workflow_run:
     workflows: [Build] # backref to run-build as dependency
     types: [completed]
@@ -197,6 +202,7 @@ jobs:
         echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "mlir_dir=$(pwd)/model_mlir" >> "$GITHUB_OUTPUT" # Define the model_mlir directory
 
     - name: Use build artifacts
       uses: actions/download-artifact@v4
@@ -227,7 +233,7 @@ jobs:
       run: |
         source env/activate
 
-        pytest --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 
@@ -262,3 +268,23 @@ jobs:
         files: ${{ steps.strings.outputs.test_report_path_models }}
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload MLIR files
+      uses: actions/upload-artifact@v4
+      if: ${{ (success() || failure()) && inputs.run-dump-mlir == 'true' }}
+      with:
+        name: model-mlir-execute-nightly-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.mlir_dir }}
+
+  merge_mlir_artifacts:
+    needs: [tests]
+    if: ${{ inputs.run-dump-mlir == 'true' }}
+    runs-on: ubuntu-latest
+    name: Merge MLIR Artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: model-mlir-execute-nightly
+          pattern: model-mlir-execute-nightly-*
+          delete-merged: true

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string # properly a boolean but autocast to string when passed in using 'with' inputs
         default: 'true'
+      run-dump-mlir:
+        description: 'Dump MLIR files'
+        required: false
+        type: string
+        default: 'true'
   workflow_run:
     workflows: [Build] # backref to run-build as dependency
     types: [completed]
@@ -137,6 +142,7 @@ jobs:
         echo "install-dir=$(pwd)/install" >> "$GITHUB_OUTPUT"
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
+        echo "mlir_dir=$(pwd)/model_mlir" >> "$GITHUB_OUTPUT" # Define the model_mlir directory
 
     - name: Use build artifacts
       uses: actions/download-artifact@v4
@@ -167,7 +173,7 @@ jobs:
       run: |
         source env/activate
 
-        pytest --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 
@@ -202,3 +208,23 @@ jobs:
         files: ${{ steps.strings.outputs.test_report_path_models }}
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Upload MLIR files
+      uses: actions/upload-artifact@v4
+      if: ${{ (success() || failure()) && inputs.run-dump-mlir == 'true' }}
+      with:
+        name: model-mlir-execute-push-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
+        path: ${{ steps.strings.outputs.mlir_dir }}
+
+  merge_mlir_artifacts:
+    needs: [tests]
+    if: ${{ inputs.run-dump-mlir == 'true' }}
+    runs-on: ubuntu-latest
+    name: Merge MLIR Artifacts
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: model-mlir-execute-push
+          pattern: model-mlir-execute-push-*
+          delete-merged: true

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -287,6 +287,7 @@ class CompilerConfig:
         self.record_property = None
         self.record_property = lambda *args, **kwargs: None  # Default to no-op
         self.runtime_intermediate_cache = None  # Do not serialize.
+        self.save_mlir_override = None
 
         self.apply_environment_overrides()
         self.post_init()
@@ -360,6 +361,20 @@ class CompilerConfig:
         if dump_intermediates:
             self.dump_debug = dump_intermediates == "DEBUG"
             self.dump_info = self.dump_debug or dump_intermediates == "INFO"
+        save_mlir_str = os.environ.get("TT_TORCH_SAVE_MLIR")
+        if save_mlir_str:
+            self.save_mlir_override = []
+            dialects = [
+                d.strip() for d in save_mlir_str.split(",")
+            ]  # Using comma as a separator
+            valid_dialects = ["STABLEHLO", "TTIR", "TTNN"]
+            for dialect in dialects:
+                if dialect in valid_dialects and dialect not in self.save_mlir_override:
+                    self.save_mlir_override.append(dialect)
+                elif dialect:
+                    print(
+                        f"Warning: Invalid SAVE_MLIR value: {dialect}. Expected one or more of {valid_dialects} separated by commas."
+                    )
 
     def post_init(self):
         if self.consteval_parameters:


### PR DESCRIPTION
### Ticket
None

### Problem description
As we have more models compiling/running end-to-end, there's an increasing demand for MLIR dumps of these models at various stages (Stablehlo, TTIR, TTNN)

### What's changed
Added an environment variable that can be set to control at what stages will the MLIR be dumped. Note: this only works when models are run in full, not op-by-op. 

ex: `TT_TORCH_SAVE_MLIR=STABLEHLO pytest tests/models/resnet/test_resnet.py::test_resnet[full-eval]`
The `TT_TORCH_SAVE_MLIR` could be set to `STABLEHLO` `TTIR` `TTNN`. Or a list of them: `TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR`

This environment variable is true by default, which means mlir files will be loaded as artifacts. It is set to false for on pr and on push flows, as that is unneeded overhead. Used merge-artifacts so that mlir dump artifacts are easy to navigate through.

### Checklist
- [X] Added `TT_TORCH_SAVE_MLIR` support to `backend.py` and `CompilerConfig`
- [X] Edited end-to end compile/ execute workflows to upload merged MLIR file artifacts on nightly run
