### PR TITLE
Early return in verify_outputs() to skip golden check if compile_depth!=EXECUTE (Issue #739)

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -318,6 +318,12 @@ class ModelTester:
         return results
 
     def verify_outputs(self, golden, outputs):
+
+        # Only do golden check if running EXECUTE. Limited value comparing in other situations.
+        if self.compiler_config.compile_depth != CompileDepth.EXECUTE:
+            print(f"Skipping golden check for {self.compiler_config.compile_depth}")
+            return
+
         assert type(outputs) == type(
             golden
         ), "Expecting the type of both calculated and golden to be identical. Whether that be a tensor, list, dictonary, etc."


### PR DESCRIPTION
### Ticket
#739 

### Problem description
 - Models added to e2e-compile list can fail with pcc check sometimes, but pass in full model execute (few unet tests lately)
 - It is said that the comparison outside of full-model-execute is not valuable, compares torch decomposed to torch orig model

### What's changed
 - Return early from verify_outputs() which calls failing verify_against_golden() function when compile_depth!=EXECUTE 
 - Solves occasional PCC failures seen when running models in e2e-compile list, op-by-op flow take different path, not affected.

### Checklist
- [x] Tested locally in tests with/without `TT_TORCH_COMPILE_DEPTH=TTNN_IR` env-var
