### PR TITLE
Fix incorrect exit code sampling to avoid false positive op by op pass

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -258,10 +258,10 @@ jobs:
 
           echo "====== BEGIN LOG: $test_case ======" >> full_job_output.log
           pytest -svv -rf "$test_case" > test.log 2>&1
+          exit_code=$?
           cat test.log >> full_job_output.log
           sed -n '/=========================== short test summary info ============================/,$p' test.log >>pytest.log
 
-          exit_code=$?
 
           echo "====== END LOG: $test_case ========" >> full_job_output.log
           echo >> full_job_output.log


### PR DESCRIPTION
### Ticket
#746 

### Problem description
Addition of fail logger caused the failure condition (sampling prev. command exit code) to start sampling the exit code of `sed` rather than `pytest`, which would always return 0 and show all op by op tests as passing regardless of exit code of the pytest.

### What's changed
Move exit code to be adjacent to pytest.

### Checklist
- [x] New/Existing tests provide coverage for changes
