### PR TITLE
Add Stable Diffusion 3.5 #332

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -53,7 +53,7 @@ jobs:
                   tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]
             "
-          }
+          },
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -115,6 +115,7 @@ jobs:
             # Approximately 40 minutes.
             runs-on: wormhole_b0, name: "eval_6", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
+                  tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-medium-transformer-eval]
             "
           },
           {
@@ -161,6 +162,9 @@ jobs:
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-10B-Base-eval]
                 tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
+                tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-medium-eval]
+                tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-large-eval]
+                tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-large-transformer-eval]
             "
           },
         ]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -163,6 +163,13 @@ jobs:
               tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_schnell-eval]
               tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_dev-eval]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "stable-diffusion-v3.5", tests: "
+              tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[op_by_op_torch-SD3.5-medium-eval]
+              tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[op_by_op_torch-SD3.5-large-eval]
+              tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[op_by_op_torch-SD3.5-large-transformer-eval]
+              "
           }
         ]
     runs-on:

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -226,6 +226,11 @@ jobs:
             runs-on: wormhole_b0, name: "falcon3", tests: "
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-1B-Base-eval]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "stable-diffusion-3.5", tests: "
+              tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[op_by_op_torch-SD3.5-medium-transformer-eval]
+              "
           }
         ]
     runs-on:

--- a/tests/models/stable_diffusion/test_stable_diffusion_3_5.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_3_5.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from tests.utils import ModelTester, skip_full_eval_test
+from diffusers import StableDiffusion3Pipeline, AutoencoderTiny
+
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        pipe = StableDiffusion3Pipeline.from_pretrained(
+            model_path,
+            text_encoder_3=None,
+            tokenizer_3=None,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+        )
+        # memory optimization recommended by: https://huggingface.co/docs/diffusers/en/api/pipelines/stable_diffusion/stable_diffusion_3#tiny-autoencoder-for-stable-diffusion-3
+        pipe.vae = AutoencoderTiny.from_pretrained(
+            "madebyollin/taesd3", torch_dtype=torch.bfloat16, low_cpu_mem_usage=True
+        )
+        pipe.enable_attention_slicing()
+        return pipe
+
+    def _load_inputs(self):
+        prompt = [
+            "a photo of an astronaut riding a horse on mars",
+        ]
+
+        negative_prompt = ""
+        height = 512
+        width = 512
+        guidance_scale = 7.0
+        arguments = {
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "height": height,
+            "width": width,
+            "guidance_scale": guidance_scale,
+        }
+
+        return arguments
+
+
+model_info_list = [
+    ("SD3.5-medium", "stabilityai/stable-diffusion-3.5-medium"),
+    ("SD3.5-large", "stabilityai/stable-diffusion-3.5-large"),
+]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_info",
+    model_info_list,
+    ids=[model_info[0] for model_info in model_info_list],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_stable_diffusion_3_5(record_property, model_info, mode, op_by_op):
+    model_group = "red"
+    model_name, model_path = model_info
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    # consteval_parameters is disabled because it results in a memory related crash
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Cannot lower StableHLO --> TTIR : results/mlir_tests/stable_hlo/aten::round.decimals_0.mlir:3:10: error: failed to legalize operation 'stablehlo.round_nearest_even' - https://github.com/tenstorrent/tt-torch/issues/769",
+        model_group=model_group,
+    )
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        assert_atol=False,
+        assert_pcc=False,
+        model_group="red",
+    )
+    results = tester.test_model()
+    if mode == "eval":
+        image = results.images[0]
+        image.save("generated_image.png")
+
+    tester.finalize()

--- a/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+from tests.utils import ModelTester, skip_full_eval_test
+from diffusers import (
+    StableDiffusion3Pipeline,
+    FlowMatchEulerDiscreteScheduler,
+    SD3Transformer2DModel,
+)
+
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        self.pipe = StableDiffusion3Pipeline.from_pretrained(
+            model_path,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+        )
+        self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+            model_path, subfolder="scheduler"
+        )
+        self.transformer = SD3Transformer2DModel.from_pretrained(
+            model_path, subfolder="transformer", torch_dtype=torch.bfloat16
+        )
+        return self.transformer
+
+    def _load_inputs(self):
+        prompt = "A futuristic cityscape at sunset"
+        num_images_per_prompt = 1
+        height = 512
+        width = 512
+        (
+            prompt_embeds,
+            negative_prompt_embeds,
+            pooled_prompt_embeds,
+            negative_pooled_prompt_embeds,
+        ) = self.pipe.encode_prompt(
+            prompt=prompt,
+            prompt_2=prompt,  # Using the same prompt for all encoders for simplicity
+            prompt_3=prompt,
+            num_images_per_prompt=num_images_per_prompt,
+            do_classifier_free_guidance=False,  # For simplicity in this direct call
+        )
+
+        num_channels_latents = self.transformer.config.in_channels
+        latents = self.pipe.prepare_latents(
+            batch_size=num_images_per_prompt,
+            num_channels_latents=num_channels_latents,
+            height=height,
+            width=width,
+            dtype=prompt_embeds.dtype,
+            device=None,
+            generator=None,
+        )
+
+        self.scheduler.set_timesteps(28)
+        timestep = self.scheduler.timesteps[0].expand(latents.shape[0])
+        arguments = {
+            "hidden_states": latents,
+            "timestep": timestep,
+            "encoder_hidden_states": prompt_embeds,
+            "pooled_projections": pooled_prompt_embeds,
+            "joint_attention_kwargs": {},
+            "return_dict": False,
+        }
+        return arguments
+
+
+model_info_list = [
+    ("SD3.5-medium-transformer", "stabilityai/stable-diffusion-3.5-medium"),
+    ("SD3.5-large-transformer", "stabilityai/stable-diffusion-3.5-large"),
+]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_info",
+    model_info_list,
+    ids=[model_info[0] for model_info in model_info_list],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_stable_diffusion_transformer(record_property, model_info, mode, op_by_op):
+    model_group = "red"
+    model_name, model_path = model_info
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Model compilation exceeds CI timeout limit (240 minutes), compiles e2e locally. Model execution fails with `Not enough space to allocate 47316992 B DRAM buffer across 12 banks.`",
+        model_group=model_group,
+        model_name_filter="SD3.5-large-transformer",
+    )
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        assert_atol=False,
+        assert_pcc=False,
+        model_group=model_group,
+    )
+    results = tester.test_model()
+
+    tester.finalize()

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import gc
 from torch.fx.experimental import const_fold
 from typing import List, Optional, Union
 from torch.export.graph_signature import InputKind
@@ -103,6 +104,7 @@ def bypass_dtype_promotion(gm, compiler_config):
 
 def constant_fold(gm):
     gm = const_fold.split_const_subgraphs(gm)
+    gc.collect()
     gm.run_folding()
 
     gm.graph.eliminate_dead_code()


### PR DESCRIPTION
### Ticket
#332 

### Problem description
StableDiffusion (SD) 3.5 is a big model. The model uses SD3Transformer2DModel. I added two different tests - one that simply uses SD3Transformer2DModel and one that runs SD3.5. To get SD3.5 working, I made some model level optimizations and included memory cleanup in `pass_pipeline`. Even then, the
`tests/models/stable_diffusion/test_stable_diffusion_3_5.py` test can only run the medium variant op-by-op. It cannot run compile/ execute, and it cannot run the large variant.

Also added licensing material.

### What's changed
Added 2 test files for SD3.5 - one using the backbone transformer and one for the complete model. 
Edited workflow files to run SD3.5
Added some memory cleanup to backend
