### PR TITLE
Demote int64 constant value to int32

### DIFF
--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -305,8 +305,6 @@ class Executor:
             )
 
         assert self.binary is not None
-        if self.compiler_config.typecast_inputs:
-            inputs = self.typecast_inputs(inputs)
 
         activations_len = len(inputs)
         if (
@@ -314,6 +312,9 @@ class Executor:
             and self.preprocessed_graph_constants is None
         ):
             inputs = self.graph_constants + inputs
+
+        if self.compiler_config.typecast_inputs:
+            inputs = self.typecast_inputs(inputs)
 
         inputs = list(inputs)
         device = self._get_device()


### PR DESCRIPTION
### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-torch/issues/663)

### Problem description
Our device misinterprets int64 tensors when they are provided as constants, resulting in like [1, 0, 2, 0, 3, 0, ...] instead of [1, 2, 3, ...]. 

### What's changed
To prevent this, this function safely casts int64 tensors to int32 if all values fit within the int32 range, ensuring correct data is passed to the device.

### Checklist
- [v] Run swin_b without PCC drops with https://github.com/tenstorrent/tt-mlir/pull/3320
