### PR TITLE
Lock onnx version to unblock CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ matplotlib
 mlp_mixer_pytorch
 wheel
 xlsxwriter
-onnx
+onnx==1.17.0 # 1.18.0 fails with "Unsupported model IR version: 11, max supported IR version: 10"
 onnxruntime
 openpyxl
 pillow


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/761

### Problem description
Onnx and onnxruntime python packages recently released new versions and break onnx tests. See issue for details.

Old versions from local
`pip list | grep onnx`
```
onnx                  1.17.0
onnxruntime           1.22.0
```


New versions from [[CI]](https://github.com/tenstorrent/tt-torch/actions/runs/14995826684/job/42130693659#step:14:1451)

```
Collecting onnx (from -r requirements.txt (line 27))
  Using cached onnx-1.18.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (6.9 kB)
Collecting onnxruntime (from -r requirements.txt (line 28))
  Using cached onnxruntime-1.22.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (4.5 kB)
```

### What's changed
Locking down onnx version.
No need to lock down onnxruntime version as tests still pass with latest.

### Checklist
- [x] New/Existing tests provide coverage for changes
