### PR TITLE
Add support for automatic data parallelization guarded by compiler config option

### DIFF
--- a/.github/workflows/run-multidevice-tests.yml
+++ b/.github/workflows/run-multidevice-tests.yml
@@ -87,3 +87,9 @@ jobs:
       run: |
         source env/activate
         pytest --durations=0 -svv tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]
+
+    - name: Run Resnet50
+      shell: bash
+      run: |
+        source env/activate
+        pytest --durations=0 -svv tests/models/resnet50/test_resnet50_llmbox.py::test_resnet[full-eval]

--- a/tests/models/resnet50/test_resnet50_llmbox.py
+++ b/tests/models/resnet50/test_resnet50_llmbox.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import requests
+import torchvision.models as models
+from torchvision import transforms
+from PIL import Image
+
+import pytest
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        # Load the ResNet-50 model with updated API
+        self.weights = models.ResNet50_Weights.DEFAULT
+        model = models.resnet50(weights=self.weights)
+        model = model.to(torch.bfloat16)
+        return model
+
+    def _load_inputs(self):
+        # Define a transformation to preprocess the input image using the weights transforms
+        preprocess = self.weights.transforms()
+
+        # Load and preprocess the image
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        img_t = preprocess(image)
+        batch_t = img_t.unsqueeze(0).repeat(128, 1, 1, 1)
+        batch_t = batch_t.to(torch.bfloat16)
+        return batch_t
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_resnet(record_property, mode, op_by_op):
+    if mode == "train":
+        pytest.skip()
+    model_name = "ResNet50"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.automatic_parallelization = True
+    cc.mesh_shape = [1, 8]
+    cc.dump_info = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        required_atol=0.03,
+        required_pcc=0.98,
+        compiler_config=cc,
+        assert_pcc=True,
+        assert_atol=False,
+        record_property_handle=record_property,
+    )
+
+    results = tester.test_model()
+    if mode == "eval":
+        # Print the top 5 predictions
+        _, indices = torch.topk(results, 5)
+        print(f"Top 5 predictions: {indices[0].tolist()}")
+
+    tester.finalize()
+
+
+# Empty property record_property
+def empty_record_property(a, b):
+    pass
+
+
+# Run pytorch implementation
+if __name__ == "__main__":
+    test_resnet(empty_record_property)

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -143,6 +143,14 @@ static torch::Tensor create_torch_tensor(const tt::runtime::Tensor &tensor) {
   return torch_tensor;
 }
 
+std::string stable_hlo_automatic_parallelization(
+    std::string_view code, std::vector<int64_t> mesh_shape,
+    size_t len_activations, size_t len_graph_constants) {
+  auto ret = tt::torch::stableHLOAutomaticParallelization(
+      code, mesh_shape, len_activations, len_graph_constants);
+  return ret;
+}
+
 std::string compile_stable_hlo_to_ttir(std::string_view code) {
   auto ret = tt::torch::compileStableHLOToTTIR(code);
   return ret;
@@ -336,6 +344,9 @@ get_op_output_torch_tensor(tt::runtime::OpContext opContextHandle,
 
 PYBIND11_MODULE(tt_mlir, m) {
   m.doc() = "tt_mlir";
+  py::enum_<::tt::runtime::DispatchCoreType>(m, "DispatchCoreType")
+      .value("WORKER", ::tt::runtime::DispatchCoreType::WORKER)
+      .value("ETH", ::tt::runtime::DispatchCoreType::ETH);
   py::class_<tt::runtime::Binary>(m, "Binary")
       .def("getProgramInputs", &tt::runtime::Binary::getProgramInputs)
       .def("getProgramOutputs", &tt::runtime::Binary::getProgramOutputs)
@@ -378,6 +389,9 @@ PYBIND11_MODULE(tt_mlir, m) {
         py::arg("ttir"), py::arg("system_desc_path"),
         py::arg("len_activations") = 0, py::arg("len_graph_constants") = 0,
         "A function that compiles TTIR to a bytestream");
+  m.def("stable_hlo_automatic_parallelization",
+        &stable_hlo_automatic_parallelization,
+        "Run shardy automatic data parallelization pass on stableHLO");
   m.def("compile_stable_hlo_to_ttir", &compile_stable_hlo_to_ttir,
         "A function that compiles stableHLO to TTIR");
   m.def("open_mesh_device", &tt::runtime::openMeshDevice, py::arg("mesh_shape"),

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -38,6 +38,7 @@
 #include "ttmlir/Dialect/TT/IR/TTOps.h"
 #include "ttmlir/Dialect/TT/IR/TTTraits.h"
 
+#include "ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h"
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"
 #include "ttmlir/Dialect/TTIR/Transforms/Passes.h"
 #include "ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h"
@@ -50,6 +51,83 @@
 #include <llvm/ADT/SmallVector.h>
 
 namespace tt::torch {
+
+static inline llvm::StringMap<llvm::SmallVector<mlir::tt::ArgumentType>>
+setArgumentTypes(size_t len_activations, size_t len_graph_constants) {
+  llvm::SmallVector<mlir::tt::ArgumentType> argTypes;
+
+  for (size_t i = 0; i < len_graph_constants; ++i) {
+    argTypes.push_back(mlir::tt::ArgumentType::Constant);
+  }
+
+  for (size_t i = 0; i < len_activations; ++i) {
+    argTypes.push_back(mlir::tt::ArgumentType::Input);
+  }
+
+  llvm::StringMap<llvm::SmallVector<mlir::tt::ArgumentType>> argTypesMap;
+  argTypesMap["main"] = argTypes;
+  return argTypesMap;
+}
+
+std::string stableHLOAutomaticParallelization(std::string_view code,
+                                              std::vector<int64_t> mesh_shape,
+                                              size_t len_activations,
+                                              size_t len_graph_constants) {
+  mlir::MLIRContext context;
+  mlir::DialectRegistry registry;
+
+  registry.insert<mlir::arith::ArithDialect>();
+  registry.insert<mlir::func::FuncDialect>();
+  registry.insert<mlir::ml_program::MLProgramDialect>();
+  registry.insert<mlir::shape::ShapeDialect>();
+
+  mlir::tt::registerAllDialects(registry);
+  mlir::stablehlo::registerAllDialects(registry);
+  mlir::func::registerAllExtensions(registry);
+  mlir::tt::registerAllExtensions(registry);
+
+  context.appendDialectRegistry(registry);
+
+  mlir::OwningOpRef<mlir::ModuleOp> mlir_module =
+      mlir::parseSourceString<mlir::ModuleOp>(
+          llvm::StringRef(code.data(), code.size()),
+          // IR may be invalid because some fields may be using DenseElements
+          // instead of DenseArray. We rectify that below and verify after.
+          mlir::ParserConfig{&context, /*verifyAfterParse=*/true});
+
+  mlir::PassManager automatic_sharding_pipeline_pm(
+      mlir_module.get()->getName(), mlir::PassManager::Nesting::Implicit);
+  const char *enable_printing = std::getenv("TT_TORCH_IR_LOG_LEVEL");
+  if (enable_printing && std::string(enable_printing) == "DEBUG") {
+    automatic_sharding_pipeline_pm.getContext()->disableMultithreading();
+    automatic_sharding_pipeline_pm.enableIRPrinting();
+  }
+
+  mlir::tt::stablehlo::AutomaticShardingPipelineOptions
+      automatic_sharding_pipeline_options;
+  automatic_sharding_pipeline_options.meshShape = mesh_shape;
+
+  // Set argument types.
+  if (len_activations > 0 || len_graph_constants > 0) {
+    automatic_sharding_pipeline_options.argumentTypeMap =
+        tt::torch::setArgumentTypes(len_activations, len_graph_constants);
+  }
+
+  mlir::tt::stablehlo::createAutomaticShardingPipeline(
+      automatic_sharding_pipeline_pm, automatic_sharding_pipeline_options);
+
+  // Run the pass manager.
+  if (mlir::failed(automatic_sharding_pipeline_pm.run(mlir_module.get()))) {
+    throw std::runtime_error("Failed to run automatic sharding pipeline.");
+  }
+
+  std::string buffer;
+  llvm::raw_string_ostream os(buffer);
+  mlir_module.get()->print(os, mlir::OpPrintingFlags().enableDebugInfo());
+  os.flush();
+
+  return buffer;
+}
 
 std::string compileStableHLOToTTIR(std::string_view code) {
   mlir::MLIRContext context;
@@ -166,7 +244,8 @@ compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
     }
     llvm::StringMap<llvm::SmallVector<mlir::tt::ArgumentType>> argTypesMap;
     argTypesMap["main"] = argTypes;
-    options.argumentTypeMap = argTypesMap;
+    options.argumentTypeMap =
+        tt::torch::setArgumentTypes(len_activations, len_graph_constants);
   }
 
   std::filesystem::path system_desc_temp_path;

--- a/tt_torch/csrc/tt-mlir-interface.hpp
+++ b/tt_torch/csrc/tt-mlir-interface.hpp
@@ -10,6 +10,10 @@
 
 namespace tt::torch {
 std::shared_ptr<void> *Compile(std::string_view code);
+std::string stableHLOAutomaticParallelization(std::string_view code,
+                                              std::vector<int64_t> mesh_shape,
+                                              size_t len_activations = 0,
+                                              size_t len_graph_constants = 0);
 std::string compileStableHLOToTTIR(std::string_view code);
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -228,7 +228,10 @@ class Executor:
         if self.devices[device_idx] is not None:
             return self.devices[device_idx]
         # Return a default parent mesh
-        device = tt_mlir.open_mesh_device([1, 1], tt_mlir.MeshDeviceOptions())
+        mesh_options = tt_mlir.MeshDeviceOptions()
+        if len(self.compiler_config.mesh_shape) == 32:
+            mesh_options.dispatch_core_type = tt_mlir.DispatchCoreType.WORKER
+        device = tt_mlir.open_mesh_device(self.compiler_config.mesh_shape, mesh_options)
         self.devices[device_idx] = device
         self.owned_device_indices.append(device_idx)
         return device
@@ -403,6 +406,7 @@ class Executor:
 
 class OnnxExecutor(Executor):
     def __init__(self, model_proto: onnx.ModelProto):
+        super().__init__()
         self.model_proto = model_proto
         self.binary = None
         self.sess = None

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -322,6 +322,8 @@ class CompilerConfig:
         self.device_map = {}
         self.apply_environment_overrides()
         self.post_init()
+        self.automatic_parallelization = False
+        self.mesh_shape = [1, 1]
 
     @property
     def verify_op_by_op(self):


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/tt-torch/issues/763

Usage
```
cc.automatic_parallelization = True
cc.mesh_shape = [1, 8]
```

Example
```
pytest -ssv tt-torch/tests/models/resnet50/test_resnet50_llmbox.py::test_resnet[full-eval]
```