### PR TITLE
Automatic pipeline parallel 

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -77,6 +77,7 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_8gf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_16gf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_x_32gf]
+                  tests/models/mistral/test_mistral.py::test_mistral[full-ministral3b-eval]
             "
           },
           {
@@ -97,10 +98,11 @@ jobs:
                 tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-wide_resnet101_2]
             "
           },
+          # This test group needs to be moved. This will be done once multichip tests are refactored: #780
           {
             runs-on: n300, name: "eval_6", tests: "
                 tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]
-                tests/models/mistral/test_mistral.py::test_mistral[full-ministral3b-eval]
+                tests/torch/test_basic_async.py
                 tests/torch/test_basic_multichip.py
             "
           },

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -101,6 +101,7 @@ jobs:
             runs-on: n300, name: "eval_6", tests: "
                 tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]
                 tests/models/mistral/test_mistral.py::test_mistral[full-ministral3b-eval]
+                tests/torch/test_basic_multichip.py
             "
           },
         ]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -98,6 +98,7 @@ jobs:
       run: |
         source env/activate
         pytest -v tests/torch \
+           --ignore=tests/torch/test_basic_multichip.py \
            --junit-xml=${{ steps.strings.outputs.test_report_path_torch }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml
 

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -99,7 +99,7 @@ def main(use_simplified_manager):
     for device in devices:
         options = BackendOptions()
         options.compiler_config = cc
-        options.device = device
+        options.devices = [device]
         # Compile the model for each device
         tt_models.append(
             torch.compile(model, backend=backend, dynamic=False, options=options)

--- a/demos/resnet/resnet50_single_vs_multi_device_compare.py
+++ b/demos/resnet/resnet50_single_vs_multi_device_compare.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
     for device in devices:
         multi_options = BackendOptions()
         multi_options.compiler_config = cc
-        multi_options.device = device
+        multi_options.devices = [device]
         multi_models.append(
             torch.compile(model, backend=backend, dynamic=False, options=multi_options)
         )

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -16,6 +16,8 @@ from transformers.modeling_outputs import (
 from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.processing_utils import Unpack
+from accelerate import infer_auto_device_map
+from tt_torch.tools.verify import verify_against_golden
 
 
 def get_model_and_tokenizer(model_name):
@@ -27,7 +29,6 @@ def get_model_and_tokenizer(model_name):
     m = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16)
     for param in m.parameters():
         param.requires_grad = False
-    m.eval()
     return m, tokenizer
 
 
@@ -49,261 +50,6 @@ def decode_output(outputs, tokenizer):
     return tokenizer.decode([next_token])
 
 
-class LlamaFirstHalf(nn.Module):
-    def __init__(self, original_model):
-        super().__init__()
-        self.original_model = original_model
-        assert self.original_model.model.config.num_hidden_layers % 2 == 0
-        self.num_layers = self.original_model.model.config.num_hidden_layers // 2
-
-    def forward(
-        self,
-        input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Cache] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        use_cache: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
-    ):
-        output_attentions = (
-            output_attentions
-            if output_attentions is not None
-            else self.original_model.model.config.output_attentions
-        )
-        output_hidden_states = (
-            output_hidden_states
-            if output_hidden_states is not None
-            else self.original_model.model.config.output_hidden_states
-        )
-
-        use_cache = (
-            use_cache
-            if use_cache is not None
-            else self.original_model.model.config.use_cache
-        )
-
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError(
-                "You must specify exactly one of input_ids or inputs_embeds"
-            )
-
-        if (
-            self.original_model.model.gradient_checkpointing
-            and self.original_model.model.training
-            and use_cache
-        ):
-            use_cache = False
-
-        assert not output_attentions
-        assert not output_hidden_states
-
-        # TODO (joao): remove this exception in v4.56 -- it exists for users that try to pass a legacy cache
-        if not isinstance(past_key_values, (type(None), Cache)):
-            raise ValueError(
-                "The `past_key_values` should be either a `Cache` object or `None`."
-            )
-
-        if inputs_embeds is None:
-            inputs_embeds = self.original_model.model.embed_tokens(input_ids)
-
-        if use_cache and past_key_values is None:
-            past_key_values = DynamicCache()
-
-        if cache_position is None:
-            past_seen_tokens = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
-            cache_position = torch.arange(
-                past_seen_tokens,
-                past_seen_tokens + inputs_embeds.shape[1],
-                device=inputs_embeds.device,
-            )
-
-        if position_ids is None:
-            position_ids = cache_position.unsqueeze(0)
-
-        causal_mask = self.original_model.model._update_causal_mask(
-            attention_mask,
-            inputs_embeds,
-            cache_position,
-            past_key_values,
-            output_attentions,
-        )
-
-        hidden_states = inputs_embeds
-
-        # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.original_model.model.rotary_emb(
-            hidden_states, position_ids
-        )
-
-        for decoder_layer in self.original_model.model.layers[: self.num_layers]:
-            assert not (
-                self.original_model.model.gradient_checkpointing
-                and self.original_model.model.training
-            )
-            layer_outputs = decoder_layer(
-                hidden_states,
-                attention_mask=causal_mask,
-                position_ids=position_ids,
-                past_key_value=past_key_values,
-                output_attentions=output_attentions,
-                use_cache=use_cache,
-                cache_position=cache_position,
-                position_embeddings=position_embeddings,
-                **flash_attn_kwargs,
-            )
-
-            hidden_states = layer_outputs[0]
-
-        return hidden_states
-
-
-class LlamaSecondHalf(nn.Module):
-    def __init__(self, original_model):
-        super().__init__()
-        self.original_model = original_model
-        assert self.original_model.model.config.num_hidden_layers % 2 == 0
-        self.num_layers = self.original_model.model.config.num_hidden_layers // 2
-
-    def forward(
-        self,
-        input_ids: Optional[torch.LongTensor] = None,
-        hidden_states: Optional[torch.FloatTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Cache] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        use_cache: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        cache_position: Optional[torch.LongTensor] = None,
-        logits_to_keep: Union[int, torch.Tensor] = 0,
-        **kwargs,
-    ) -> CausalLMOutputWithPast:
-        assert (input_ids is not None) and (hidden_states is not None)
-        output_attentions = (
-            output_attentions
-            if output_attentions is not None
-            else self.original_model.model.config.output_attentions
-        )
-        output_hidden_states = (
-            output_hidden_states
-            if output_hidden_states is not None
-            else self.original_model.model.config.output_hidden_states
-        )
-
-        use_cache = (
-            use_cache
-            if use_cache is not None
-            else self.original_model.model.config.use_cache
-        )
-
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError(
-                "You must specify exactly one of input_ids or inputs_embeds"
-            )
-
-        if (
-            self.original_model.model.gradient_checkpointing
-            and self.original_model.model.training
-            and use_cache
-        ):
-            use_cache = False
-
-        assert not output_attentions
-        assert not output_hidden_states
-
-        # TODO (joao): remove this exception in v4.56 -- it exists for users that try to pass a legacy cache
-        if not isinstance(past_key_values, (type(None), Cache)):
-            raise ValueError(
-                "The `past_key_values` should be either a `Cache` object or `None`."
-            )
-
-        if inputs_embeds is None:
-            inputs_embeds = self.original_model.model.embed_tokens(input_ids)
-
-        if use_cache and past_key_values is None:
-            past_key_values = DynamicCache()
-
-        if cache_position is None:
-            past_seen_tokens = (
-                past_key_values.get_seq_length() if past_key_values is not None else 0
-            )
-            cache_position = torch.arange(
-                past_seen_tokens,
-                past_seen_tokens + inputs_embeds.shape[1],
-                device=inputs_embeds.device,
-            )
-
-        if position_ids is None:
-            position_ids = cache_position.unsqueeze(0)
-
-        causal_mask = self.original_model.model._update_causal_mask(
-            attention_mask,
-            inputs_embeds,
-            cache_position,
-            past_key_values,
-            output_attentions,
-        )
-
-        # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.original_model.model.rotary_emb(
-            inputs_embeds, position_ids
-        )
-
-        # Process through the second half of layers
-        for decoder_layer in self.original_model.model.layers[self.num_layers :]:
-            assert not (
-                self.original_model.model.gradient_checkpointing
-                and self.original_model.model.training
-            )
-            layer_outputs = decoder_layer(
-                hidden_states,
-                attention_mask=causal_mask,
-                position_ids=position_ids,
-                past_key_value=past_key_values,
-                output_attentions=output_attentions,
-                use_cache=use_cache,
-                cache_position=cache_position,
-                position_embeddings=position_embeddings,
-                **kwargs,
-            )
-
-            hidden_states = layer_outputs[0]
-
-        # Apply the final normalization
-        hidden_states = self.original_model.model.norm(hidden_states)
-
-        outputs = BaseModelOutputWithPast(
-            last_hidden_state=hidden_states,
-            past_key_values=past_key_values if use_cache else None,
-            hidden_states=tuple(),
-            attentions=tuple(),
-        )
-
-        hidden_states = outputs.last_hidden_state
-        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = (
-            slice(-logits_to_keep, None)
-            if isinstance(logits_to_keep, int)
-            else logits_to_keep
-        )
-        logits = self.original_model.lm_head(hidden_states[:, slice_indices, :])
-
-        return CausalLMOutputWithPast(
-            loss=None,
-            logits=logits,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-        )
-
-
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
@@ -311,7 +57,7 @@ class LlamaSecondHalf(nn.Module):
 @pytest.mark.parametrize("model_name", ["huggyllama/llama-7b"])
 def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     prompt = "I enjoy walking in the"
-    original_model, tokenizer = get_model_and_tokenizer(model_name)
+    model, tokenizer = get_model_and_tokenizer(model_name)
     test_input = get_sample_input(tokenizer, prompt)
     parent_device = DeviceManager.create_parent_mesh_device([1, 2])
 
@@ -319,38 +65,26 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
     device2 = DeviceManager.create_sub_mesh_device(parent_device, (0, 1))
 
-    # Compile the first half, targeting device1
-    options1 = BackendOptions()
-    cc1 = CompilerConfig()
-    options1.compiler_config = cc1
-    options1.device = device1
-    first_half = LlamaFirstHalf(original_model)
-    tt_first_half = torch.compile(
-        first_half, backend=backend, dynamic=False, options=options1
+    dont_split = (
+        model._no_split_modules if hasattr(model, "_no_split_modules") else None
     )
-
-    # Compile the second half, targeting device2
-    options2 = BackendOptions()
-    cc2 = CompilerConfig()
-    options2.compiler_config = cc2
-    options2.device = device2
-    second_half = LlamaSecondHalf(original_model)
-    tt_second_half = torch.compile(
-        second_half, backend=backend, dynamic=False, options=options2
+    device_map = infer_auto_device_map(
+        model, max_memory={0: "8GiB", 1: "8GiB"}, no_split_module_classes=dont_split
     )
+    device_map["model.rotary_emb"] = 0
 
-    # Run first and second half back to back
-    hidden_states = tt_first_half(**test_input)
-    results = tt_second_half(**test_input, hidden_states=hidden_states)
-
-    decoded_output = decode_output(results, tokenizer)
-    DeviceManager.release_sub_mesh_device(device1)
-    DeviceManager.release_sub_mesh_device(device2)
-    DeviceManager.release_parent_device(parent_device)
-    print(
-        f"""
-      model_name: {model_name}
-      input: {prompt}
-      output: {decoded_output}
-      """
+    options = BackendOptions()
+    cc = CompilerConfig()
+    options.compiler_config = cc
+    cc.device_map = device_map
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    options.devices = [device1, device2]
+    compiled_model = torch.compile(
+        model, backend=backend, dynamic=False, options=options
+    )
+    out = compiled_model(**test_input)
+    golden = model(**test_input)
+    verify_against_golden(
+        tuple([golden.logits]), tuple([out.logits]), True, True, required_atol=0.1
     )

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -94,3 +94,5 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     verify_against_golden(
         tuple([golden.logits]), tuple([out.logits]), True, False, required_atol=0.1
     )
+
+    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -95,4 +95,6 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
         tuple([golden.logits]), tuple([out.logits]), True, False, required_atol=0.1
     )
 
-    DeviceManager.release_parent_device(parent, cleanup_sub_devices=True)
+    DeviceManager.release_sub_mesh_device(device1)
+    DeviceManager.release_sub_mesh_device(device2)
+    DeviceManager.release_parent_device(parent_device)

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -71,6 +71,12 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     device_map = infer_auto_device_map(
         model, max_memory={0: "8GiB", 1: "8GiB"}, no_split_module_classes=dont_split
     )
+    # The device map shards model chunks based on the order they're defined in the model
+    # not based on the topological order of the graph. We need to move rotary embeddings
+    # to the first device, otherwise we wouldn't be able to execute each device in full.
+    # That is, device 1 would need to run rotart_emb, device 0 the full graph, device 1,
+    # the remainder of the graph. We should extend the pass to be able to automatically
+    # handle this: https://github.com/tenstorrent/tt-torch/issues/779
     device_map["model.rotary_emb"] = 0
 
     options = BackendOptions()
@@ -86,5 +92,5 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     out = compiled_model(**test_input)
     golden = model(**test_input)
     verify_against_golden(
-        tuple([golden.logits]), tuple([out.logits]), True, True, required_atol=0.1
+        tuple([golden.logits]), tuple([out.logits]), True, False, required_atol=0.1
     )

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -89,7 +89,7 @@ def test_add_multidevice():
                 "mod": mod,
                 "input_shapes": input_shapes,
                 "compiler_config": cc,
-                "device": device,
+                "devices": [device],
             },
         )
         threads.append(thread)

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -35,29 +35,10 @@ def test_pipeline_parallel():
     options.devices = [device1, device2]
 
     host_model = Basic()
-    import numpy as np
 
     model = torch.compile(host_model, backend=backend, options=options)
     x = torch.rand(32, 32)
     y = torch.rand(32, 64)
-    start = time.time()
     calculated = model(x, y)
-    end = time.time()
-    print(f"Time taken first iter: {end - start}")
-    start = time.time()
-    times = []
-    for _ in range(100):
-        start = time.time()
-        calculated = model(x, y)
-        end = time.time()
-        times.append(end - start)
-    min_time = min(times)
-    max_time = max(times)
-    mean_time = sum(times) / len(times)
-    std_time = np.std(times)
-    print(f"Min time taken: {min_time}")
-    print(f"Max time taken: {max_time}")
-    print(f"Mean time taken: {mean_time}")
-    print(f"Standard deviation time taken: {std_time}")
     golden = host_model(x, y)
     verify_against_golden((golden,), (calculated,), True, True, required_atol=0.1)

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from tt_torch.dynamo.backend import backend, BackendOptions
+from torch import nn
+import torch
+from tt_torch.tools.utils import CompilerConfig
+from tt_torch.tools.device_manager import DeviceManager
+from tt_torch.tools.verify import verify_against_golden
+
+import time
+
+
+def test_pipeline_parallel():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = nn.Linear(32, 32)
+            self.l2 = nn.Linear(64, 32)
+
+        def forward(self, x, y):
+            x = self.l1(x)
+            y = self.l2(y)
+            return x + y
+
+    options = BackendOptions()
+    cc = CompilerConfig()
+    options.compiler_config = cc
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.device_map = {"l1": 0, "l2": 1}
+    parent_device = DeviceManager.create_parent_mesh_device([1, 2])
+    device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
+    device2 = DeviceManager.create_sub_mesh_device(parent_device, (0, 1))
+    options.devices = [device1, device2]
+
+    host_model = Basic()
+    import numpy as np
+
+    model = torch.compile(host_model, backend=backend, options=options)
+    x = torch.rand(32, 32)
+    y = torch.rand(32, 64)
+    start = time.time()
+    calculated = model(x, y)
+    end = time.time()
+    print(f"Time taken first iter: {end - start}")
+    start = time.time()
+    times = []
+    for _ in range(100):
+        start = time.time()
+        calculated = model(x, y)
+        end = time.time()
+        times.append(end - start)
+    min_time = min(times)
+    max_time = max(times)
+    mean_time = sum(times) / len(times)
+    std_time = np.std(times)
+    print(f"Min time taken: {min_time}")
+    print(f"Max time taken: {max_time}")
+    print(f"Mean time taken: {mean_time}")
+    print(f"Standard deviation time taken: {std_time}")
+    golden = host_model(x, y)
+    verify_against_golden((golden,), (calculated,), True, True, required_atol=0.1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -233,7 +233,7 @@ class ModelTester:
         # Compile model
         options = BackendOptions()
         options.compiler_config = compiler_config
-        options.device = self.device
+        options.devices = [self.device]
         model = torch.compile(model, backend=backend, dynamic=False, options=options)
         self.compiled_model = model
         return self.compiled_model

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -165,22 +165,24 @@ def torch_to_shlo(gm: torch.fx.GraphModule, example_inputs, compiler_config):
         module = import_program(program)
         verify_ir(module)
 
-    dump_module(module=module, name="Torch FX", compiler_config=compiler_config)
+        dump_module(module=module, name="Torch FX", compiler_config=compiler_config)
 
         if compiler_config.profile_ops:
             compiler_config.set_torch_mlir_module(module.operation.get_asm())
 
-    run_pipeline_with_repro_report(
-        module,
-        f"builtin.module(torchdynamo-export-to-torch-backend-pipeline)",
-        "Lowering TorchFX IR -> Torch Backend IR",
-        compiler_config.dump_debug,
-    )
-    dump_module(module=module, name="Torch Backend", compiler_config=compiler_config)
+        run_pipeline_with_repro_report(
+            module,
+            f"builtin.module(torchdynamo-export-to-torch-backend-pipeline)",
+            "Lowering TorchFX IR -> Torch Backend IR",
+            compiler_config.dump_debug,
+        )
+        dump_module(
+            module=module, name="Torch Backend", compiler_config=compiler_config
+        )
 
         lower_mlir_module(False, OutputType.STABLEHLO, module)
 
-    dump_module(module=module, name="StableHLO", compiler_config=compiler_config)
+        dump_module(module=module, name="StableHLO", compiler_config=compiler_config)
 
         mcg.shlo_modules[device_idx] = module
 

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -18,7 +18,6 @@ from tt_torch.tools.utils import (
     IOType,
     CompilerConfig,
     OpCompilationStatus,
-    RuntimeIntermediate,
 )
 from tt_torch.tools.utils import (
     run_model_proto,

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -5,6 +5,7 @@ import torch
 from torch.fx.experimental import const_fold
 from typing import List, Optional, Union
 from torch.export.graph_signature import InputKind
+from tt_torch.tools.utils import RuntimeIntermediate
 
 from tt_torch.tools.utils import MultiChipInput, MultiChipOutput, IOType, MultiChipGraph
 
@@ -520,6 +521,10 @@ def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
             ), "Intermediate verification is not supported for multi-chip models"
 
         # Once a program is generated, it should not be mutated, so we can safely generate the golden intermediate cache here
-        _generate_golden_intermediate_cache(mcg.programs[0], sub_example_inputs)
+        _generate_golden_intermediate_cache(
+            mcg.programs[0],
+            mcg.constant_inputs[0] + mcg.example_inputs[0],
+            compiler_config,
+        )
 
     return mcg

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -2,13 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
-import traceback
-from torch.fx.experimental.proxy_tensor import make_fx
 from torch.fx.experimental import const_fold
-from torch._decomp import get_decompositions
-from torch.func import functionalize
 from typing import List, Optional, Union
 from torch.export.graph_signature import InputKind
+
+from tt_torch.tools.utils import MultiChipInput, MultiChipOutput, IOType, MultiChipGraph
 
 from .decompositions import (
     CUSTOM_DECOMPOSITION_TABLE,
@@ -110,48 +108,332 @@ def constant_fold(gm):
     return gm
 
 
+def node_to_device(node, device_map):
+    if (
+        not hasattr(node, "meta")
+        or "nn_module_stack" not in node.meta
+        or len(node.meta["nn_module_stack"]) == 0
+    ):
+        return None
+
+    # The last stack contains the most information, only relevent fields will be used
+    # Contains string like: "L['self']._modules['model']._modules['layers']._modules['30'].mlp.up_proj"
+    # or like "L['self'].model.embed_tokens"
+    module_stack = list(node.meta["nn_module_stack"].values())[-1][0]
+
+    vals = module_stack.rsplit(".")[1:]
+    parsed_vals = []
+    for val in vals:
+        if val.startswith("_modules['"):
+            parsed_vals.append(val[10:-2])
+        else:
+            parsed_vals.append(val)
+
+    # append layers to each other until we find something in the device map. This needs to be done because
+    # the model can be split at model.layers.1 or model.layers.1.mlp
+    for i in range(1, len(parsed_vals) + 1):
+        layer = ".".join(parsed_vals[:i])
+        if layer in device_map:
+            return device_map[layer]
+
+    print(f"Warning: No device found for node {node}")
+    return None
+
+
+def flatten_args(args):
+    flattened = []
+
+    def _flatten(obj):
+        if isinstance(obj, list):
+            return ["list", [_flatten(x) for x in obj]]
+        elif isinstance(obj, tuple):
+            return ["tuple", [_flatten(x) for x in obj]]
+        elif isinstance(obj, dict):
+            return ["dict", {k: _flatten(v) for k, v in obj.items()}]
+        else:
+            flattened.append(obj)
+            return None  # leaf node
+
+    structure = _flatten(args)
+    return flattened, structure
+
+
+def rebuild_args(flattened, structure):
+    flat_iter = iter(flattened)
+
+    def _rebuild(struct):
+        if struct is None:
+            return next(flat_iter)
+        kind, content = struct
+        if kind == "list":
+            return [_rebuild(x) for x in content]
+        elif kind == "tuple":
+            return tuple(_rebuild(x) for x in content)
+        elif kind == "dict":
+            return {k: _rebuild(v) for k, v in content.items()}
+        else:
+            raise TypeError(f"Unknown structure kind: {kind}")
+
+    return _rebuild(structure)
+
+
+def dump_graph(graph, file_name):
+    with open(file_name, "w") as f:
+        f.write(str(graph))
+
+
+# The following function splits the graph onto the devices specified in the device_map
+# We create empty subgraphs for each device and then add the nodes to the appropriate subgraph
+def split_onto_devices(gm, compiler_config):
+    devices = set(compiler_config.device_map.values())
+    mcg = MultiChipGraph(devices)
+    mcg.gm = gm
+    if len(devices) <= 1:
+        mcg.device_graphs = {0: gm.graph}
+        return mcg
+
+    node_to_new_nodes = {}
+    user_input_index = 0
+    consumer_input_indices = [0] * len(devices)
+    output_indices = [0] * len(devices)
+    outputs = [[] for _ in devices]
+    prev_device_idx = None
+
+    for node in gm.graph.nodes:
+        if node.op == "get_attr" or node.op == "placeholder":
+            user_devices = [
+                node_to_device(user, compiler_config.device_map) for user in node.users
+            ]
+            user_devices = [d for d in user_devices if d is not None]
+            devices = list(set(user_devices))
+            if len(devices) == 0:
+                devices = [prev_device_idx]
+            for device_idx in devices:
+                prev_device_idx = device_idx
+                inp_node = (
+                    mcg.device_graphs[device_idx].get_attr(node.target)
+                    if node.op == "get_attr"
+                    else mcg.device_graphs[device_idx].placeholder(node.target)
+                )
+                inp_node.meta = node.meta
+                node_to_new_nodes[node] = {device_idx: inp_node}
+                mci = MultiChipInput(
+                    device_idx,
+                    IOType.USER,
+                    user_input_index,
+                    consumer_input_indices[device_idx],
+                )
+                mcg.graph_inputs[device_idx].append(mci)
+                consumer_input_indices[device_idx] += 1
+                user_input_index += 1
+            # TODO Assert on graphs that feed each other
+
+        elif (
+            node.op == "call_function"
+            or node.op == "call_method"
+            or node.op == "call_module"
+        ):
+            device_idx = node_to_device(node, compiler_config.device_map)
+            if device_idx is None:
+                device_idx = prev_device_idx
+            prev_device_idx = device_idx
+            graph = mcg.device_graphs[device_idx]
+            node_args = []
+            node_kw_args = []
+            flattened_args, structure_args = flatten_args(node.args)
+            flattened_kwargs, structure_kwargs = flatten_args(node.kwargs)
+
+            def _process_arg(arg):
+                if isinstance(arg, torch.fx.node.Node):
+                    if arg in node_to_new_nodes:
+                        new_arg = node_to_new_nodes[arg]
+                        if device_idx in new_arg:
+                            return new_arg[device_idx]
+                        else:
+                            feeding_device = list(new_arg.keys())[0]
+                            outputs[feeding_device].append(new_arg[feeding_device])
+                            mco = MultiChipOutput(
+                                feeding_device,
+                                IOType.INTER_DEVICE,
+                                output_indices[feeding_device],
+                            )
+                            mcg.graph_outputs[feeding_device].append(mco)
+                            # TODO Assert on graphs that feed each other
+                            placeholder = graph.placeholder(
+                                new_arg[feeding_device].name
+                            )
+                            placeholder.meta = new_arg[feeding_device].meta
+                            node_to_new_nodes[arg][device_idx] = placeholder
+                            mci = MultiChipInput(
+                                device_idx,
+                                IOType.INTER_DEVICE,
+                                output_indices[feeding_device],
+                                consumer_input_indices[device_idx],
+                            )
+                            mco.link_input(mci)
+                            mcg.graph_inputs[device_idx].append(mci)
+                            consumer_input_indices[device_idx] += 1
+                            output_indices[feeding_device] += 1
+                            return placeholder
+                    else:
+                        assert False
+                else:
+                    return arg
+
+            for arg in flattened_args:
+                node_args.append(_process_arg(arg))
+            for arg in flattened_kwargs:
+                node_kw_args.append(_process_arg(arg))
+
+            if len(node_args) != len(node.args):
+                # are any of the args duplicates? If so, we need to duplicate the placeholders
+                for idx, arg in enumerate(node.args):
+                    if arg in node.args[idx + 1 :]:
+                        node_args.append(node_args[idx])
+
+            rebuilt_args = rebuild_args(node_args, structure_args)
+            rebuilt_kwargs = rebuild_args(node_kw_args, structure_kwargs)
+            if node.op == "call_function":
+                node_creator = graph.call_function
+            elif node.op == "call_method":
+                node_creator = graph.call_method
+            elif node.op == "call_module":
+                node_creator = graph.call_module
+            else:
+                assert False
+            new_node = node_creator(node.target, tuple(rebuilt_args), rebuilt_kwargs)
+            new_node.meta = node.meta
+            new_node.name = node.name
+            node_to_new_nodes[node] = {device_idx: new_node}
+
+        elif node.op == "output":
+            # Final outputs
+            final_outputs = node.args[0]
+            for index, output in enumerate(final_outputs):
+                device_idx = node_to_device(output, compiler_config.device_map)
+                if device_idx is None:
+                    device_idx = prev_device_idx
+                prev_device_idx = device_idx
+                outputs[device_idx].append(node_to_new_nodes[output][device_idx])
+                mco = MultiChipOutput(device_idx, IOType.USER, index)
+                mcg.graph_outputs[device_idx].append(mco)
+        else:
+            assert False
+
+    for idx, output in enumerate(outputs):
+        graph = mcg.device_graphs[idx]
+        if len(output) == 1:
+            output = output[0]
+        else:
+            output = tuple(output)
+        output_node = graph.output(output)
+
+    for graph in mcg.device_graphs.values():
+        graph.lint()
+
+    return mcg
+
+
+def prune_inputs(program, constant_inputs):
+    placeholder_index = 0
+    indices_to_remove = []
+    for node in program.graph_module.graph.nodes:
+        if node.op == "placeholder":
+            if len(node.users) == 0:
+                indices_to_remove.append(placeholder_index)
+                program.graph_module.graph.erase_node(node)
+            placeholder_index += 1
+            if placeholder_index == len(constant_inputs):
+                break
+
+    program.graph_module.graph.eliminate_dead_code()
+    constant_inputs = [
+        constant_inputs[i]
+        for i in range(len(constant_inputs))
+        if i not in indices_to_remove
+    ]
+    program._graph_signature.input_specs = [
+        input_spec
+        for i, input_spec in enumerate(program._graph_signature.input_specs)
+        if i not in indices_to_remove
+    ]
+    return constant_inputs
+
+
 def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
     decompositions = torch.export.default_decompositions()
     decompositions.update(CUSTOM_DECOMPOSITION_TABLE)
 
     # we use the export API to run the decompositions, as this maintains the
     # soruce locations in stack_trace
-    gm = (
-        torch.export.export_for_training(gm, tuple(example_inputs), strict=False)
-        .run_decompositions(decompositions)
-        .module()
-    )
+    mcg = split_onto_devices(gm, compiler_config)
 
-    gm = bypass_dtype_promotion(gm, compiler_config)
-    # shape prop also propagates dtypes, need to run to figure out which casts are redundant
-    run_shape_prop(gm, example_inputs)
-    gm = bypass_redundant_cast(gm)
+    for idx, graph in mcg.device_graphs.items():
+        sub_example_inputs = []
+        for node in graph.nodes:
+            if node.op == "placeholder":
+                if "tensor_meta" in node.meta:
+                    sub_example_inputs.append(
+                        torch.randn(node.meta["tensor_meta"].shape).to(
+                            dtype=node.meta["tensor_meta"].dtype
+                        )
+                    )
+                else:
+                    assert "example_value" in node.meta
+                    sub_example_inputs.append(
+                        torch.randn(node.meta["example_value"].shape).to(
+                            dtype=node.meta["example_value"].dtype
+                        )
+                    )
 
-    if compiler_config.enable_consteval:
-        gm = constant_fold(gm)
-    elif compiler_config.consteval_parameters:
-        raise Exception("consteval_parameters is enabled but enable_consteval is not")
-
-    gm = bypass_redundant_getitem(gm)
-
-    # reduce_graph(gm) - ISSUE: https://github.com/tenstorrent/tt-torch/issues/513
-    program = torch.export.export(gm, tuple(example_inputs), strict=False)
-    # The proper order of inputs when outlining everything is constants + parameters + buffers + example_inputs
-    if not compiler_config.inline_parameters:
-        constant_inputs = (
-            list(program.tensor_constants.values())
-            + [
-                param.contiguous() if not param.is_contiguous() else param
-                for param in program.parameters()
-            ]
-            + list(program.buffers())
+        gm_device = torch.fx.GraphModule(gm, graph, f"_device_{idx}")
+        gm_device = (
+            torch.export.export_for_training(
+                gm_device, tuple(sub_example_inputs), strict=False
+            )
+            .run_decompositions(decompositions)
+            .module()
         )
-        for i in range(len(program._graph_signature.input_specs)):
-            if program._graph_signature.input_specs[i].kind != InputKind.USER_INPUT:
-                program._graph_signature.input_specs[i].kind = InputKind.USER_INPUT
-    else:
-        constant_inputs = []
+        run_shape_prop(gm_device, sub_example_inputs)
 
-    # Need to run shape_prop again to populate tensor_meta
-    run_shape_prop(program.graph_module, constant_inputs + example_inputs)
-    return program, constant_inputs
+        gm_device = bypass_dtype_promotion(gm_device, compiler_config)
+        # shape prop also propagates dtypes, need to run to figure out which casts are redundant
+        run_shape_prop(gm_device, sub_example_inputs)
+        gm_device = bypass_redundant_cast(gm_device)
+
+        if compiler_config.enable_consteval:
+            gm_device = constant_fold(gm_device)
+        elif compiler_config.consteval_parameters:
+            raise Exception(
+                "consteval_parameters is enabled but enable_consteval is not"
+            )
+
+        gm_device = bypass_redundant_getitem(gm_device)
+
+        # reduce_graph(gm) - ISSUE: https://github.com/tenstorrent/tt-torch/issues/513
+        program = torch.export.export(
+            gm_device, tuple(sub_example_inputs), strict=False
+        )
+        # The proper order of inputs when outlining everything is constants + parameters + buffers + sub_example_inputs
+        if not compiler_config.inline_parameters:
+            constant_inputs = (
+                list(program.tensor_constants.values())
+                + [
+                    param.contiguous() if not param.is_contiguous() else param
+                    for param in program.parameters()
+                ]
+                + list(program.buffers())
+            )
+            for i in range(len(program._graph_signature.input_specs)):
+                if program._graph_signature.input_specs[i].kind != InputKind.USER_INPUT:
+                    program._graph_signature.input_specs[i].kind = InputKind.USER_INPUT
+        else:
+            constant_inputs = []
+
+        constant_inputs = prune_inputs(program, constant_inputs)
+        run_shape_prop(program.graph_module, constant_inputs + sub_example_inputs)
+        mcg.programs[idx] = program
+        mcg.constant_inputs[idx] = constant_inputs
+        mcg.example_inputs[idx] = sub_example_inputs
+
+    return mcg

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -301,6 +301,7 @@ class StablehloExecutor(OpByOpExecutor):
         self.gm = None
         self.graph_constants = None
         self.model_proto = None
+        self.program = None
         self.sess = None
 
     def set_module(

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -16,6 +16,7 @@ from tt_torch.tools.utils import (
     run_model_proto,
     onnx_output_to_torch,
     torch_input_to_onnx,
+    MultiChipGraph,
 )
 
 from tt_torch.tools.utils import (
@@ -282,14 +283,14 @@ class StablehloExecutor(OpByOpExecutor):
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
-        device=None,
+        devices=None,
         async_mode=False,
     ):
         super().__init__(
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,
-            device=device,
+            devices=devices,
             async_mode=async_mode,
         )
         self.parsed_module = None

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -185,26 +185,26 @@ def cast_ios_and_run(node, args, kwargs):
 class TorchExecutor(OpByOpExecutor):
     def __init__(
         self,
-        program,
-        graph_constants,
+        mcg,
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
-        device=None,
+        devices=None,
         async_mode=False,
     ):
         super().__init__(
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,
-            device=device,
+            devices=devices,
             async_mode=async_mode,
         )
-        self.program = program
+        assert len(mcg.programs) == 1
+        self.program = mcg.programs[0]
         self.graph_constants = (
-            (graph_constants,)
-            if isinstance(graph_constants, (int, float))
-            else tuple(graph_constants)
+            (mcg.constant_inputs[0],)
+            if isinstance(mcg.constant_inputs[0], (int, float))
+            else tuple(mcg.constant_inputs[0])
         )
         if self.compiler_config is None:
             compiler_config = CompilerConfig()

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -193,6 +193,7 @@ class TorchExecutor(OpByOpExecutor):
         async_mode=False,
     ):
         super().__init__(
+            mcg=mcg,
             compiler_config=compiler_config,
             required_pcc=required_pcc,
             required_atol=required_atol,

--- a/tt_torch/onnx_compile/onnx_compile.py
+++ b/tt_torch/onnx_compile/onnx_compile.py
@@ -25,6 +25,7 @@ from tt_torch.tools.utils import (
     OpByOpBackend,
     CompilerConfig,
     CompileDepth,
+    MultiChipGraph,
 )
 
 from tt_torch.dynamo.shlo_backend import StablehloExecutor
@@ -106,6 +107,6 @@ def compile_onnx(model_proto: onnx.ModelProto, compiler_config: CompilerConfig =
         if compiler_config.compile_depth == CompileDepth.STABLEHLO:
             return executor
         # TODO: Add consteval support for onnx https://github.com/tenstorrent/tt-torch/issues/703
-        binary = shlo_to_flatbuffer(executor, module, compiler_config, 0, 0)
+        binary = shlo_to_flatbuffer(executor, None, module, compiler_config, 0, 0)
         executor.set_binary(binary)
         return executor

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -113,8 +113,6 @@ class MultiChipGraph:
         self.example_inputs = {}
         self.shlo_modules = {}
 
-        self.gm = None
-
 
 class Tensor:
     def __init__(self, shape):

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -77,6 +77,45 @@ class OpByOpBackend(Enum):
     STABLEHLO = 2
 
 
+class IOType(Enum):
+    INTER_DEVICE = 1
+    USER = 2
+
+
+class MultiChipOutput:
+    def __init__(self, originating_device, io_type, index):
+        self.originating_device = originating_device
+        self.io_type = io_type
+        self.index = index
+        self.linked_input = None
+
+    def link_input(self, input):
+        self.linked_input = input
+
+
+class MultiChipInput:
+    def __init__(self, originating_device, io_type, producer_index, consumer_index):
+        self.originating_device = originating_device
+        self.io_type = io_type
+        self.producer_index = producer_index
+        self.consumer_index = consumer_index
+
+
+class MultiChipGraph:
+    def __init__(self, devices):
+        self.devices = devices
+        self.device_graphs = {device: torch.fx.Graph() for device in devices}
+        self.graph_outputs = {device: [] for device in devices}
+        self.graph_inputs = {device: [] for device in devices}
+        self.programs = {}
+        self.binaries = {}
+        self.constant_inputs = {}
+        self.example_inputs = {}
+        self.shlo_modules = {}
+
+        self.gm = None
+
+
 class Tensor:
     def __init__(self, shape):
         constrained_shape = []
@@ -288,7 +327,7 @@ class CompilerConfig:
         self.record_property = lambda *args, **kwargs: None  # Default to no-op
         self.runtime_intermediate_cache = None  # Do not serialize.
         self.save_mlir_override = None
-
+        self.device_map = {}
         self.apply_environment_overrides()
         self.post_init()
 

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -21,7 +21,7 @@ from tt_torch.tools.device_manager import DeviceManager
 def compile_model(model, compiler_config, device, async_mode):
     torch_options = BackendOptions()
     torch_options.compiler_config = compiler_config
-    torch_options.device = device
+    torch_options.devices = [device]
     torch_options.async_mode = async_mode
     return torch.compile(model, backend=backend, options=torch_options)
 


### PR DESCRIPTION
Added support for automatic pipeline parallel based on transformers device_map infrastructure. Transformers library allows us to shard a model on multiple devices if it does not fit into the DRAM of a single device. This appears to be a pretty rudimentary pass which just takes model weights (in the order that they're allocated in the model) and sums them up, and once they no longer fit on one device, throws them onto the next device. This is enough for us to start a high level pipeline parallel pass. 

A follow up will be to simply create the separate shards, but decide which device they go on based on a topological sort we perform ourselves. This will remove the manual override in test_llama_7b_pipeline_parallel. See #779.

With this PR, I added the functionality to read the device map and create multiple graphs (from the original FX graph which contains the entire model), one for each device. These graphs are then compiled separately (into individual flatbuffers) and executed consecutively. 

### Ticket
#770 

### What's changed
Models can be pipelined across devices by supplying a device map to compiler_config
Refactored backend and executor to allow for multiple device graphs.