### PR TITLE
Skip running CI jobs from on-pr.yml if PR is draft

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -8,6 +8,7 @@ on:
         required: false
         type: string
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main" ]
 
 concurrency:
@@ -16,17 +17,21 @@ concurrency:
 
 jobs:
   pre-commit:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/pre-commit.yml
     secrets: inherit
   spdx:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/spdx.yml
     secrets: inherit
   docker-build:
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/build-image.yml
     secrets: inherit
     with:
       mlir_override: ${{ inputs.mlir_override }}
   check-files:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.check.outputs.skip }}
@@ -62,7 +67,7 @@ jobs:
 
   build:
     needs: [pre-commit, spdx, docker-build, check-files]
-    if: needs.check-files.outputs.skip == 'false'
+    if: github.event.pull_request.draft == false && needs.check-files.outputs.skip == 'false'
     uses: ./.github/workflows/run-build.yml
     secrets: inherit
     with:
@@ -71,6 +76,7 @@ jobs:
       setup-args: "--build_perf" #TODO - This should be toggleable?
   test:
     needs: [build, docker-build]
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/run-tests.yml
     secrets: inherit
     with:
@@ -83,6 +89,7 @@ jobs:
   #     docker-image: ${{ needs.docker-build.outputs.docker-image }}
   full-model-test:
     needs: [build, docker-build]
+    if: github.event.pull_request.draft == false
     uses: ./.github/workflows/run-full-model-execution-tests.yml
     secrets: inherit
     with:
@@ -101,4 +108,5 @@ jobs:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
+        allowed-skips: pre-commit,spdx,docker-build,check-files,build,test,full-model-test
         jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### Ticket
None

### Problem
- I want us to be able to iterate on changes on branch with draft PR without triggering CI, especially for our contractor colleagues.

### What's changed
 - Update on-pr.yml with changes like were deployed in tt-mlir few months ago via https://github.com/tenstorrent/tt-mlir/pull/2099 
 
### Verification
- [x] Tested with pushes to this branch while in Draft, no longer triggers CI (jobs marked skipped)
- [x] Tested with pushes to this branch while not in Draft, triggers CI.
- [x] Observed that CI launches automatically when transition from Draft to Ready-For-Review
