### PR TITLE
Add Detr onnx test

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -178,6 +178,7 @@ jobs:
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-medium-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-large-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-large-transformer-eval]
+                tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
             "
           },
         ]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -167,7 +167,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "detr", tests: "
-              tests/models/detr/test_detr_onnx.py:test_detr_onnx[op_by_op_stablehlo-eval]
+              tests/models/detr/test_detr_onnx.py::test_detr_onnx[op_by_op_stablehlo-eval]
               "
           }
         ]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -167,7 +167,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "detr", tests: "
-              tests/models/detr/test_detr_onnx.py:test_detr_onnx[op_by_op_torch-eval]
+              tests/models/detr/test_detr_onnx.py:test_detr_onnx[op_by_op_stablehlo-eval]
               "
           }
         ]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -164,6 +164,11 @@ jobs:
               tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[op_by_op_torch-SD3.5-large-eval]
               tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[op_by_op_torch-SD3.5-large-transformer-eval]
               "
+          },
+          {
+            runs-on: wormhole_b0, name: "detr", tests: "
+              tests/models/detr/test_detr_onnx.py:test_detr_onnx[op_by_op_torch-eval]
+              "
           }
         ]
     runs-on:

--- a/tests/models/detr/test_detr_onnx.py
+++ b/tests/models/detr/test_detr_onnx.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from PIL import Image
+import torch
+import onnx
+import os
+import numpy as np
+from torchvision import transforms
+import pytest
+from tests.utils import OnnxModelTester, skip_full_eval_test
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(OnnxModelTester):
+    def _load_model(self):
+        """
+        The model is from https://github.com/facebookresearch/detr
+        """
+        # Model
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
+        self.torch_model = torch.hub.load(
+            "facebookresearch/detr:main", "detr_resnet50", pretrained=True
+        )
+        model = self.torch_model.eval()
+
+        # Export to ONNX
+        torch.onnx.export(model, self._load_torch_inputs(), f"{self.model_name}.onnx")
+        model = onnx.load(f"{self.model_name}.onnx")
+        os.remove(f"{self.model_name}.onnx")
+        return model
+
+    def _load_torch_inputs(self):
+        # Images
+        input_image = Image.open("tests/models/detr/zidane.jpg")
+        m, s = np.mean(input_image, axis=(0, 1)), np.std(input_image, axis=(0, 1))
+        preprocess = transforms.Compose(
+            [
+                transforms.ToTensor(),
+                transforms.Normalize(mean=m, std=s),
+            ]
+        )
+        input_tensor = preprocess(input_image)
+        input_batch = input_tensor.unsqueeze(0)
+        return input_batch
+
+    def _extract_outputs(self, output_object):
+        return (output_object["pred_logits"], output_object["pred_boxes"])
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, None],
+    ids=["op_by_op_stablehlo", "full"],
+)
+def test_detr_onnx(record_property, mode, op_by_op):
+    model_name = "DETR_onnx"
+    model_group = "red"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+
+    if op_by_op is not None:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        cc.op_by_op_backend = op_by_op
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_TTMLIR_COMPILATION",
+        # In op-by-op flow this shows up as "stablehlo.reduce_window crash in StableHLOToTTIRReduceWindowOpConversionPattern() "
+        reason="loc(/transformer/Expand): error: failed to legalize operation 'torch.operator'",
+        model_group=model_group,
+    )
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group=model_group,
+    )
+    results = tester.test_model()
+
+    if mode == "eval":
+        # Results
+        print(results)
+
+    tester.finalize()

--- a/tests/models/detr/test_detr_onnx.py
+++ b/tests/models/detr/test_detr_onnx.py
@@ -73,9 +73,8 @@ def test_detr_onnx(record_property, mode, op_by_op):
         record_property,
         cc,
         model_name,
-        bringup_status="FAILED_TTMLIR_COMPILATION",
-        # In op-by-op flow this shows up as "stablehlo.reduce_window crash in StableHLOToTTIRReduceWindowOpConversionPattern() "
-        reason="loc(/transformer/Expand): error: failed to legalize operation 'torch.operator'",
+        bringup_status="FAILED_RUNTIME",
+        reason="Out of Memory: Not enough space to allocate 59244544 B L1 buffer across 64 banks, where each bank needs to store 925696 B - https://github.com/tenstorrent/tt-torch/issues/729",
         model_group=model_group,
     )
 


### PR DESCRIPTION
### Ticket
[#352](https://github.com/tenstorrent/tt-torch/issues/352)

### Problem description
 Adds Detr onnx model. 
 This model was already supported in the transformers but didn't have the ONNX version.
 
### What's changed
- Added a new test file test_detr_onnx.py that implements ONNX testing for the Detr model and add it to op by op nightly
- Add ORT shape inference pass (avoids dynamic shapes in onnx like torch backend, not supported) for #776 
 
### Checklist
- [x] New/Existing tests provide coverage for changes
