### PR TITLE
Fix scan workflow test matrices to capture partially specified tests

### DIFF
--- a/tt_torch/tools/benchmark_promotion.py
+++ b/tt_torch/tools/benchmark_promotion.py
@@ -16,12 +16,13 @@ MAXIMUM_JOB_TIMEOUT_MINUTES = 500  # 500 minutes maximum per-job timeout
 DEFAULT_JOB_TIMEOUT_MINUTES = 120
 
 
-def enumerate_all_tests(filter_full_eval=True):
-    test_dir = "tests/models"
+def enumerate_all_tests(filter_full_eval=True, test_dir="tests/models", dry_run=False):
+    print(f"Running pytest collect command: pytest {test_dir} --collect-only -q")
     try:
         # Run pytest with --collect-only and capture the output
         # sudo apt install -y libgl1 libglx-mesa0 # (may be needed locally)
-        print(f"Running pytest collect command: pytest {test_dir} --collect-only -q")
+        if dry_run:
+            return []
         result = subprocess.run(
             ["pytest", test_dir, "--collect-only", "-q"],
             stdout=subprocess.PIPE,


### PR DESCRIPTION
### Ticket
None

### Problem description
Scan workflow matrices attempts to statically analyze our test yamls + defined pytests to look for mistakes in (re)naming or moving tests between the yaml file and test source. This static analysis failed in a few edgecases, namely:
- Searching for tests which were not defined under tests/models
- Searching for incompletely specified tests, i.e. a test directory like tests/torch

### What's changed
- Recursively call pytest --collect-only on test string literals that don't resolve to a fully parameterized pytest. Pytest can "run" tests specified by their file name, python module, or parent directory, so a recursive application of collect-only is required to ensure that the test string literal is a real test
- Remove hardcoded test discovery directory
- Add __init__.py to tests/onnx to prevent test discovery errors as it has duplicate test_basic.py in shared test namespace with tests/torch

### Checklist
- [x] New/Existing tests provide coverage for changes
