### PR TITLE
Uplift ttmlir to fix local build break due to /ttir_builder access

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "a21c16acfe7e11279c2c502025dae3b931a44729")
+set(TT_MLIR_VERSION "1b47b466634f6519b7fc9c50cb1ae1d2e39cf39b")
 # torch-mlir is using branch tt_torch/main
 # see issue https://github.com/tenstorrent/tt-torch/issues/671
 set(TORCH_MLIR_VERSION "fe292ef77433c9da6ff539780f2b09d8fab146f4")


### PR DESCRIPTION
### Ticket
None

### Problem description
You need to manually create /ttir_builder and chown it to build tt-torch. The ttir_builder path ending up at fsroot is a mistake and was addressed in a PR to ttmlir merged right after tt-torch uplifts.

### What's changed
Point uplift to include change "Guard misc tools/ against disabled bindings". 

### Checklist
- [x] New/Existing tests provide coverage for changes
