### PR TITLE
Uplift third_party/tt-mlir to  2025-05-16

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "a21c16acfe7e11279c2c502025dae3b931a44729")
+set(TT_MLIR_VERSION "1b47b466634f6519b7fc9c50cb1ae1d2e39cf39b")
 # torch-mlir is using branch tt_torch/main
 # see issue https://github.com/tenstorrent/tt-torch/issues/671
 set(TORCH_MLIR_VERSION "fe292ef77433c9da6ff539780f2b09d8fab146f4")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,9 +4,6 @@
 #
 
 set(TT_MLIR_VERSION "1b47b466634f6519b7fc9c50cb1ae1d2e39cf39b")
-# torch-mlir is using branch tt_torch/main
-# see issue https://github.com/tenstorrent/tt-torch/issues/671
-set(TORCH_MLIR_VERSION "fe292ef77433c9da6ff539780f2b09d8fab146f4")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
@@ -81,7 +78,9 @@ else()
     install(DIRECTORY ${TTMLIR_INSTALL_PREFIX}/ DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # torch-mlir build
-
+    # torch-mlir is using branch tt_torch/main
+    # see issue https://github.com/tenstorrent/tt-torch/issues/671
+    set(TORCH_MLIR_VERSION "fe292ef77433c9da6ff539780f2b09d8fab146f4")
     set(TORCH_MLIR_PREFIX ${TTTORCH_SOURCE_DIR}/third_party/torch-mlir)
     set(TORCH_MLIR_INSTALL_PREFIX ${TORCH_MLIR_PREFIX}/install)
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the commit 1b47b46

- Contains fix for local build break due to /ttir_builder access
- Move TORCH_MLIR_VERSION version specification to be closer to usage, 
   prevent conflicts with upcoming tt-forge-models changes
