### PR TITLE
Fix tt-download-artifact usage

### DIFF
--- a/.github/workflows/generate-benchmark-matrix.yml
+++ b/.github/workflows/generate-benchmark-matrix.yml
@@ -39,6 +39,11 @@ jobs:
         submodules: recursive
         lfs: true
 
+    - name: Install unzip package (Temporary, tt-torch issue 787)
+      shell: bash
+      run: |
+        apt-get update && apt-get install -y unzip
+
     - name: Set reusable strings
       id: strings
       shell: bash

--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -27,6 +27,11 @@ jobs:
         submodules: recursive
         lfs: true
 
+    - name: Install unzip package (Temporary, tt-torch issue 787)
+      shell: bash
+      run: |
+        apt-get update && apt-get install -y unzip
+
     - name: Set reusable strings
       id: strings
       shell: bash

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -37,15 +37,12 @@ jobs:
       with:
         submodules: recursive
         lfs: true
-    
-    - name: Show apt installed packages
+
+    - name: Install unzip package (Temporary, tt-torch issue 787)
       shell: bash
       run: |
         apt-get update && apt-get install -y unzip
-        echo "Installed packages:"
-        apt list --installed
-        dpkg -l | grep '^ii' | awk '{print $2, $3}'
-        
+
     - name: Set reusable strings
       id: strings
       shell: bash

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -37,7 +37,15 @@ jobs:
       with:
         submodules: recursive
         lfs: true
-
+    
+    - name: Show apt installed packages
+      shell: bash
+      run: |
+        apt-get update && apt-get install -y unzip
+        echo "Installed packages:"
+        apt list --installed
+        dpkg -l | grep '^ii' | awk '{print $2, $3}'
+        
     - name: Set reusable strings
       id: strings
       shell: bash

--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install unzip package (Temporary, tt-torch issue 787)
+        shell: bash
+        run: |
+          apt-get update && apt-get install -y unzip
+
       - name: Set reusable strings
         id: strings
         shell: bash

--- a/.github/workflows/run-tools-tests.yml
+++ b/.github/workflows/run-tools-tests.yml
@@ -70,10 +70,10 @@ jobs:
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-    - name: Use build artifacts
+    - name: Use debug build artifacts with build artifact key
       uses: tenstorrent/tt-forge/.github/actions/download-artifact@main
       with:
-        name: install-artifacts
+        name: install-artifacts${{ inputs.build-artifact-key }}
         path: install
         github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Changes in #745 cause two regressions:
- Incorrect build artifact used for runtime intermediate validation, causing false failure because not using debug artifact
- CI runners using `:latest` containers do not have the true latest container, with expected "unzip" package. This needs to be investigated further in issue #787  

### What's changed
- Pass debug build artifact
- (temporary hack) manually install unzip package in every job using tagged:latest CI runner

### Checklist
- [x] Ran verification pass in CI
