### PR TITLE
Aknezevic/disable pruning

### DIFF
--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -6,9 +6,14 @@ import gc
 from torch.fx.experimental import const_fold
 from typing import List, Optional, Union
 from torch.export.graph_signature import InputKind
-from tt_torch.tools.utils import RuntimeIntermediate
-
-from tt_torch.tools.utils import MultiChipInput, MultiChipOutput, IOType, MultiChipGraph
+from tt_torch.tools.utils import (
+    MultiChipInput,
+    MultiChipOutput,
+    IOType,
+    MultiChipGraph,
+    RuntimeIntermediate,
+    CompileDepth,
+)
 
 from .decompositions import (
     CUSTOM_DECOMPOSITION_TABLE,
@@ -510,7 +515,8 @@ def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
         else:
             constant_inputs = []
 
-        constant_inputs = prune_inputs(program, constant_inputs)
+        if compiler_config.compile_depth == CompileDepth.EXECUTE:
+            constant_inputs = prune_inputs(program, constant_inputs)
         run_shape_prop(program.graph_module, constant_inputs + sub_example_inputs)
         mcg.programs[idx] = program
         mcg.constant_inputs[idx] = constant_inputs


### PR DESCRIPTION
### Problem description
I recently added the option to delete unused constants for graphs. These would come about if we had consteval enabled, as both the constevaled and the original params were in the graph. This works for most tests, but fails in compile only [tests](https://github.com/tenstorrent/tt-torch/actions/runs/15081491402/job/42406680894), since these actually need the original params (to execute the original GM). 

### What's changed
Only prune inputs for full execute tests. 

### Checklist
- [x] New/Existing tests provide coverage for changes
