### PR TITLE
Nightly Test Changes - promote 3x unet models, enable PCC check in SD3.5 xformer, mark vit_h_14 xfail for full-model-execute

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -112,10 +112,13 @@ jobs:
             "
           },
           {
-            # Approximately 40 minutes.
+            # Approximately 50 minutes.
             runs-on: wormhole_b0, name: "eval_6", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
                   tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-medium-transformer-eval]
+                  tests/models/unet/test_unet.py::test_unet[full-eval]
+                  tests/models/unet_brain/test_unet_brain.py::test_unet_brain[full-eval]
+                  tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[full-eval]
             "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -71,9 +71,6 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "unet", tests: "
-              tests/models/unet/test_unet.py::test_unet[op_by_op_torch-eval]
-              tests/models/unet_brain/test_unet_brain.py::test_unet_brain[op_by_op_torch-eval]
-              tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[op_by_op_torch-eval]
               tests/models/vgg19_unet/test_vgg19_unet.py::test_vgg19_unet[op_by_op_torch-eval]
               "
           },

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -231,7 +231,15 @@ jobs:
             runs-on: wormhole_b0, name: "stable-diffusion-3.5", tests: "
               tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[op_by_op_torch-SD3.5-medium-transformer-eval]
               "
-          }
+          },
+          {
+            runs-on: wormhole_b0, name: "unet", tests: "
+              tests/models/unet/test_unet.py::test_unet[op_by_op_torch-eval]
+              tests/models/unet_brain/test_unet_brain.py::test_unet_brain[op_by_op_torch-eval]
+              tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[op_by_op_torch-eval]
+              "
+          },
+
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}

--- a/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
@@ -120,7 +120,7 @@ def test_stable_diffusion_transformer(record_property, model_info, mode, op_by_o
         compiler_config=cc,
         record_property_handle=record_property,
         assert_atol=False,
-        assert_pcc=False,
+        assert_pcc=True,
         model_group=model_group,
     )
     results = tester.test_model()

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -101,7 +101,9 @@ model_info_list = [
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
-def test_torchvision_image_classification(record_property, model_info, mode, op_by_op):
+def test_torchvision_image_classification(
+    request, record_property, model_info, mode, op_by_op
+):
     if mode == "train":
         pytest.skip()
 
@@ -119,6 +121,15 @@ def test_torchvision_image_classification(record_property, model_info, mode, op_
     assert_atol = False
 
     model_group = "red" if model_name == "swin_v2_s" else "generality"
+
+    # Out of Memory: Not enough space to allocate 336691200 B DRAM buffer across 12 banks, where each bank needs to store 28057600 B
+    if model_name == "vit_h_14" and cc.compile_depth == CompileDepth.EXECUTE:
+        request.node.add_marker(
+            pytest.mark.xfail(
+                reason="Out of Memory: Not enough space to allocate in DRAM error - https://github.com/tenstorrent/tt-torch/issues/793",
+                strict=True,
+            )
+        )
 
     tester = ThisTester(
         model_info,


### PR DESCRIPTION
Bunch of misc changes for nightly full-model-execute list tests

### What's changed
 - set assert_pcc=True in SD3.5 transformer test, is passing
 - promote 3 unet tests to full model execute w/ pcc after conv2d_transpose compiler fix https://github.com/tenstorrent/tt-mlir/pull/3252 landed here Friday night
 - Mark vit_h_14 model with xfail in full model execute for now, recently regressed due to 82aafff4 may 14 commit, opened https://github.com/tenstorrent/tt-torch/issues/793

### Checklist
- [x] Tests run on branch CI https://github.com/tenstorrent/tt-torch/actions/runs/15122231198
