### PR TITLE
Fix TypeError in Executor.__del__ on close_mesh_device() call introduced recently

### DIFF
--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -368,8 +368,8 @@ class Executor:
         for _, device_weights in self.preprocessed_graph_constants.items():
             for weight in device_weights:
                 tt_mlir.deallocate_tensor(weight, force=True)
-        for device in self.owned_device_indices:
-            tt_mlir.close_mesh_device(device)
+        for device_idx in self.owned_device_indices:
+            tt_mlir.close_mesh_device(self.devices[device_idx])
 
 
 class OnnxExecutor(Executor):


### PR DESCRIPTION
### Ticket
None

### Problem description
- Test was not tearing down properly due to typo introduced in d81214bc from #771 after vit_h_14 test hits tt-metal assert.
- This caused subsequent test in nightly to segfault and all results for group to not be reported in database (big drop in models on dashboard)
  
### What's changed
- Fix the typo, another `function _cleanup_resources()` was correct but `__del__()` was not.

### Checklist
- [x] Segfault on subsequent test (musicgen) is gone on branch CI run https://github.com/tenstorrent/tt-torch/actions/runs/15122231198
