### PR TITLE
Add 8 relatively quick passing torchvision model variants to nightly full model execute

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -75,7 +75,7 @@ jobs:
             "
           },
           {
-            # Approximately 70 minutes.
+            # Approximately 95 minutes.
             runs-on: wormhole_b0, name: "eval_2", tests: "
                   tests/models/bloom/test_bloom.py::test_bloom[full-eval]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]
@@ -92,6 +92,14 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_b]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet201]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-ese_vovnet19b_dw.ra_in1k]
+                  tests/models/torchvision/test_torchvision_object_detection.py::test_torchvision_object_detection[full-ssd300_vgg16-eval]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_s]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet161]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_t]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_b]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-swin_v2_s]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet121]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-densenet169]
             "
           },
           {


### PR DESCRIPTION
Weekly depth benchmarks flagged a dozen or so model variants as able to run full model execute. 

### What's changed
 - Add 8 of them to nightly full model execute list (2-4 min each)
 - No need to remove from other ymls, weren't tested in op-by-op

### Checklist
- [x] Run on branch CI here : https://github.com/tenstorrent/tt-torch/actions/runs/15125195854
