### PR TITLE
Improve Docker image handling in CI workflows

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -13,14 +13,9 @@ CI_IMAGE_NAME=ghcr.io/$REPO/tt-torch-ci-ubuntu-22-04
 DOCKER_TAG=$(./.github/get-docker-tag.sh)
 echo "Docker tag: $DOCKER_TAG"
 
-# Are we on main branch
-ON_MAIN=$(git branch --show-current | grep -q main && echo "true" || echo "false")
-
 build_and_push() {
     local image_name=$1
     local dockerfile=$2
-    local on_main=$3
-
 
     if docker manifest inspect $image_name:$DOCKER_TAG > /dev/null; then
         echo "Image $image_name:$DOCKER_TAG already exists"
@@ -30,22 +25,15 @@ build_and_push() {
             --progress=plain \
             --build-arg FROM_TAG=$DOCKER_TAG \
             -t $image_name:$DOCKER_TAG \
-            -t $image_name:latest \
             -f $dockerfile .
 
         echo "Pushing image $image_name:$DOCKER_TAG"
         docker push $image_name:$DOCKER_TAG
-
-        # If we are on main branch also push the latest tag
-        if [ "$on_main" = "true" ]; then
-            echo "Pushing image $image_name:latest"
-            docker push $image_name:latest
-        fi
     fi
 }
 
-build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base $ON_MAIN
-build_and_push $CI_IMAGE_NAME .github/Dockerfile.ci $ON_MAIN
+build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base
+build_and_push $CI_IMAGE_NAME .github/Dockerfile.ci
 
 echo "All images built and pushed successfully"
 echo "CI_IMAGE_NAME:"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -45,13 +45,6 @@ jobs:
             # Update the CMakeLists.txt file with the new SHA
             sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${{ inputs.mlir_override }}\")/" third_party/CMakeLists.txt
 
-      # Clean everything from submodules (needed to avoid issues
-      # with cmake generated files leftover from previous builds)
-      - name: Cleanup submodules
-        run: |
-          git submodule foreach --recursive git clean -ffdx
-          git submodule foreach --recursive git reset --hard
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -69,3 +62,23 @@ jobs:
           DOCKER_CI_IMAGE=$(tail -n 1 docker.log)
           echo "DOCKER_CI_IMAGE $DOCKER_CI_IMAGE"
           echo "docker-image=$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"
+
+  set-latest:
+    # Set the latest tag on the CI image
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set latest tag on the image
+        run: |
+          DOCKER_CI_IMAGE=${{ needs.build-image.outputs.docker-image }}
+          DOCKER_TAG=$(echo $DOCKER_CI_IMAGE | sed 's/^.*://')
+          IMAGE_NAME=$(echo $DOCKER_CI_IMAGE | sed 's/:.*//')
+          echo "Setting latest tag on the image $IMAGE_NAME:$DOCKER_TAG"
+          skopeo copy "docker://$IMAGE_NAME:$DOCKER_TAG" "docker://$IMAGE_NAME:latest"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -35,7 +35,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-            submodules: recursive
             fetch-depth: 0 # Fetch all history and tags
 
       - name: Override tt-mlir SHA mlir_override is set

--- a/.github/workflows/generate-benchmark-matrix.yml
+++ b/.github/workflows/generate-benchmark-matrix.yml
@@ -41,14 +41,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
-
-    - name: Install unzip package (Temporary, tt-torch issue 787)
-      shell: bash
-      run: |
-        apt-get update && apt-get install -y unzip
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/generate-benchmark-matrix.yml
+++ b/.github/workflows/generate-benchmark-matrix.yml
@@ -18,6 +18,7 @@ jobs:
     secrets: inherit
 
   tests:
+    needs: docker-build
     outputs:
        matrix-json-splits: ${{ steps.generate_matrix.outputs.matrix-json-splits }}
 

--- a/.github/workflows/generate-benchmark-matrix.yml
+++ b/.github/workflows/generate-benchmark-matrix.yml
@@ -12,6 +12,11 @@ on:
     types: [completed]
 
 jobs:
+
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
   tests:
     outputs:
        matrix-json-splits: ${{ steps.generate_matrix.outputs.matrix-json-splits }}
@@ -24,7 +29,7 @@ jobs:
       - wormhole_b0
 
     container:
-      image: ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest
+      image: ${{ needs.docker-build.outputs.docker-image }}
       options: --user root --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -3,6 +3,11 @@ name: Generate Benchmark Report
 on:
   workflow_call:
 jobs:
+
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
   tests:
     timeout-minutes: 30
     strategy:
@@ -12,7 +17,7 @@ jobs:
       - wormhole_b0
 
     container:
-      image: ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest
+      image: ${{ needs.docker-build.outputs.docker-image }}
       options: --user root --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -29,14 +29,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
-
-    - name: Install unzip package (Temporary, tt-torch issue 787)
-      shell: bash
-      run: |
-        apt-get update && apt-get install -y unzip
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -9,6 +9,7 @@ jobs:
     secrets: inherit
 
   tests:
+    needs: docker-build
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -12,6 +12,10 @@ on:
     types: [completed]
 
 jobs:
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
   report-tests:
     outputs:
       spreadsheet_name: ${{ steps.git-info.outputs.spreadsheet_name }}
@@ -23,7 +27,7 @@ jobs:
       - wormhole_b0
 
     container:
-      image: ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest
+      image: ${{ needs.docker-build.outputs.docker-image }}
       options: --user root --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -39,14 +39,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
-
-    - name: Install unzip package (Temporary, tt-torch issue 787)
-      shell: bash
-      run: |
-        apt-get update && apt-get install -y unzip
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -17,6 +17,7 @@ jobs:
     secrets: inherit
 
   report-tests:
+    needs: docker-build
     outputs:
       spreadsheet_name: ${{ steps.git-info.outputs.spreadsheet_name }}
     timeout-minutes: 120

--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit
   generate_md:
+    needs: docker-build
     timeout-minutes: 120
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -19,11 +19,14 @@ on:
         type: string
 
 jobs:
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
   generate_md:
     timeout-minutes: 120
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:latest
+      image: ${{ needs.docker-build.outputs.docker-image }}
       options: --user root
 
     steps:

--- a/.github/workflows/generate-ttnn-md.yml
+++ b/.github/workflows/generate-ttnn-md.yml
@@ -33,11 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install unzip package (Temporary, tt-torch issue 787)
-        shell: bash
-        run: |
-          apt-get update && apt-get install -y unzip
-
       - name: Set reusable strings
         id: strings
         shell: bash

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -20,7 +20,6 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0 # Fetch all history and tags
           ref: main
 

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -46,9 +46,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Override tt-mlir SHA mlir_override is set
       if: ${{ inputs.mlir_override }}

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -46,9 +46,6 @@ jobs:
         - /mnt/dockercache:/mnt/dockercache
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -73,9 +73,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -196,9 +196,6 @@ jobs:
         - /mnt/dockercache:/mnt/dockercache
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -124,9 +124,6 @@ jobs:
         - /mnt/dockercache:/mnt/dockercache
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-multidevice-tests.yml
+++ b/.github/workflows/run-multidevice-tests.yml
@@ -43,10 +43,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
-
     - name: Fetch job id
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -187,9 +187,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -259,10 +259,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
-
     - name: Fetch job id
       id: fetch-job-id
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,9 +44,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/run-tools-tests.yml
+++ b/.github/workflows/run-tools-tests.yml
@@ -42,9 +42,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        lfs: true
 
     - name: Fetch job id
       id: fetch-job-id

--- a/.github/workflows/upload-benchmark-file.yml
+++ b/.github/workflows/upload-benchmark-file.yml
@@ -16,10 +16,6 @@ jobs:
         steps:
 
         - uses: actions/checkout@v4
-          with:
-            submodules: recursive
-            lfs: true
-
         - uses: actions/upload-artifact@v4
           with:
             name: ${{ inputs.benchmark_report_path }}


### PR DESCRIPTION
### Ticket
Closes: #787

### Problem description
Improve Docker image handling in CI workflows

### What's changed
- separate image building from "latest" tag management
- add "set-latest" job that runs on push to main branch
- replace latest tag with output from build job
- remove unnecessary git submodule cleanup step from build process

Cleanup
- revert changes from https://github.com/tenstorrent/tt-torch/pull/799 and remove submodule checkout and lfs

### Checklist
- [ ] New/Existing tests provide coverage for changes
