### PR TITLE
Fix shlo op by op errors after introduction of MultiChipGraph

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,6 @@ jobs:
         echo "dist-dir=$(pwd)/dist" >> "$GITHUB_OUTPUT"
         echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
         echo "test_report_path_torch=report_torch_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
-        echo "test_report_path_check_all_ops_execute=report_check_all_ops_execute_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_models=report_models_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
         echo "test_report_path_onnx=report_onnx_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
 
@@ -125,16 +124,13 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        TT_TORCH_CHECK_ALL_OPS_EXECUTE=1 pytest -svv tests/models/MobileNetV2/test_MobileNetV2.py tests/models/mnist/test_mnist.py --op_by_op_torch \
-            --junit-xml=${{ steps.strings.outputs.test_report_path_check_all_ops_execute }} \
-            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append
+        TT_TORCH_CHECK_ALL_OPS_EXECUTE=1 pytest -svv tests/models/MobileNetV2/test_MobileNetV2.py tests/models/mnist/test_mnist.py --op_by_op_torch
 
-    - name: Upload Test Report - Check All Ops Execute
-      uses: actions/upload-artifact@v4
-      if: success() || failure()
-      with:
-        name: test-reports-check-all-ops-execute-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
-        path: ${{ steps.strings.outputs.test_report_path_check_all_ops_execute }}
+    - name: Stablehlo Op-By-Op Test
+      shell: bash
+      run: |
+        source env/activate
+        pytest -svv tests/models/mnist/test_mnist.py --op_by_op_stablehlo
 
     - name: Run Resnet demo
       shell: bash
@@ -168,6 +164,6 @@ jobs:
       continue-on-error: true
       uses: codecov/test-results-action@v1
       with:
-        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}, ${{ steps.strings.outputs.test_report_path_check_all_ops_execute }}
+        files: ${{ steps.strings.outputs.test_report_path_torch }}, ${{ steps.strings.outputs.test_report_path_onnx }}
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/env/activate
+++ b/env/activate
@@ -49,7 +49,6 @@ else
   fi
   pip install $TT_TORCH_HOME/dist/torchvision*.whl
 
-  pip install stablehlo -f https://github.com/openxla/stablehlo/releases/expanded_assets/v1.0.0
 fi
 export TTTORCH_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ seaborn
 gliner
 ultralytics
 efficientnet_pytorch
+stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp310-cp310-linux_x86_64.whl

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -124,23 +124,19 @@ def dump_module(module, name, compiler_config):
 
 
 def _shlo_backend(
-    shlo,
+    mcg,
     example_inputs,
     compiler_config,
-    program=None,
-    graph_constants=None,
     devices=None,
     async_mode=False,
 ):
     executor = StablehloExecutor(
-        module=shlo,
+        module=mcg.shlo_modules[0],
         compiler_config=compiler_config,
         devices=devices,
         async_mode=async_mode,
     )
-    if program is not None:
-        # original input is a torch graph
-        executor.add_program(program, graph_constants)
+    executor.add_program(mcg)
     return executor
 
 
@@ -187,7 +183,6 @@ def torch_to_shlo(gm: torch.fx.GraphModule, example_inputs, compiler_config):
         dump_module(module=module, name="StableHLO", compiler_config=compiler_config)
 
         mcg.shlo_modules[device_idx] = module
-
     return mcg
 
 
@@ -278,15 +273,11 @@ def backend(gm, example_inputs, options: BackendOptions = None):
         else:
             # op_by_op_backend == OpByOpBackend.STABLEHLO
             # convert torch to stablehlo, then run stablehlo op-by-op
-            module, program, graph_constants = torch_to_shlo(
-                gm, example_inputs, compiler_config=cc
-            )
+            mcg = torch_to_shlo(gm, example_inputs, compiler_config=cc)
             return _shlo_backend(
-                shlo=module,
+                mcg=mcg,
                 example_inputs=example_inputs,
                 compiler_config=cc,
-                program=program,
-                graph_constants=graph_constants,
                 devices=devices,
                 async_mode=async_mode,
             )

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -479,16 +479,15 @@ class StablehloExecutor(OpByOpExecutor):
 
         if self.binary is not None:
             try:
-                print("Executing binary")
                 output = tt_mlir.run_end_to_end(
                     self.typecast_inputs(inputs), self.binary
                 )
+                return output
             except Exception as e:
                 print(f"Failed to execute binary: {e}")
 
         if self.program is not None:
             try:
-                print("Executing program")
                 return self.program.graph_module(
                     *(self.graph_constants + tuple(self.program.buffers()) + inputs)
                 )
@@ -497,7 +496,6 @@ class StablehloExecutor(OpByOpExecutor):
 
         if self.model_proto is not None:
             try:
-                print("Executing model proto")
                 output = run_model_proto(
                     sess=self.sess, model_proto=self.model_proto, inputs=inputs
                 )

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -280,6 +280,7 @@ class StablehloExecutor(OpByOpExecutor):
     def __init__(
         self,
         module: Union[str, "torch_mlir._mlir_libs._mlir.ir.Module", None] = None,
+        mcg: MultiChipGraph = None,
         compiler_config=None,
         required_pcc=0.99,
         required_atol=1e-2,
@@ -314,18 +315,18 @@ class StablehloExecutor(OpByOpExecutor):
         else:
             raise ValueError(f"Invalid module type: {type(module)}")
 
-    def add_program(self, program: torch.export.ExportedProgram, graph_constants):
+    def add_program(self, mcg: MultiChipGraph):
         assert (
             self.compiler_config.compile_depth == CompileDepth.COMPILE_OP_BY_OP
             or self.compiler_config.compile_depth == CompileDepth.EXECUTE_OP_BY_OP
         ) and self.compiler_config.op_by_op_backend == OpByOpBackend.STABLEHLO, (
             "program can only be added in op by op mode"
         )
-        self.program = program
+        self.program = mcg.programs[0]
         self.graph_constants = (
-            (graph_constants,)
-            if isinstance(graph_constants, (int, float))
-            else tuple(graph_constants)
+            (mcg.constant_inputs[0],)
+            if isinstance(mcg.constant_inputs[0], (int, float))
+            else tuple(mcg.constant_inputs[0])
         )
 
     def add_onnx_model_proto(self, model_proto: onnx.ModelProto):
@@ -371,7 +372,6 @@ class StablehloExecutor(OpByOpExecutor):
                 for op in block.operations:
                     if op.name.startswith(("func.", "return")):
                         continue
-
                     inputs = {
                         operand.get_name(): str(operand.type) for operand in op.operands
                     }
@@ -479,6 +479,7 @@ class StablehloExecutor(OpByOpExecutor):
 
         if self.binary is not None:
             try:
+                print("Executing binary")
                 output = tt_mlir.run_end_to_end(
                     self.typecast_inputs(inputs), self.binary
                 )
@@ -487,6 +488,7 @@ class StablehloExecutor(OpByOpExecutor):
 
         if self.program is not None:
             try:
+                print("Executing program")
                 return self.program.graph_module(
                     *(self.graph_constants + tuple(self.program.buffers()) + inputs)
                 )
@@ -495,6 +497,7 @@ class StablehloExecutor(OpByOpExecutor):
 
         if self.model_proto is not None:
             try:
+                print("Executing model proto")
                 output = run_model_proto(
                     sess=self.sess, model_proto=self.model_proto, inputs=inputs
                 )


### PR DESCRIPTION
### Ticket
None

### Problem description
We switched to `MultiChipGraph`. https://github.com/tenstorrent/tt-torch/pull/771 However, this PR didn't include changes for stablehlo executor concerning torch graphs. 
This was not caught because we do not have any torch models running with stablehlo op-by-op. 
Also, we currently install stablehlo in `env/activate` which is an exception compared to how everything else is installed through `requirements.txt`

### What's changed
The `StablehloExecutor` now takes in mcg object instead of program.
MNIST is ran with `--op_by_op_stablehlo` during on pr tests
Stablehlo now installed through `requirements.txt`

### Checklist
- [X] Edit `StablehloExecutor` and `backend.py` to pipe mcg etc properly
- [X] Add MNIST op by op stablehlo to on pr tests.
- [X] Moved stablehlo from `env/activate` to `requirements.txt`
