### PR TITLE
Fix resnet demo and add it to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -136,6 +136,11 @@ jobs:
         name: test-reports-check-all-ops-execute-${{ matrix.build.runs-on }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path_check_all_ops_execute }}
 
+    - name: Run Resnet demo
+      shell: bash
+      run: |
+        source env/activate
+        python demos/resnet/resnet50_demo.py --run_default_img
 
     - name: Show Test Report
       continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ third_party/toolchain
 third_party/tt-mlir
 third_party/vision
 third_party/torch-mlir
+third_party/tt_forge_models

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -14,9 +14,11 @@ from tt_torch.tools.utils import CompilerConfig
 
 
 class BackendOptions:
-    def __init__(self, compiler_config=CompilerConfig(), device=None, async_mode=False):
+    def __init__(
+        self, compiler_config=CompilerConfig(), devices=[None], async_mode=False
+    ):
         self.compiler_config = compiler_config
-        self.device = device
+        self.devices = devices
         self.async_mode = async_mode
 
 


### PR DESCRIPTION
### Ticket
[807](https://github.com/tenstorrent/tt-torch/issues/807)

### Problem description
A [previous PR](https://github.com/tenstorrent/tt-torch/pull/771) added a `devices` parameter to the `BackendOptions` objects without adding it to the actual `BackendOptions` class. That broke the normal resnet demo and the async demo.

### What's changed
- Replaced `device` with `devices` in the `BackendOptions` class. This fixes the normal resnet demo.
- Fixed the resnet async demo. Also, made the code more readable by removing an unnecessary loop.
- Added the normal resnet demo to On-PR and On-Push CI.
- [QoL] added `third_party/tt_forge_models` to the .gitignore file.

### Checklist
- [x] New/Existing tests provide coverage for changes
