### PR TITLE
Promote 3 models vovnet_onnx, mobilnetv2_onnx, inceptionv4 to e2e

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -120,13 +120,16 @@ jobs:
             "
           },
           {
-            # Approximately 50 minutes.
+            # Approximately 55 minutes.
             runs-on: wormhole_b0, name: "eval_6", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
                   tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-medium-transformer-eval]
                   tests/models/unet/test_unet.py::test_unet[full-eval]
                   tests/models/unet_brain/test_unet_brain.py::test_unet_brain[full-eval]
                   tests/models/unet_carvana/test_unet_carvana.py::test_unet_carvana[full-eval]
+                  tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2_onnx[full-eval]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[full-eval-inception_v4.tf_in1k]
+                  tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
             "
           },
           {
@@ -172,7 +175,6 @@ jobs:
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-10B-Base-eval]
-                tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-medium-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-large-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-large-transformer-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -53,11 +53,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "mobilenet", tests: "
-              tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2_onnx[op_by_op_stablehlo-eval]
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "openpose", tests: "
               tests/models/openpose/test_openpose.py::test_openpose[op_by_op_torch-eval]
               "
@@ -86,8 +81,6 @@ jobs:
           {
             runs-on: wormhole_b0, name: "timm", tests: "
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-ghostnetv2_100.in1k]
-              tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-inception_v4.tf_in1k]
-              tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[op_by_op_stablehlo-eval]
               "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -119,6 +119,7 @@ jobs:
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-tf_efficientnet_lite4.in1k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-mixer_b16_224.goog_in21k]
               tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-ese_vovnet19b_dw.ra_in1k]
+              tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-inception_v4.tf_in1k]
               "
           },
           {

--- a/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_onnx.py
@@ -50,7 +50,7 @@ def test_MobileNetV2_onnx(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -93,6 +93,7 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
             "tf_efficientnet_lite3.in1k",
             "tf_efficientnet_lite4.in1k",
             "xception71.tf_in1k",
+            "inception_v4.tf_in1k",
         ]
         else False
     )
@@ -106,7 +107,7 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         else 0.99
     )
 
-    model_group = "red" if model_name == "ese_vovnet19b_dw.ra_in1k" else "generality"
+    model_group = "generality"
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/vovnet/test_vovnet_onnx.py
+++ b/tests/models/vovnet/test_vovnet_onnx.py
@@ -66,16 +66,6 @@ def test_vovnet_onnx(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = op_by_op
 
-    skip_full_eval_test(
-        record_property,
-        cc,
-        model_name,
-        bringup_status="FAILED_TTMLIR_COMPILATION",
-        # In op-by-op flow this shows up as "stablehlo.reduce_window crash in StableHLOToTTIRReduceWindowOpConversionPattern() "
-        reason="loc(/head/global_pool/pool/GlobalAveragePool): error: failed to legalize operation 'stablehlo.reduce_window' - https://github.com/tenstorrent/tt-torch/issues/736",
-        model_group=model_group,
-    )
-
     tester = ThisTester(
         model_name,
         mode,


### PR DESCRIPTION
Will merge after tt-mlir uplift including #736 fix arrives here, maybe tonight.

### Ticket
Closes #736

### What's changed
 - Fix for 736 is landing in tt-mlir via PR https://github.com/tenstorrent/tt-mlir/pull/3271 soon solves issues
 - Promote 3 models to e2e and enable PCC on 2/3 tested locally, tests take few mins.
 - Put torch version of vovnet as generality instead of red now that onnx passes

### Checklist
- [x] Tested locally with changes from tt-mlir
