### PR TITLE
Lower PCC slightly and enable checking for 6 models with high (0.97-0.98) PCC

### DIFF
--- a/tests/models/EfficientNet/test_EfficientNet.py
+++ b/tests/models/EfficientNet/test_EfficientNet.py
@@ -73,25 +73,20 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    assert_pcc = (
-        True
+    required_pcc = (
+        0.98
         if model_name
         in [
-            "efficientnet-b0",
-            "efficientnet-b2",
-            "efficientnet-b3",
-            "efficientnet-b4",
-            "efficientnet-b5",
-            "efficientnet-b6",
-            "efficientnet-b7",
+            "efficientnet-b1",
         ]
-        else False
+        else 0.99
     )
 
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=assert_pcc,
+        required_pcc=required_pcc,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -49,11 +49,11 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
+        required_pcc=0.975,
         relative_atol=0.01,
         compiler_config=cc,
         record_property_handle=record_property,
-        # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/492
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
     )
     results = tester.test_model()

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -67,11 +67,11 @@ def test_deit(record_property, model_name, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
+        required_pcc=0.97,
         relative_atol=0.015,
         compiler_config=cc,
         record_property_handle=record_property,
-        # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/551
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
     )
     results = tester.test_model()

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -83,6 +83,7 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         True
         if model_name
         in [
+            "mobilenetv1_100.ra4_e3600_r224_in1k",
             "dla34.in1k",
             "ghostnet_100.in1k",
             "hrnet_w18.ms_aug_in1k",
@@ -96,10 +97,20 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
         else False
     )
 
+    required_pcc = (
+        0.98
+        if model_name
+        in [
+            "mobilenetv1_100.ra4_e3600_r224_in1k",
+        ]
+        else 0.99
+    )
+
     model_group = "red" if model_name == "ese_vovnet19b_dw.ra_in1k" else "generality"
     tester = ThisTester(
         model_name,
         mode,
+        required_pcc=required_pcc,
         compiler_config=cc,
         assert_pcc=assert_pcc,
         assert_atol=False,

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -56,7 +56,8 @@ def test_yolos(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=False,
+        required_pcc=0.98,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -40,7 +40,8 @@ def test_yolov3(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=False,
+        required_pcc=0.98,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,


### PR DESCRIPTION
### Ticket
None

### What's changed
- Superset dashboard flagged 6 models with PCC higher than 0.97 without checking enabled, so lower required PCC slightly for 6 models and enable checking.

### Checklist
- [x] Run tests locally
