### PR TITLE
Move system_desc creation to Executor

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -64,4 +64,3 @@ fi
 export PYTHONPATH="$(pwd):$(pwd)/env/venv:$(pwd)/env/venv/lib:$(pwd)/install/lib:$(pwd)/install:$(pwd)/.local/toolchain/python_packages/mlir_core:${TT_METAL_HOME}:${TT_METAL_HOME}/tt_eager:${TT_METAL_BUILD_HOME}/tools/profiler/bin"
 export ARCH_NAME="${ARCH_NAME:-wormhole_b0}"
 export TT_METAL_LOGGER_LEVEL="ERROR"
-export SYSTEM_DESC_PATH="/tmp/system_desc.ttsys"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,21 +38,6 @@ def manage_dependencies(request):
     )
 
 
-@pytest.fixture(scope="session", autouse=True)
-def create_system_descriptor(request):
-    try:
-        tt_mlir.create_system_desc()
-    except Exception as e:
-        print(f"Failed to create system descriptor: {e}")
-
-    yield
-
-    try:
-        os.remove(os.getenv("SYSTEM_DESC_PATH"))
-    except OSError:
-        pass
-
-
 def pytest_addoption(parser):
     parser.addoption(
         "--op_by_op_stablehlo",

--- a/tests/torch/test_constant_fold.py
+++ b/tests/torch/test_constant_fold.py
@@ -60,7 +60,6 @@ def test_interp():
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
-    cc.compile_depth = CompileDepth.TORCH_FX
     verify_module(Basic(), inputs=[small], compiler_config=cc)
 
 

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -3,20 +3,6 @@ list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
-# Get git commit hash for tt-mlir currently built
-execute_process(
-    COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/tt-mlir
-    OUTPUT_VARIABLE TT_MLIR_GIT_COMMIT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/tt_mlir_version.h.in
-    ${CMAKE_CURRENT_BINARY_DIR}/tt_mlir_version.h
-)
-
-
 add_library(TT_TORCH_MLIR "tt-mlir-interface.cpp")
 
 add_dependencies(TT_TORCH_MLIR

--- a/tt_torch/csrc/tt-mlir-interface.hpp
+++ b/tt_torch/csrc/tt-mlir-interface.hpp
@@ -12,9 +12,8 @@ namespace tt::torch {
 std::shared_ptr<void> *Compile(std::string_view code);
 std::string compileStableHLOToTTIR(std::string_view code);
 std::tuple<std::shared_ptr<void> *, std::string>
-compileTTIRToTTNN(std::string_view code,
-                  std::optional<tt::runtime::Device> device = std::nullopt,
+compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
                   size_t len_activations = 0, size_t len_graph_constants = 0);
-void create_system_desc(
-    std::optional<tt::runtime::Device> device = std::nullopt);
+void create_system_desc(tt::runtime::Device device,
+                        std::string_view descriptor_path);
 } // namespace tt::torch

--- a/tt_torch/csrc/tt_mlir_version.h.in
+++ b/tt_torch/csrc/tt_mlir_version.h.in
@@ -1,2 +1,0 @@
-#pragma once
-#define TT_MLIR_GIT_COMMIT "@TT_MLIR_GIT_COMMIT@"

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -190,7 +190,12 @@ def torch_to_shlo(gm: torch.fx.GraphModule, example_inputs, compiler_config):
 
 
 def shlo_to_flatbuffer(
-    executor, device, module, compiler_config, len_activations, len_graph_constants
+    executor,
+    system_desc_path,
+    module,
+    compiler_config,
+    len_activations,
+    len_graph_constants,
 ):
 
     if compiler_config.profile_ops:
@@ -207,7 +212,7 @@ def shlo_to_flatbuffer(
         )
 
     binary, ttnn = tt_mlir.compile_ttir_to_bytestream(
-        ttir, device, len_activations, len_graph_constants
+        ttir, system_desc_path, len_activations, len_graph_constants
     )
     dump_module(module=ttnn, name="TTNN", compiler_config=compiler_config)
 
@@ -231,7 +236,7 @@ def _base_backend(gm, example_inputs, compiler_config, devices, async_mode):
     for i, shlo in mcg.shlo_modules.items():
         binary = shlo_to_flatbuffer(
             executor,
-            devices[i],
+            executor.system_desc_paths[i],
             shlo,
             compiler_config,
             len(mcg.example_inputs[i]),

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -60,10 +60,11 @@ def compile_process(receiver, sender, ttir_event, ttnn_event, json_event):
     obj = receiver.get()
     faulthandler.disable()
     asm = obj["asm"]
+    system_desc_path = obj["system_desc_path"]
     ttir = tt_mlir.compile_stable_hlo_to_ttir(asm)
     sender.put({"ttir": ttir})
     ttir_event.wait()
-    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir)
+    binary, ttnn = tt_mlir.compile_ttir_to_bytestream(ttir, system_desc_path)
     sender.put({"binary": binary, "ttnn": ttnn})
     ttnn_event.wait()
     sender.put({"json": tt_mlir.bytestream_to_json(binary)})
@@ -160,6 +161,29 @@ class Executor:
         self.owned_device_indices = []
         self.async_mode = async_mode
         self._validate_executor()
+        self.system_desc_paths = self._create_system_descriptors()
+
+    def _create_system_descriptors(self):
+        if self.compiler_config.compile_depth in [
+            CompileDepth.TORCH_FX,
+            CompileDepth.STABLEHLO,
+        ]:
+            return []
+
+        system_desc_paths = []
+        for device_idx, device_from_user in enumerate(self.devices):
+            descriptor_path = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".ttsys"
+            ).name
+            descriptor_device = self._get_device(device_idx)
+
+            tt_mlir.create_system_desc(descriptor_device, descriptor_path)
+
+            if device_from_user is None:
+                self._cleanup_resources([], device_idx)
+
+            system_desc_paths.append(descriptor_path)
+        return system_desc_paths
 
     def _validate_executor(self):
         if self.compiler_config.compile_depth in (
@@ -199,8 +223,8 @@ class Executor:
 
     def _get_device(self, device_idx=0):
         assert (
-            len(self.devices) > device_idx
-        ), f"Not enough devices provided: {len(self.devices)} < {device_idx}"
+            len(self.devices) >= device_idx
+        ), f"Not enough devices provided: {len(self.devices)} <= {device_idx}"
         if self.devices[device_idx] is not None:
             return self.devices[device_idx]
         # Return a default parent mesh
@@ -370,6 +394,11 @@ class Executor:
                 tt_mlir.deallocate_tensor(weight, force=True)
         for device_idx in self.owned_device_indices:
             tt_mlir.close_mesh_device(self.devices[device_idx])
+        for path in self.system_desc_paths:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
 
 class OnnxExecutor(Executor):
@@ -377,7 +406,8 @@ class OnnxExecutor(Executor):
         self.model_proto = model_proto
         self.binary = None
         self.sess = None
-        self.device = None
+        self.devices = [None]
+        self.system_desc_paths = self._create_system_descriptors()
 
     def typecast_inputs(self, inputs):
         raise NotImplementedError("This should not be called on an OnnxExecutor.")
@@ -539,7 +569,10 @@ class OpByOpExecutor(Executor):
         ttir_event = mp.Event()
         ttnn_event = mp.Event()
         json_event = mp.Event()
-        obj = {"asm": module.operation.get_asm()}
+        obj = {
+            "asm": module.operation.get_asm(),
+            "system_desc_path": self.system_desc_paths[0],
+        }
         process = mp.Process(
             target=compile_process,
             args=(sender, receiver, ttir_event, ttnn_event, json_event),

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -407,6 +407,9 @@ class OnnxExecutor(Executor):
         self.binary = None
         self.sess = None
         self.devices = [None]
+        self.compiler_config = CompilerConfig()
+        self.preprocessed_graph_constants = {}
+        self.owned_device_indices = []
         self.system_desc_paths = self._create_system_descriptors()
 
     def typecast_inputs(self, inputs):

--- a/tt_torch/onnx_compile/onnx_compile.py
+++ b/tt_torch/onnx_compile/onnx_compile.py
@@ -107,6 +107,8 @@ def compile_onnx(model_proto: onnx.ModelProto, compiler_config: CompilerConfig =
         if compiler_config.compile_depth == CompileDepth.STABLEHLO:
             return executor
         # TODO: Add consteval support for onnx https://github.com/tenstorrent/tt-torch/issues/703
-        binary = shlo_to_flatbuffer(executor, None, module, compiler_config, 0, 0)
+        binary = shlo_to_flatbuffer(
+            executor, executor.system_desc_path[0], module, compiler_config, 0, 0
+        )
         executor.set_binary(binary)
         return executor

--- a/tt_torch/onnx_compile/onnx_compile.py
+++ b/tt_torch/onnx_compile/onnx_compile.py
@@ -108,7 +108,7 @@ def compile_onnx(model_proto: onnx.ModelProto, compiler_config: CompilerConfig =
             return executor
         # TODO: Add consteval support for onnx https://github.com/tenstorrent/tt-torch/issues/703
         binary = shlo_to_flatbuffer(
-            executor, executor.system_desc_path[0], module, compiler_config, 0, 0
+            executor, executor.system_desc_paths[0], module, compiler_config, 0, 0
         )
         executor.set_binary(binary)
         return executor


### PR DESCRIPTION
### Ticket
To unblock [Data parallelization PR](https://github.com/tenstorrent/tt-torch/pull/764)

### Problem description
System desc is currently created by pytest fixture.
We want to tie lifetime of system desc to lifetime of Executor instead.
This is so that correct device config can be used to create system desc.

### What's changed
- System desc is created at Executor __init__ instead of pytest fixture
- Remove dead code
  - Old system desc creation code
  - Unused compile flow
- misc fixes

### Checklist
- [x] New/Existing tests provide coverage for changes

Checked locally that string "linux-gnu" does not exist in compiled IR.
Since only hardcoded system desc contains this string.
This is to make sure we're generating the real system desc.

Using the following tests to cover each flow
- torch
- onnx
- multidevice
- op_by_op_torch
- op_by_op_stablehlo
#### flows to smoke test system desc 
```sh
TT_TORCH_IR_LOG_LEVEL=DEBUG pytest -svv tests/torch/test_conv2d.py |& tee logs/conv.log
TT_TORCH_IR_LOG_LEVEL=DEBUG pytest -svv tests/onnx/test_basic.py::test_add |& tee logs/onnx.log
TT_TORCH_IR_LOG_LEVEL=DEBUG pytest -svv tests/models/distilbert/test_distilbert.py::test_distilbert_multiloop[full-distilbert-base-uncased-eval-64] |& tee logs/multi.log
TT_TORCH_IR_LOG_LEVEL=DEBUG pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[op_by_op_torch-eval] |& tee logs/mnist.log
TT_TORCH_IR_LOG_LEVEL=DEBUG pytest -svv tests/models/MobileNetV2/test_MobileNetV2_onnx.py::test_MobileNetV2_onnx[op_by_op_stablehlo-eval] |& tee logs/mblnet.log
```

##### report if has correct system desc
```sh
logfiles="logs/conv.log logs/onnx.log logs/multi.log logs/mnist.log logs/mblnet.log"
for logfile in $logfiles; do
    echo "Log file: $logfile"
    
    # expect to be non-zero
    echo "Has system descriptor: $(grep -c 'system_desc' $logfile)"
    
    # expect to be zero
    echo "Has fake system descriptor: $(grep -c linux-gnu $logfile)"
done
```
