### PR TITLE
Skip onPR build + test for more file types and add support for #skip-onpr-tests in commit description

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -45,9 +45,24 @@ jobs:
           all_match=true
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})
+
+            # Define patterns for files that should skip the build
+            SKIP_PATTERNS=(
+              '^.*\.md$'
+              '^.*\.gitignore$'
+              '^.*LICENSE.*$'
+              '^\.github/workflows/.*nightly.*\.yml$'
+              '^\.github/workflows/.*weekly.*\.yml$'
+              '^\.github/workflows/.*depth.*bench.*\.yml$'
+              '^\.github/workflows/fail_inspector.yml$'
+              '^results/parse_op_by_op_results\.py$'
+            )
+            COMBINED_PATTERN=$(IFS='|'; echo "${SKIP_PATTERNS[*]}")
+
+            # Determine if all files changed in PR can skip CI
             for file in $CHANGED_FILES;
             do
-              if [[ ! $file =~ ^.*\.(md|gitignore)$ && $file != *"LICENSE"* ]]; then
+              if [[ ! $file =~ $COMBINED_PATTERN ]]; then
                 all_match=false
                 break
               fi

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -37,11 +37,23 @@ jobs:
       skip: ${{ steps.check.outputs.skip }}
     steps:
       - uses: actions/checkout@v4
-      - name: Check if ignored files are modified
+        with:
+          fetch-depth: 0  # fetch full history
+      - name: Check if ignored files are modified or "#skip-onpr-tests" in commit description
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Fetch the PR head commit so it's available locally
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          # Now check that commit message for flag to skip build
+          COMMIT_MSG=$(git log -1 --pretty=%B ${{ github.event.pull_request.head.sha }})
+          if [[ "$COMMIT_MSG" == *"#skip-onpr-tests"* ]]; then
+            echo "User requested skip via commit message."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           all_match=true
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             CHANGED_FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only --repo ${{ github.repository }})


### PR DESCRIPTION
### Ticket
None

### Problem description
- Sometimes CI gets bogged down building and running for changes that don't even affect build + test in onPR|
- Sometimes there are PR feedback for new models being added to Nightly, and every minor tweak requires full rerun of onPR CI which doesn't even test the model.
- Would be great to extend existing pattern of files that can skip CI, and add way to skip on demand by user.

### What's changed
- Extend list of skip patterns to cover bunch of .yml files only used in nightly/weekly and some scripts
- Add flag #skip-onpr-tests which can be put in commit description by user to skip build + test if they are sure there change is no risk and doesn't impact CI.  Github docs show how other strings are used to skip entire CI, but we want to keep lint, spdx check etc in place.

### Checklist
- [x] Test on branch, screenshots links in PR