### PR TITLE
move tt forge models install to non-toolchain build branch

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -116,17 +116,16 @@ else()
 
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
+    # tt-forge-models - Python-only project, no need to build.
+    set(TT_FORGE_MODELS_VERSION "d4c282fed846e021b7601eda9513495d8ddf31e3")
+    ExternalProject_Add(
+        tt_forge_models
+        SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models
+        GIT_REPOSITORY https://github.com/tenstorrent/tt-forge-models.git
+        GIT_TAG ${TT_FORGE_MODELS_VERSION}
+        GIT_PROGRESS ON
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND ""
+    )
 endif()
-
-# tt-forge-models - Python-only project, no need to build.
-set(TT_FORGE_MODELS_VERSION "d4c282fed846e021b7601eda9513495d8ddf31e3")
-ExternalProject_Add(
-    tt_forge_models
-    SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models
-    GIT_REPOSITORY https://github.com/tenstorrent/tt-forge-models.git
-    GIT_TAG ${TT_FORGE_MODELS_VERSION}
-    GIT_PROGRESS ON
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-)


### PR DESCRIPTION
### Ticket
None

### Problem description
Using ExternalProject_add(tt-forge-models...) occurs as a side effect of building the toolchain, which will break because the toolchain build branch doesn't include(ExternalProject).

### What's changed
Move tt-forge-models fetch to inside the non-toolchain build path.

### Checklist
- [ ] New/Existing tests provide coverage for changes
