### PR TITLE
Uplift third_party/tt-mlir to  2025-05-23

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "e9dc5df098d386edfe1605044ce569f650ac8734")
+set(TT_MLIR_VERSION "5f8af65bc101703c6ebb3de6b2015a3befdcdc87")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -80,7 +80,7 @@ else()
     # torch-mlir build
     # torch-mlir is using branch tt_torch/main
     # see issue https://github.com/tenstorrent/tt-torch/issues/671
-    set(TORCH_MLIR_VERSION "fe292ef77433c9da6ff539780f2b09d8fab146f4")
+    set(TORCH_MLIR_VERSION "be21b75d7fc2a45d5cccf5ac5d8d9448106735bd")
     set(TORCH_MLIR_PREFIX ${TTTORCH_SOURCE_DIR}/third_party/torch-mlir)
     set(TORCH_MLIR_INSTALL_PREFIX ${TORCH_MLIR_PREFIX}/install)
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the commit 5f8af6

- Update torch-mlir commit to newer version to match llvm uplift from tt-mlir uplift