### PR TITLE
Remove unncessary program export when intermediate cache enabled

### DIFF
--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -519,6 +519,12 @@ def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
             program, constants + example_inputs, compiler_config
         )
 
+        # we don't need to run_pass_for_graph again because there is only one device_graph
+        mcg.programs[0] = program
+        mcg.constant_inputs[0] = constants
+        mcg.example_inputs[0] = example_inputs
+        return mcg
+
     for idx, graph in mcg.device_graphs.items():
         sub_example_inputs = []
         for node in graph.nodes:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Avoids redundant export steps that occur when intermediate caching is turned on.

### What's changed
`mcg` can be returned as soon as the program is ready.

