### PR TITLE
Add buffer inplace copy workaround for StaticCache update

### DIFF
--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -107,6 +107,32 @@ def bypass_dtype_promotion(gm, compiler_config):
     return gm
 
 
+def rectify_buffer_inplace_copy(gm):
+    # Rewrite the graph to remove in-place torch.ops.aten.copy_ into buffer operations
+    #   and reroute them to graph outputs, as these arrive from inplace
+    #   buffer updates, which should be canonically represented as
+    #   an outplace manipulation and graph output
+
+    output_cache = []
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target == torch.ops.aten.copy_.default:
+            # Detect inplace copy with buffer destination
+            destination_node = node.args[0]
+            if destination_node.op != "get_attr":
+                continue
+            source_node = node.args[1]
+            output_cache.append(source_node)
+            gm.graph.erase_node(node)
+
+    output_node = [node for node in gm.graph.nodes if node.op == "output"][0]
+    current_output = output_node.args[0]  # one node reference
+
+    new_args = current_output + tuple(output_cache)
+    new_args = (new_args,)
+    output_node.args = new_args
+    return gm
+
+
 def constant_fold(gm):
     gm = const_fold.split_const_subgraphs(gm)
     gc.collect()
@@ -475,6 +501,7 @@ def run_pass_for_graph(
         raise Exception("consteval_parameters is enabled but enable_consteval is not")
 
     gm_device = bypass_redundant_getitem(gm_device)
+    gm_device = rectify_buffer_inplace_copy(gm_device)
 
     # reduce_graph(gm) - ISSUE: https://github.com/tenstorrent/tt-torch/issues/513
     program = torch.export.export(gm_device, tuple(example_inputs), strict=False)
@@ -548,5 +575,8 @@ def pass_pipeline(gm: torch.fx.GraphModule, example_inputs, compiler_config):
         mcg.programs[idx] = program
         mcg.constant_inputs[idx] = constant_inputs
         mcg.example_inputs[idx] = sub_example_inputs
+
+    mcg.reify_extra_outputs_post_decomposition()
+    mcg.lint()
 
     return mcg

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -107,6 +107,79 @@ class MultiChipGraph:
         self.example_inputs = {}
         self.shlo_modules = {}
 
+    def lint(self):
+        output_user_nodes = self.get_nodes_of_iotype(
+            iotype=IOType.USER, include_mc_inputs=False, include_mc_outputs=True
+        )
+        output_interdevice_nodes = self.get_nodes_of_iotype(
+            iotype=IOType.INTER_DEVICE, include_mc_inputs=False, include_mc_outputs=True
+        )
+        true_output_nodes = []
+
+        for device_idx, program in enumerate(self.programs.values()):
+            graph_output_node = next(
+                node for node in program.graph_module.graph.nodes if node.op == "output"
+            )
+            graph_outputs = graph_output_node.args[0]
+            true_output_nodes.extend(graph_outputs)
+
+        assert len(output_user_nodes) + len(output_interdevice_nodes) == len(
+            true_output_nodes
+        ), f"Mismatch in number of output nodes. In MCG: {len(output_user_nodes)} user outputs, { len(output_interdevice_nodes) } interdevice, in graphmodule output args: {len(true_output_nodes)}"
+
+    def get_nodes_of_iotype(
+        self, iotype, include_mc_inputs=False, include_mc_outputs=False
+    ):
+        # Given an MCG, return all MultiChipInputs or MultiChipOutputs of a given IOType.
+
+        if not include_mc_inputs and not include_mc_outputs:
+            assert (
+                False
+            ), "Must specify at least one of MultiChipInputs or MultiChipOutputs to count nodes of IOType"
+
+        nodes = []
+
+        if include_mc_outputs:
+            all_outputs = [
+                mco
+                for device_outputs_list in self.graph_outputs.values()
+                for mco in device_outputs_list
+            ]
+            nodes.extend([mco for mco in all_outputs if mco.io_type == iotype])
+
+        if include_mc_inputs:
+            all_inputs = [
+                mci
+                for device_inputs_list in self.graph_inputs.values()
+                for mci in device_inputs_list
+            ]
+            nodes.extend([mci for mci in all_inputs if mci.io_type == iotype])
+
+        return nodes
+
+    def reify_extra_outputs_post_decomposition(self):
+        # Outputs are baked into the multichip graph during split_onto_devices. If a decomp appends to outputs,
+        #   a runtime error will result. Check for extra outputs and append to mcg expected outputs to reflect
+        #   post-decomposition graph.
+        for idx, program in enumerate(self.programs.values()):
+            all_user_outputs = self.get_nodes_of_iotype(
+                IOType.USER, include_mc_outputs=True
+            )
+            next_output_idx = max(all_user_outputs, key=lambda x: x.index).index + 1
+            graph_output_node = next(
+                node for node in program.graph_module.graph.nodes if node.op == "output"
+            )
+            true_graph_outputs = graph_output_node.args[0]
+            expected_graph_outputs = self.graph_outputs[idx]
+            if len(true_graph_outputs) > len(expected_graph_outputs):
+                print(
+                    "Found more graph outputs than expected, adding them to mcg.graph_outputs"
+                )
+                for i in range(len(expected_graph_outputs), len(true_graph_outputs)):
+                    mco = MultiChipOutput(idx, IOType.USER, next_output_idx)
+                    self.graph_outputs[idx].append(mco)
+                    next_output_idx += 1
+
 
 class Tensor:
     def __init__(self, shape):


### PR DESCRIPTION
### Ticket
#614 

### Problem description
- We cannot currently torch.compile in place ops, as torch mlir decomposition into outplace_equiv_op + copy_ generates invalid IR
- StaticCache is incorrectly traced by torch.compile, so its past_key_values don't show up in as graph outputs

### What's changed
- Create a workaround path to allow inplace copies with destination of get_attr (static cache buffer). 
- Instead of creating an invalid inplace copy, delete the copy_ op and reroute the copy source arg to a graph output, to align with the canonical representation of a buffer update in a functional graph/exported program
- Recalculate the graph outputs in a multichipgraph post-decomposition

### Checklist
- [x] New/Existing tests provide coverage for changes
