### PR TITLE
Generative Models `torch.compile` restructure

### DIFF
--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -18,7 +18,7 @@ class ThisTester(ModelTester):
         self.tokenizer = AutoTokenizer.from_pretrained(
             self.model_name, torch_dtype=torch.bfloat16
         )
-        return model.generate
+        return model
 
     def _load_inputs(self):
 
@@ -62,6 +62,7 @@ def test_qwen2_casual_lm(record_property, model_name, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
 
     # TODO - Enable checking - https://github.com/tenstorrent/tt-torch/issues/526

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -17,7 +17,7 @@ class ThisTester(ModelTester):
             checkpoint, torch_dtype=torch.bfloat16
         )
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-        return model.generate
+        return model
 
     def _load_inputs(self):
         text = "def hello_world():"
@@ -51,6 +51,7 @@ def test_codegen(record_property, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
     results = tester.test_model()
 

--- a/tests/models/falcon/test_falcon3.py
+++ b/tests/models/falcon/test_falcon3.py
@@ -17,7 +17,7 @@ class ThisTester(ModelTester):
         model = AutoModelForCausalLM.from_pretrained(
             self.model_name, torch_dtype=torch.bfloat16
         )
-        return model.generate
+        return model
 
     def _load_inputs(self):
         self.prompt = "Hey, are you conscious? Can you talk to me?"
@@ -84,6 +84,7 @@ def test_falcon(record_property, model_name, mode, op_by_op):
         assert_pcc=False,
         assert_atol=False,
         model_group=model_group,
+        run_generate=True,  # run model.generate(**inputs)
     )
     results = tester.test_model()
 

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -16,7 +16,7 @@ class ThisTester(ModelTester):
         model = AutoModelForSeq2SeqLM.from_pretrained(
             "google/flan-t5-small", torch_dtype=torch.bfloat16
         )
-        return model.generate
+        return model
 
     def _load_inputs(self):
         inputs = self.tokenizer(
@@ -57,6 +57,7 @@ def test_flan_t5(record_property, mode, op_by_op):
         assert_pcc=False,
         assert_atol=False,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
     results = tester.test_model(assert_eval_token_mismatch=False)
     if mode == "eval":

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -16,7 +16,7 @@ class ThisTester(ModelTester):
             "EleutherAI/gpt-neo-125M", torch_dtype=torch.bfloat16
         )
         self.tokenizer = GPT2Tokenizer.from_pretrained("EleutherAI/gpt-neo-125M")
-        return model.generate
+        return model
 
     def _load_inputs(self):
         prompt = (
@@ -64,6 +64,7 @@ def test_gpt_neo(record_property, mode, op_by_op):
         assert_pcc=False,
         assert_atol=False,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
     results = tester.test_model(assert_eval_token_mismatch=False)
     if mode == "eval":

--- a/tests/models/mamba/test_mamba.py
+++ b/tests/models/mamba/test_mamba.py
@@ -25,7 +25,7 @@ class ThisTester(ModelTester):
             self.model_name, torch_dtype=torch.bfloat16
         )
 
-        return model.generate
+        return model
 
     def _load_inputs(self):
         prompt = "Hey how are you doing?"
@@ -37,9 +37,6 @@ class ThisTester(ModelTester):
             "use_cache": False,
         }
         return arguments
-
-    def set_model_eval(self, model):
-        return model
 
 
 @pytest.mark.parametrize(
@@ -74,6 +71,7 @@ def test_mamba(record_property, model_name, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
 
     # TODO - Enable checking - # https://github.com/tenstorrent/tt-torch/issues/632

--- a/tests/models/phi/test_phi_1_1p5_2.py
+++ b/tests/models/phi/test_phi_1_1p5_2.py
@@ -19,7 +19,7 @@ class ThisTester(ModelTester):
             self.model_name, torch_dtype=torch.bfloat16
         )
         model = AutoModelForCausalLM.from_pretrained(self.model_name)
-        return model.generate
+        return model
 
     def _load_inputs(self):
         input_str = '''def print_prime(n):
@@ -70,6 +70,7 @@ def test_phi(record_property, model_name, mode, op_by_op):
         record_property_handle=record_property,
         is_token_output=True,
         model_group=model_group,
+        run_generate=True,  # run model.generate(**inputs)
     )
 
     # TODO - Enable checking - https://github.com/tenstorrent/tt-torch/issues/528

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -14,7 +14,7 @@ class ThisTester(ModelTester):
         model = T5ForConditionalGeneration.from_pretrained(
             self.model_name, torch_dtype=torch.bfloat16
         )
-        return model.generate
+        return model
 
     def _load_inputs(self):
         self.input_text = "translate English to French: How are you?"
@@ -54,6 +54,7 @@ def test_t5(record_property, model_name, mode, op_by_op):
         assert_pcc=False,
         assert_atol=False,
         is_token_output=True,
+        run_generate=True,  # run model.generate(**inputs)
     )
     results = tester.test_model(assert_eval_token_mismatch=False)
     if mode == "eval":


### PR DESCRIPTION
### Ticket
None

### Problem description / What's changed

While looking into phi design @ssaliceTT is working on, I realized changing the way we compile generative models would fix most of the issues. I am putting up this PR before torch uplift as it might help troubleshooting errors easier.

Currently, we are running `torch.compile(model.generate)`. This isn't ideal and will become a problem when we uplift torch/ transformers. In torch 2.7, generative models are not compiled due to `.item` access, and there are some tips on how to handle that:[Torch compiler troubleshooting - data-dependent operations]( https://docs.pytorch.org/docs/stable/torch.compiler_troubleshooting.html#data-dependent-operations )

However, a better solution for generative models would be:
```
model.forward = torch.compile(model.forward, ...)
...
fnc = model.generate
outputs = fnc(inputs)
```
I noticed this results in OOM errors for some generative models. We might be able to use a solution proposed by PyTorch developers about torch.compile memory cleanup, since they noticed torch.compile increases memory usage: https://github.com/pytorch/pytorch/issues/107444

[Their fix](https://github.com/NVIDIA/Fuser/commit/3435b2682b9aea6e8e1eeb4264ec40bdcd1411f6)? Running `dynamo.reset()` before each test with `torch.compile` 

[When I tried running all generative models,](https://github.com/tenstorrent/tt-torch/actions/runs/15265724279/job/42931167708) I noticed two tests still fail due to memory and bring their runners down:
```
TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval] # please note, 1B and 3B are working fine
TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]  # please note, other variants are working after changes to the test
```

I think the way to move forward would be to:
- merge generative model changes proposed in this PR
- handle the tests running out of memory in separate issues, with help from the rest of the team (note: one is happening after `torch.compile`, the other I haven't confirmed yet. They need more debug)
- perhaps move the failing tests to a separate runner so they don't bring down other tests on the same runner?
- put up the torch/ transformers uplift PR **after** we have some nightly runs with this PR. I only tested generative models  e2e because in theory, only they should be affected. Though unlikely, it would be best to confirm there are no nightly failures.

### Checklist
- [X] Added `run_generate` to `ModelTester` which calls `model.generate`, instead of this being called in `_load_models`
- [X] Based on `run_generate` compiling the forward pass only in `compile_model`
- [X] Calling `model` or `model.generate` in `run_model` based on `run_generate`
- [X] Restructured all tests which call `model.generate`
- [X] Edited `tests/models/phi/test_phi_1_1p5_2.py`to reduce the memory requirements
- [X] Added a description to `ModelTester` 
- [X] Cleaned up `OnnxModelTester` 
- [ ] TODO: debug 
```
TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval] # please note, 1B and 3B are working fine
TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN TT_TORCH_COMPILE_DEPTH=TTNN_IR pytest --durations=50 -v -rf tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]  # please note, other variants are working after changes to the test
```
- [ ] TODO: uplift PyTorch/ transformers

Thanks to @LPanosTT for the idea to compile froward pass only. 