### PR TITLE
Move e2e-compile full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval to own group

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -43,7 +43,6 @@ jobs:
             runs-on: wormhole_b0, name: "compile_2", tests: "
                   tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-regnet_y_128gf]
-                  tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
                   tests/models/Qwen/test_qwen2_token_classification.py::test_qwen2_token_classification[full-Qwen/Qwen2-7B-eval]
                   tests/models/vilt/test_vilt.py::test_vilt[full-eval]
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
@@ -58,6 +57,12 @@ jobs:
                   tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]
             "
           },
+          {
+            # Approximately 10 minutes.
+            runs-on: wormhole_b0, name: "quarantine", tests: "
+                  tests/models/deepseek/test_deepseek_qwen.py::test_deepseek_qwen[full-deepseek-ai/DeepSeek-R1-Distill-Qwen-32B-eval]
+            "
+          }
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}


### PR DESCRIPTION
### Ticket
None

### Problem description
 - This model is often (not always) dying (reason unknown), first seen on May 17 b062ba9 nightly run
 - Suspected out-of-memory, but locally I see segfault on tt_mlir.compile_ttir_to_bytestream() call from backend.py
 - Needs debug. op-by-op for same model also dies lately.

### What's changed
- Move it to it's own group so it doesn't take down entire group and kill reporting

### Checklist
- [x] Run on branch isolated, seems like only test killed
