### PR TITLE
Don't duplicate example inptus when they're already present

### DIFF
--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -88,11 +88,14 @@ class MultiChipOutput:
 
 
 class MultiChipInput:
-    def __init__(self, originating_device, io_type, producer_index, consumer_index):
+    def __init__(
+        self, originating_device, io_type, producer_index, consumer_index, node
+    ):
         self.originating_device = originating_device
         self.io_type = io_type
         self.producer_index = producer_index
         self.consumer_index = consumer_index
+        self.node = node
 
 
 class MultiChipGraph:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/issues/844)

### Problem description
Memory use increased significantly with auto pipeline parallel pass. The issue was that we were creating example inputs for subgraphs and storing them, including example parameters. This is unnecessary since pytorch already provides us with example inputs. 

### What's changed
User inputs are passed in from the torch-generated example inputs and chip-to-chip inputs are generated. 

### Checklist
- [x] New/Existing tests provide coverage for changes
