### PR TITLE
Add detr_onnx to e2e compile list now that it passes

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -36,6 +36,7 @@ jobs:
             runs-on: wormhole_b0, name: "compile_1", tests: "
               tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
+              tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
             "
           },
           {


### PR DESCRIPTION
### Ticket
Related to https://github.com/tenstorrent/tt-torch/issues/833

### What's changed
 - Add the test to compile e2e list, can run now after https://github.com/tenstorrent/tt-torch/pull/847 fix
 - Can't go to full model execute list yet or be removed from op-by-op flow since hitting large conv2d fails at runtime.
 
### Checklist
- [x] tested locally
