### PR TITLE
Fixes to allow consteval caching and multiple iterations of compiled model.

### DIFF
--- a/tests/torch/test_basic_multiple_execution.py
+++ b/tests/torch/test_basic_multiple_execution.py
@@ -4,6 +4,7 @@
 import torch
 from torch import nn
 import tt_torch
+from tt_torch.dynamo.backend import backend
 
 
 def test_multiple_execution():
@@ -16,7 +17,7 @@ def test_multiple_execution():
             return self.linear(x)
 
     model = Basic()
-    model = torch.compile(model, backend=tt_torch.dynamo.backend.backend)
+    model = torch.compile(model, backend=backend)
     inputs = torch.randn(32, 32)
 
     for _ in range(10):

--- a/tests/torch/test_basic_multiple_execution.py
+++ b/tests/torch/test_basic_multiple_execution.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from torch import nn
+import tt_torch
+
+
+def test_multiple_execution():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(32, 32)
+
+        def forward(self, x):
+            return self.linear(x)
+
+    model = Basic()
+    model = torch.compile(model, backend=tt_torch.dynamo.backend.backend)
+    inputs = torch.randn(32, 32)
+
+    for _ in range(10):
+        model(inputs)

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -240,7 +240,7 @@ def _base_backend(gm, example_inputs, compiler_config, devices, async_mode):
         return executor
 
     for i, shlo in mcg.shlo_modules.items():
-        binary = shlo_to_flatbuffer(
+        binary_bytestream = shlo_to_flatbuffer(
             executor,
             executor.system_desc_paths[i],
             shlo,
@@ -248,7 +248,7 @@ def _base_backend(gm, example_inputs, compiler_config, devices, async_mode):
             len(mcg.example_inputs[i]),
             len(mcg.constant_inputs[i]),
         )
-        mcg.binaries[i] = binary
+        mcg.binaries[i] = tt_mlir.create_binary_from_bytestream(binary_bytestream)
 
     compiler_config.record_property("achieved_compile_depth", "TTNN_IR")
     return executor

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -180,7 +180,7 @@ class Executor:
             tt_mlir.create_system_desc(descriptor_device, descriptor_path)
 
             if device_from_user is None:
-                tt_mlir.close_mesh_device(descriptor_device)
+                self._cleanup_resources([], device_idx)
 
             system_desc_paths.append(descriptor_path)
         return system_desc_paths
@@ -244,7 +244,7 @@ class Executor:
         ):
             self.preprocessed_graph_constants[device_idx] = preprocessed_constants
 
-    def _cleanup_resources(self, preprocessed_activations):
+    def _cleanup_resources(self, preprocessed_activations, device_idx=0):
         for t in preprocessed_activations:
             tt_mlir.deallocate_tensor(t, force=True)
 

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -180,7 +180,7 @@ class Executor:
             tt_mlir.create_system_desc(descriptor_device, descriptor_path)
 
             if device_from_user is None:
-                self._cleanup_resources([], device_idx)
+                tt_mlir.close_mesh_device(descriptor_device)
 
             system_desc_paths.append(descriptor_path)
         return system_desc_paths
@@ -244,15 +244,9 @@ class Executor:
         ):
             self.preprocessed_graph_constants[device_idx] = preprocessed_constants
 
-    def _cleanup_resources(self, preprocessed_activations, device_idx):
+    def _cleanup_resources(self, preprocessed_activations):
         for t in preprocessed_activations:
             tt_mlir.deallocate_tensor(t, force=True)
-
-        # if we opened the device, close it.
-        if device_idx in self.owned_device_indices:
-            tt_mlir.close_mesh_device(self.devices[device_idx])
-            self.owned_device_indices.remove(device_idx)
-            self.devices[device_idx] = None
 
     def get_inputs(self, *inputs, binary, program_idx, device_idx=0):
         def get_torch_tensors(tensors):
@@ -347,7 +341,6 @@ class Executor:
         for device_idx, binary in self.mcg.binaries.items():
             device_inputs = graph_inputs[device_idx]
 
-            binary = tt_mlir.create_binary_from_bytestream(binary)
             program_idx = 0
             preprocessed_weights, preprocessed_activations = self.get_inputs(
                 *device_inputs,

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -180,7 +180,9 @@ class Executor:
             tt_mlir.create_system_desc(descriptor_device, descriptor_path)
 
             if device_from_user is None:
-                self._cleanup_resources([], device_idx)
+                self.owned_device_indices.remove(device_idx)
+                self.devices[device_idx] = None
+                tt_mlir.close_mesh_device(descriptor_device)
 
             system_desc_paths.append(descriptor_path)
         return system_desc_paths
@@ -244,7 +246,7 @@ class Executor:
         ):
             self.preprocessed_graph_constants[device_idx] = preprocessed_constants
 
-    def _cleanup_resources(self, preprocessed_activations, device_idx=0):
+    def _cleanup_resources(self, preprocessed_activations):
         for t in preprocessed_activations:
             tt_mlir.deallocate_tensor(t, force=True)
 
@@ -380,7 +382,7 @@ class Executor:
                 else:
                     final_outputs[graph_output.index] = output
 
-        self._cleanup_resources(preprocessed_activations, device_idx)
+        self._cleanup_resources(preprocessed_activations)
         assert all([o is not None for o in final_outputs])
         return final_outputs
 

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -468,7 +468,7 @@ class StablehloExecutor(OpByOpExecutor):
             self.print_op(op)
 
     def __call__(self, *inputs):
-
+        # breakpoint()
         if self.compiler_config.compile_depth in (
             CompileDepth.EXECUTE_OP_BY_OP,
             CompileDepth.COMPILE_OP_BY_OP,


### PR DESCRIPTION
### Problem description
- Currently the device is closed after the first execution, causing the program to crash upon a second execution call.
- Cached values stored on device are owned by the `tt_mlir.Binary` object. Re-creating that object from the byte stream each execution causes those references to be lost.

### What's changed
- Remove code which automatically closes the device after execution of the compiled program
- Store `tt_mlir.Binary` object rather than byte stream in `mcg.binaries`
### Checklist
- [ ] New/Existing tests provide coverage for changes
