### PR TITLE
Promote few newly running/passing models in Nightly CI

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -34,7 +34,6 @@ jobs:
           {
             # Approximately 50 minutes.
             runs-on: wormhole_b0, name: "compile_1", tests: "
-              tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
             "
@@ -50,7 +49,6 @@ jobs:
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
                   tests/models/falcon/test_falcon.py::test_falcon[full-eval]
                   tests/models/codegen/test_codegen.py::test_codegen[full-eval]
-                  tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[full-eval-googlenet]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[op_by_op_torch-eval-ghostnetv2_100.in1k]
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -148,7 +148,7 @@ jobs:
                   tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-790m-hf-eval]
             "
           },
-          # Approximately 40 minutes.
+          # Approximately 45 minutes.
           {
             runs-on: wormhole_b0, name: "eval_9", tests: "
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
@@ -159,6 +159,8 @@ jobs:
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
+                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
+                tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
             "
           },
           {
@@ -176,7 +178,6 @@ jobs:
                 tests/models/mistral/test_pixtral.py::test_pixtral[full-eval]
                 tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]
                 tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]
-                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-10B-Base-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-medium-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -68,7 +68,6 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "t5", tests: "
-              tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-large-eval]
               tests/models/speecht5_tts/test_speecht5_tts.py::test_speecht5_tts[op_by_op_torch-eval]
               "
           },
@@ -151,7 +150,6 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "falcon3", tests: "
-              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-3B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-7B-Base-eval]
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-10B-Base-eval]
               "

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -97,6 +97,7 @@ jobs:
               tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-small-eval]
               tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-base-eval]
               tests/models/flan_t5/test_flan_t5.py::test_flan_t5[op_by_op_torch-eval]
+              tests/models/t5/test_t5.py::test_t5[op_by_op_torch-t5-large-eval]
               "
           },
           {
@@ -230,6 +231,7 @@ jobs:
           {
             runs-on: wormhole_b0, name: "falcon3", tests: "
               tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-1B-Base-eval]
+              tests/models/falcon/test_falcon3.py::test_falcon[op_by_op_torch-tiiuae/Falcon3-3B-Base-eval]
               "
           },
           {

--- a/tests/models/falcon/test_falcon3.py
+++ b/tests/models/falcon/test_falcon3.py
@@ -67,10 +67,8 @@ def test_falcon(record_property, model_name, mode, op_by_op):
         reason="Model is too large to fit on single device during execution.",
         model_group=model_group,
         model_name_filter=[
-            "tiiuae/Falcon3-3B-Base",
             "tiiuae/Falcon3-7B-Base",
             "tiiuae/Falcon3-10B-Base",
-            "tiiuae/Falcon3-3B-Instruct",
             "tiiuae/Falcon3-7B-Instruct",
             "tiiuae/Falcon3-10B-Instruct",
         ],


### PR DESCRIPTION
### Ticket
None

### What's changed
 - Promote Falcon3-3B-Eval and t5-large to full-model-execute, remove skip in Falcon3-3B variants. They are no longer hitting DRAM OOM From #853 after #839 PR merged

### Checklist
- [x] Tested locally
