### PR TITLE
Disable flux tests after torch + transformers uplift

### DIFF
--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -35,7 +35,7 @@ class ThisTester(ModelTester):
         return pipe
 
     def _load_inputs(self):
-        pytest.skip() # Failing after torch + transformers uplift: https://github.com/tenstorrent/tt-torch/issues/868
+        pytest.skip()  # Failing after torch + transformers uplift: https://github.com/tenstorrent/tt-torch/issues/868
         prompt = [
             "A cat holding a sign that says hello world",
         ]

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -35,6 +35,7 @@ class ThisTester(ModelTester):
         return pipe
 
     def _load_inputs(self):
+        pytest.skip() # Failing after torch + transformers uplift: https://github.com/tenstorrent/tt-torch/issues/868
         prompt = [
             "A cat holding a sign that says hello world",
         ]


### PR DESCRIPTION
There is an issue already investigating the failure: https://github.com/tenstorrent/tt-torch/issues/868 

Added `pytest.skip()` to flux tests until above issue is fixed.
