### PR TITLE
additional n300 tests

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -118,6 +118,8 @@ jobs:
                 tests/models/yolov4/test_yolov4_n300.py::test_yolov4[full-eval]
                 tests/models/vit/test_vit_n300.py::test_vit[full-eval]
                 tests/models/segformer/test_segformer_n300.py::test_segformer[full-eval]
+                tests/models/hardnet/test_hardnet_n300.py::test_hardnet[full-eval]
+                tests/models/resnet/test_resnet_n300::test_resnet[full-eval]
             "
           },
         ]

--- a/tests/models/hardnet/test_hardnet_n300.py
+++ b/tests/models/hardnet/test_hardnet_n300.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://pytorch.org/hub/pytorch_vision_hardnet/
+# Reference: https://github.com/PingoLH/Pytorch-HarDNet
+
+from PIL import Image
+from torchvision import transforms
+import requests
+import torch
+import pytest
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
+        model = torch.hub.load("PingoLH/Pytorch-HarDNet", "hardnet68", pretrained=False)
+        checkpoint = "https://github.com/PingoLH/Pytorch-HarDNet/raw/refs/heads/master/hardnet68.pth"
+        model.load_state_dict(
+            torch.hub.load_state_dict_from_url(
+                checkpoint, progress=False, map_location="cpu"
+            )
+        )
+        model = model.to(torch.bfloat16)
+        return model
+
+    def _load_inputs(self):
+        url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
+        input_image = Image.open(requests.get(url, stream=True).raw)
+        preprocess = transforms.Compose(
+            [
+                transforms.Resize(256),
+                transforms.CenterCrop(224),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+                ),
+            ]
+        )
+        input_tensor = preprocess(input_image)
+        input_batch = torch.stack(
+            [input_tensor] * 32
+        )  # create a mini-batch as expected by the model
+        input_batch = input_batch.to(torch.bfloat16)
+        return input_batch
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_hardnet(record_property, mode, op_by_op):
+    if mode == "train":
+        pytest.skip()
+    model_name = "HardNet"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.automatic_parallelization = True
+    cc.mesh_shape = [1, 2]
+    cc.dump_info = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        required_pcc=0.98,
+        relative_atol=0.01,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/488
+        assert_atol=False,
+    )
+    results = tester.test_model()
+    if mode == "eval":
+        # Tensor of shape 1000, with confidence scores over ImageNet's 1000 classes
+        print(results[0])
+        # The output has unnormalized scores. To get probabilities, you can run a softmax on it.
+        probabilities = torch.nn.functional.softmax(results[0], dim=0)
+        print(probabilities)
+
+    tester.finalize()

--- a/tests/models/resnet/test_resnet_n300.py
+++ b/tests/models/resnet/test_resnet_n300.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torchvision
+import pytest
+from tests.utils import ModelTester
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model = torchvision.models.get_model("resnet18", pretrained=True)
+        model = model.to(torch.bfloat16)
+        return model
+
+    def _load_inputs(self):
+        inputs = torch.rand((32, 3, 224, 224), dtype=torch.bfloat16)
+        inputs = inputs.to(torch.bfloat16)
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_resnet(record_property, mode, op_by_op):
+    if mode == "train":
+        pytest.skip()
+    model_name = "ResNet18"
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.automatic_parallelization = True
+    cc.mesh_shape = [1, 2]
+    cc.dump_debug = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        assert_pcc=True,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    results = tester.test_model()
+
+    tester.finalize()


### PR DESCRIPTION
### Ticket
[Issue-763](https://github.com/tenstorrent/tt-torch/issues/763)

### Problem description
Test automatic parallelization functionality on tt-torch priority red models with batch inputs.

### What's changed
Tests added for models that successfully generate an output for a batch input when
cc.automatic_parallelization = True and cc.mesh_shape = [1,2] (n300).

Specifically:

- tests/models/:
  - added n300 batch input tests for Resnet18 and Hardnet
  
### Notes
Tests for models that currently fail can be found in https://github.com/tenstorrent/tt-torch/tree/gengelage/issue-763v2
