### PR TITLE
Add test_autoencoder_conv_v2.py to e2e-compile and remove phi-2 mistakenly added

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -37,6 +37,7 @@ jobs:
               tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
               tests/models/oft/test_oft.py::test_oft[full-eval]
+              tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[full-eval]
             "
           },
           {
@@ -54,7 +55,6 @@ jobs:
                   tests/models/mistral/test_pixtral.py::test_pixtral[full-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]
-                  tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
                   tests/models/seamless_m4t/test_seamless_m4t.py::test_seamless_m4t[full-eval]
             "
           },


### PR DESCRIPTION
### Ticket
None

### What's changed
- Add a test that compiles and remove a test that was already in full model execute list

### Checklist
- [x] run on CI