### PR TITLE
Benchmark Wheel Pull Fix

### DIFF
--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -7,7 +7,6 @@ on:
       run-id:
         description: "Optional run ID to download artifacts from a specific run"
         required: false
-        default: ""
 jobs:
   docker-build:
     uses: ./.github/workflows/build-image.yml


### PR DESCRIPTION
### Ticket
None

### Problem description
This week's weekly benchmarks failed due to inability to install tt-torch wheels.

### What's changed
Remove tt-torch attempted wheel install step from the yaml, since it isn't used at all. The report generation function doesn't require a tt-torch build (i.e. anything from the stack) and it's just pure python and invoked as a python script directly.

### Checklist
- [x] New/Existing tests provide coverage for changes
