### PR TITLE
Update vovnet PCC check for nightly tests

### DIFF
--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -94,7 +94,6 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
             "tf_efficientnet_lite4.in1k",
             "xception71.tf_in1k",
             "inception_v4.tf_in1k",
-            "ese_vovnet19b_dw.ra_in1k",
         ]
         else False
     )

--- a/tests/models/vovnet/test_vovnet_onnx.py
+++ b/tests/models/vovnet/test_vovnet_onnx.py
@@ -69,7 +69,7 @@ def test_vovnet_onnx(record_property, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,


### PR DESCRIPTION
### Ticket
None

### Problem description
Updated PCC check for wrong vovnet in f8ce07f

### What's changed
- Turn on PCC check for vovnet onnx
- Turn off PCC check for vovnet torch

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Vovnet tests [[pass in CI]](https://github.com/tenstorrent/tt-torch/actions/runs/15449572043/job/43488650603?pr=896)
#skip-onpr-tests
