### PR TITLE
Fix Flux tests after Torch + Transformers Uplift #868

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -38,6 +38,8 @@ jobs:
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
               tests/models/oft/test_oft.py::test_oft[full-eval]
               tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[full-eval]
+              tests/models/flux/test_flux.py::test_flux[full-flux_schnell-eval]
+              tests/models/flux/test_flux.py::test_flux[full-flux_dev-eval]
             "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -145,12 +145,6 @@ jobs:
               "
           },
           {
-            runs-on: n300-llmbox, name: "Flux", tests: "
-              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_schnell-eval]
-              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_dev-eval]
-              ", sh-run: true
-          },
-          {
             runs-on: wormhole_b0, name: "stable-diffusion-v3.5", tests: "
               tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[op_by_op_torch-SD3.5-medium-eval]
               tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[op_by_op_torch-SD3.5-large-eval]
@@ -161,7 +155,7 @@ jobs:
             runs-on: wormhole_b0, name: "detr", tests: "
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[op_by_op_stablehlo-eval]
               "
-          }
+          },
         ]
     runs-on:
       - ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) ||  matrix.build.runs-on }}

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -262,6 +262,11 @@ jobs:
               tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-eval]
               "
           },
+          {
+            runs-on: wormhole_b0, name: "flux_schnell", tests: "
+              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_schnell-eval]
+            "
+          },
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -2,72 +2,82 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # https://huggingface.co/black-forest-labs/FLUX.1-schnell
-from diffusers import FluxPipeline
+
+from diffusers import FluxPipeline, AutoencoderTiny
 from transformers import T5TokenizerFast, T5EncoderModel, CLIPTextModel, CLIPTokenizer
 import pytest
+import numpy as np
+import torch
+
 from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-import torch
 
 
 class ThisTester(ModelTester):
+    def __init__(self, *args, **kwargs):
+        self.guidance_scale = kwargs.pop("guidance_scale", 0.0)
+        super().__init__(*args, **kwargs)
+
     def _load_model(self):
         # Flux Pipeline
         model_info = self.model_name
-        pipe = FluxPipeline.from_pretrained(model_info, torch_dtype=torch.bfloat16)
+        pipe = FluxPipeline.from_pretrained(
+            model_info,
+            torch_dtype=torch.bfloat16,
+            use_safetensors=True,
+        )
+        pipe.vae = AutoencoderTiny.from_pretrained(
+            "madebyollin/taef1", torch_dtype=torch.bfloat16
+        )
+        pipe.enable_attention_slicing()
+        pipe.enable_vae_tiling()
+        self.transformer = pipe.transformer
+        self.scheduler = pipe.scheduler
+        self.vae = pipe.vae
+        self.text_encoder = pipe.text_encoder
+        self.text_encoder_2 = pipe.text_encoder_2
+        self.tokenizer = pipe.tokenizer
+        self.tokenizer_2 = pipe.tokenizer_2
+        self.image_processor = pipe.image_processor
+        self.pipe = pipe
 
-        # CLIP Tokenizer and Text Encoder
-        self.tokenizer = CLIPTokenizer.from_pretrained(
-            "openai/clip-vit-large-patch14", torch_dtype=torch.bfloat16
-        )
-        self.text_encoder = CLIPTextModel.from_pretrained(
-            "openai/clip-vit-large-patch14", torch_dtype=torch.bfloat16
-        )
-
-        # T5 Tokenizer and Text Encoder
-        self.tokenizer_2 = T5TokenizerFast.from_pretrained(
-            "google/t5-v1_1-xxl", torch_dtype=torch.bfloat16
-        )
-        self.text_encoder_2 = T5EncoderModel.from_pretrained(
-            "google/t5-v1_1-xxl", torch_dtype=torch.bfloat16
-        )
-
-        return pipe
+        return self.transformer
 
     def _load_inputs(self):
-        pytest.skip()  # Failing after torch + transformers uplift: https://github.com/tenstorrent/tt-torch/issues/868
-        prompt = [
-            "A cat holding a sign that says hello world",
-        ]
         max_sequence_length = 256
+        prompt = "An astronaut riding a horse in a futuristic city"
+        do_classifier_free_guidance = self.guidance_scale > 1.0
 
-        """
-        Pooled Prompt Embedding - CLIP
-        """
-        text_inputs = self.tokenizer(
+        num_inference_steps = 1  # set to 1 for single denoising loop
+        max_sequence_length = 256
+        height = 128
+        width = 128
+        num_images_per_prompt = 1
+
+        dtype = torch.bfloat16
+        batch_size = 1
+        num_channels_latents = self.transformer.config.in_channels // 4
+        prompt_2 = prompt
+        lora_scale = None
+        text_inputs_clip = self.tokenizer(
             prompt,
             padding="max_length",
-            max_length=self.tokenizer.model_max_length,
+            max_length=self.pipe.tokenizer_max_length,
             truncation=True,
-            return_overflowing_tokens=False,
-            return_length=False,
             return_tensors="pt",
         )
-        text_input_ids = text_inputs.input_ids
+        text_input_ids_clip = text_inputs_clip.input_ids
         pooled_prompt_embeds = self.text_encoder(
-            text_inputs.input_ids, output_hidden_states=False
+            text_input_ids_clip, output_hidden_states=False
+        ).pooler_output
+        pooled_prompt_embeds = pooled_prompt_embeds.to(dtype=dtype)
+        pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, num_images_per_prompt)
+        pooled_prompt_embeds = pooled_prompt_embeds.view(
+            batch_size * num_images_per_prompt, -1
         )
-        pooled_prompt_embeds = pooled_prompt_embeds.pooler_output
-        pooled_prompt_embeds = pooled_prompt_embeds.to(dtype=torch.bfloat16)
-        # duplicate text embeddings for each generation per prompt, using mps friendly method
-        pooled_prompt_embeds = pooled_prompt_embeds.repeat(1, 1)
-        pooled_prompt_embeds = pooled_prompt_embeds.view(1, -1)
 
-        """
-        Prompt Embedding - T5
-        """
-        text_inputs = self.tokenizer_2(
-            prompt,
+        text_inputs_t5 = self.tokenizer_2(
+            prompt_2,
             padding="max_length",
             max_length=max_sequence_length,
             truncation=True,
@@ -75,29 +85,94 @@ class ThisTester(ModelTester):
             return_overflowing_tokens=False,
             return_tensors="pt",
         )
-        text_input_ids = text_inputs.input_ids
-        prompt_embeds = self.text_encoder_2(text_input_ids, output_hidden_states=False)[
-            0
-        ]
-        prompt_embeds = prompt_embeds.to(dtype=torch.bfloat16)
+        text_input_ids_t5 = text_inputs_t5.input_ids
+        prompt_embeds = self.text_encoder_2(
+            text_input_ids_t5, output_hidden_states=False
+        )[0]
+        prompt_embeds = prompt_embeds.to(dtype=dtype)
+        _, seq_len_t5, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(
+            batch_size * num_images_per_prompt, seq_len_t5, -1
+        )
+        text_ids = torch.zeros(prompt_embeds.shape[1], 3).to(dtype=dtype)
+        height_latent = 2 * (int(height) // (self.pipe.vae_scale_factor * 2))
+        width_latent = 2 * (int(width) // (self.pipe.vae_scale_factor * 2))
 
-        _, seq_len, _ = prompt_embeds.shape
-        prompt_embeds = prompt_embeds.repeat(1, 1, 1)
-        prompt_embeds = prompt_embeds.view(1, seq_len, -1)
+        shape = (
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height_latent,
+            width_latent,
+        )
+
+        latents = torch.randn(shape, dtype=dtype)
+        latents = latents.view(
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height_latent // 2,
+            2,
+            width_latent // 2,
+            2,
+        )
+        latents = latents.permute(0, 2, 4, 1, 3, 5)
+        latents = latents.reshape(
+            batch_size * num_images_per_prompt,
+            (height_latent // 2) * (width_latent // 2),
+            num_channels_latents * 4,
+        )
+
+        # Prepare latent image IDs (Flux specific)
+        latent_image_ids = torch.zeros(height_latent // 2, width_latent // 2, 3)
+        latent_image_ids[..., 1] = (
+            latent_image_ids[..., 1] + torch.arange(height_latent // 2)[:, None]
+        )
+        latent_image_ids[..., 2] = (
+            latent_image_ids[..., 2] + torch.arange(width_latent // 2)[None, :]
+        )
+        (
+            latent_image_id_height,
+            latent_image_id_width,
+            latent_image_id_channels,
+        ) = latent_image_ids.shape
+        latent_image_ids = latent_image_ids.reshape(
+            latent_image_id_height * latent_image_id_width, latent_image_id_channels
+        )
+        latent_image_ids = latent_image_ids.to(dtype=dtype)
+
+        sigmas = np.linspace(1.0, 1 / num_inference_steps, num_inference_steps)
+        image_seq_len = latents.shape[1]
+        mu = (1.15 - 0.5) / (4096 - 256) * (image_seq_len - 256) + 0.5
+        self.scheduler.set_timesteps(num_inference_steps, sigmas=sigmas, mu=mu)
+        timesteps = self.scheduler.timesteps
+        num_warmup_steps = max(
+            len(timesteps) - num_inference_steps * self.scheduler.order, 0
+        )
+        joint_attention_kwargs = {}
+
+        if do_classifier_free_guidance:
+            guidance = torch.full([1], self.guidance_scale, dtype=dtype)
+        else:
+            guidance = None
+
         arguments = {
-            "prompt_embeds": prompt_embeds,
-            "pooled_prompt_embeds": pooled_prompt_embeds,
-            "guidance_scale": 0.0,
-            "num_inference_steps": 2,
-            "max_sequence_length": max_sequence_length,
-            "output_type": "latent",
+            "hidden_states": latents,
+            "timestep": torch.tensor([1.0], dtype=dtype),
+            "guidance": guidance,
+            "pooled_projections": pooled_prompt_embeds,
+            "encoder_hidden_states": prompt_embeds,
+            "txt_ids": text_ids,
+            "img_ids": latent_image_ids,
+            "joint_attention_kwargs": joint_attention_kwargs,
+            "return_dict": False,
         }
+        self.latents = latents
         return arguments
 
 
-model_info_list = [
-    ("flux_schnell", "black-forest-labs/FLUX.1-schnell"),
-    ("flux_dev", "black-forest-labs/FLUX.1-dev"),
+flux_model_configs = [
+    pytest.param("black-forest-labs/FLUX.1-schnell", 0.0, id="flux_schnell"),
+    pytest.param("black-forest-labs/FLUX.1-dev", 3.5, id="flux_dev"),
 ]
 
 
@@ -106,17 +181,15 @@ model_info_list = [
     ["eval"],
 )
 @pytest.mark.parametrize(
-    "model_info",
-    model_info_list,
-    ids=[model_info[0] for model_info in model_info_list],
+    "model_name, guidance_scale",
+    flux_model_configs,
 )
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
-def test_flux(record_property, model_info, mode, op_by_op):
-    _, model_name = model_info
+def test_flux(record_property, model_name, mode, op_by_op, guidance_scale):
     model_group = "red"
 
     cc = CompilerConfig()
@@ -132,7 +205,7 @@ def test_flux(record_property, model_info, mode, op_by_op):
         cc,
         model_name,
         bringup_status="FAILED_RUNTIME",
-        reason="aten::cat hits slice_op.cpp:80: input_tensor_a.get_padded_shape().rank() == this->slice_start.rank() && this->slice_start.rank() == this->slice_end.rank() - https://github.com/tenstorrent/tt-torch/issues/731",
+        reason="Out of Memory: Not enough space to allocate 75497472 B DRAM buffer across 12 banks, where each bank needs to store 6291456 B",
         model_group=model_group,
     )
 
@@ -144,9 +217,22 @@ def test_flux(record_property, model_info, mode, op_by_op):
         assert_atol=False,
         assert_pcc=False,
         model_group=model_group,
+        guidance_scale=guidance_scale,
     )
     results = tester.test_model()
     if mode == "eval":
-        image = results.images[0]
+        noise_pred = results[0]
+        latents = tester.scheduler.step(
+            noise_pred, tester.scheduler.timesteps[0], tester.latents, return_dict=False
+        )[0]
+        latents = tester.pipe._unpack_latents(
+            latents, 128, 128, tester.pipe.vae_scale_factor
+        )
+        latents = (
+            latents / tester.vae.config.scaling_factor
+        ) + tester.vae.config.shift_factor
+        image = tester.vae.decode(latents, return_dict=False)[0].detach()
+        image = tester.image_processor.postprocess(image, output_type="pil")[0]
+        # image.save("astronaut.png")
 
     tester.finalize()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,6 @@ import onnx
 from transformers.cache_utils import DynamicCache, _flatten_dynamic_cache
 from onnx.tools import update_model_dims
 import gc
-from transformers.cache_utils import DynamicCache
 import onnxruntime
 import numpy as np
 import collections
@@ -34,7 +33,6 @@ from tt_torch.tools.utils import RuntimeIntermediate, OpByOpBackend
 from tt_torch.tools.device_manager import DeviceManager
 import io
 import csv
-import os
 import tt_mlir
 
 


### PR DESCRIPTION
### Ticket
#868 

### Problem description
`pipeline` has problems with `torch.compile`. It is suggested to compile sub-component of pipeline individually instead of the entire pipeline. 

### What's changed
The new Flux tests compile `pipeline.transformer`
Reference tests for `schnell` and `dev` included in the original issue.
`dev` variant runs out-of-memory when running op-by-op, but can compile end-to-end.
`schnell` variant is using high memory runner for op-by-op test.
Link to a run: https://github.com/tenstorrent/tt-torch/actions/runs/15446758486/job/43480846463 

### Checklist
- [X] Changed flux tests
- [X] Added `black-forest-labs/FLUX.1-schnell` to op-by-op weekly and e2e compile tests
- [X] Added `black-forest-labs/FLUX.1-dev` to e2e compile tests
