### PR TITLE
Revert profiler test skip

### DIFF
--- a/tests/torch/tools/test_profiler.py
+++ b/tests/torch/tools/test_profiler.py
@@ -14,9 +14,6 @@ test_command_add = "pytest -svv tests/torch/test_basic.py::test_add"
 expected_report_path = f"results/perf/{Profiler.DEFAULT_OUTPUT_FILENAME}"
 
 
-@pytest.mark.skip(
-    reason="Profiler test failed due to tt-mlir uplift ccac3ad5e + additional issues with dumping device-side data"
-)
 def test_profiler_cli():
     profiler_command = f'python tt_torch/tools/profile.py "{test_command_add}"'
     profiler_subprocess = subprocess.run(profiler_command, shell=True)
@@ -42,9 +39,6 @@ def test_profiler_cli():
             print(row)
 
 
-@pytest.mark.skip(
-    reason="Profiler test failed due to tt-mlir uplift ccac3ad5e + additional issues with dumping device-side data"
-)
 def test_profiler_module():
     profile(test_command_add)
 


### PR DESCRIPTION
Profiler tests were previously broken by an uplift that mistakenly got through. 

A fix in tt-mlir and subsequent uplift reenables this profiler test.