### PR TITLE
Run working mistral models

### DIFF
--- a/tests/models/mistral/test_mistral.py
+++ b/tests/models/mistral/test_mistral.py
@@ -47,8 +47,11 @@ model_info_list = [
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_mistral(record_property, model_info, mode, op_by_op):
-    pytest.skip()  # https://github.com/tenstorrent/tt-torch/issues/864
-    _, model_name = model_info
+    model_label, model_name = model_info
+    if model_label == "ministral3b":
+        pytest.skip(
+            " Skipping Mistral-3B model test due to: https://github.com/tenstorrent/tt-torch/issues/905"
+        )
     model_group = "red"
 
     cc = CompilerConfig()


### PR DESCRIPTION
Had disabled all mistral tests after torch uplift. However, `mistral7b` and `ministral8b` [can run.](https://github.com/tenstorrent/tt-torch/actions/runs/15540437139) Only pytest skipping `ministral3b` since it is being investigated by #905 
