### PR TITLE
Re-enable test_clamp with integer range

### DIFF
--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -124,7 +124,18 @@ def test_broadcast(input):
     verify_module(Basic(), inputs=[input])
 
 
-def test_clamp():
+def test_clamp_int_bound():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return torch.clamp(x, min=-1, max=1)
+
+    verify_module(Basic(), input_shapes=[(32, 32)], input_range=(-5, 5))
+
+
+def test_clamp_float_bound():
     class Basic(nn.Module):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/issues/895)

### Problem description
test clamp with integer range seems fixed after https://github.com/tenstorrent/tt-mlir/commit/de6ba4c681d3801330b96999df7d99e0e2e009e4

### What's changed
New PR from uplift

### Checklist
- [ ] New/Existing tests provide coverage for changes
