### PR TITLE
Add D-Fine Model

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -156,6 +156,15 @@ jobs:
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[op_by_op_stablehlo-eval]
               "
           },
+          {
+            runs-on: wormhole_b0, name: "d-fine", tests: "
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-nano-coco-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-small-coco-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-medium-coco-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-large-coco-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-xlarge-coco-eval]
+              "
+          },
         ]
     runs-on:
       - ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) ||  matrix.build.runs-on }}

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -158,11 +158,11 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "d-fine", tests: "
-              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-nano-coco-eval]
-              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-small-coco-eval]
-              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-medium-coco-eval]
-              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-large-coco-eval]
-              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-ustc-community/dfine-xlarge-coco-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-nano-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-small-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-medium-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-large-eval]
+              tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-xlarge-eval]
               "
           },
         ]

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+
+from tests.utils import ModelTester  # for PyTorch Tests
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from transformers.image_utils import load_image
+from transformers import DFineForObjectDetection, AutoImageProcessor
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        self.processor = AutoImageProcessor.from_pretrained(self.model_name)
+        model = DFineForObjectDetection.from_pretrained(
+            self.model_name, torch_dtype=torch.bfloat16
+        )
+        return model
+
+    def _load_inputs(self):
+        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        self.image = load_image(url)
+        inputs = self.processor(images=self.image, return_tensors="pt")
+        inputs = inputs.to(torch.bfloat16)
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "ustc-community/dfine-small-coco",
+        "ustc-community/dfine-medium-coco",
+        "ustc-community/dfine-large-coco",
+        "ustc-community/dfine-xlarge-coco",
+        "ustc-community/dfine-medium-obj2coco",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_d_fine(record_property, model_name, mode, op_by_op):
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+    )
+    results = tester.test_model()
+
+    if mode == "eval":
+        results = tester.processor.post_process_object_detection(
+            results,
+            target_sizes=[(tester.image.height, tester.image.width)],
+            threshold=0.5,
+        )
+        for result in results:
+            for score, label_id, box in zip(
+                result["scores"], result["labels"], result["boxes"]
+            ):
+                score, label = score.item(), label_id.item()
+                box = [round(i, 2) for i in box.tolist()]
+                print(f"{tester.model.config.id2label[label]}: {score:.2f} {box}")
+
+    tester.finalize()

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -14,10 +14,10 @@ from transformers import DFineForObjectDetection, AutoImageProcessor
 class ThisTester(ModelTester):
     def _load_model(self):
         self.processor = AutoImageProcessor.from_pretrained(self.model_name)
-        model = DFineForObjectDetection.from_pretrained(
+        self.model = DFineForObjectDetection.from_pretrained(
             self.model_name, torch_dtype=torch.bfloat16
         )
-        return model
+        return self.model
 
     def _load_inputs(self):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -34,11 +34,10 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "model_name",
     [
-        "ustc-community/dfine-small-coco",
+        "ustc-community/dfine-nano-coco" "ustc-community/dfine-small-coco",
         "ustc-community/dfine-medium-coco",
         "ustc-community/dfine-large-coco",
         "ustc-community/dfine-xlarge-coco",
-        "ustc-community/dfine-medium-obj2coco",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -5,7 +5,7 @@
 import torch
 import pytest
 
-from tests.utils import ModelTester  # for PyTorch Tests
+from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from transformers.image_utils import load_image
 from transformers import DFineForObjectDetection, AutoImageProcessor
@@ -55,6 +55,14 @@ def test_d_fine(record_property, model_name, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_FE_COMPILATION",
+        reason="need 'aten::sort' torch-mlir -> stablehlo + mlir support: failed to legalize operation 'torch.constant.int' - https://github.com/tenstorrent/tt-torch/issues/724",
+    )
 
     tester = ThisTester(
         model_name,

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -9,6 +9,7 @@ from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from transformers.image_utils import load_image
 from transformers import DFineForObjectDetection, AutoImageProcessor
+from third_party.tt_forge_models.tools.utils import get_file
 
 
 class ThisTester(ModelTester):
@@ -20,8 +21,8 @@ class ThisTester(ModelTester):
         return self.model
 
     def _load_inputs(self):
-        url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        self.image = load_image(url)
+        image_file = get_file("test_images/coco_two_cats_000000039769_640x480.jpg")
+        self.image = load_image(str(image_file))
         inputs = self.processor(images=self.image, return_tensors="pt")
         inputs = inputs.to(torch.bfloat16)
         return inputs

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -27,26 +27,32 @@ class ThisTester(ModelTester):
         return inputs
 
 
+model_info_list = [
+    ("dfine-nano", "ustc-community/dfine-nano-coco"),
+    ("dfine-small", "ustc-community/dfine-small-coco"),
+    ("dfine-medium", "ustc-community/dfine-medium-coco"),
+    ("dfine-large", "ustc-community/dfine-large-coco"),
+    ("dfine-xlarge", "ustc-community/dfine-xlarge-coco"),
+]
+
+
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
 )
 @pytest.mark.parametrize(
-    "model_name",
-    [
-        "ustc-community/dfine-nano-coco",
-        "ustc-community/dfine-small-coco",
-        "ustc-community/dfine-medium-coco",
-        "ustc-community/dfine-large-coco",
-        "ustc-community/dfine-xlarge-coco",
-    ],
+    "model_info",
+    model_info_list,
+    ids=[model_info[0] for model_info in model_info_list],
 )
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
-def test_d_fine(record_property, model_name, mode, op_by_op):
+def test_d_fine(record_property, model_info, mode, op_by_op):
+
+    _, model_name = model_info
 
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -34,7 +34,8 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "model_name",
     [
-        "ustc-community/dfine-nano-coco" "ustc-community/dfine-small-coco",
+        "ustc-community/dfine-nano-coco",
+        "ustc-community/dfine-small-coco",
         "ustc-community/dfine-medium-coco",
         "ustc-community/dfine-large-coco",
         "ustc-community/dfine-xlarge-coco",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/754

### Problem description
Add a test for hugging face [D-Fine model](https://huggingface.co/docs/transformers/main/en/model_doc/d_fine) as a part of [Pytorch Model Bringup](https://github.com/tenstorrent/tt-torch/issues/420).

### What's changed
Added test function **tests/models/d_fine/test_d_fine.py::test_d_fine** with 5 different sizes:
-  ustc-community/dfine-nano-coco
-  ustc-community/dfine-small-coco
-  ustc-community/dfine-medium-coco
- ustc-community/dfine-large-coco
- ustc-community/dfine-xlarge-coco

Test skips full eval since aten.sort is not yet supported #724 . 
`op_by_op_torch` testing added to CI in **run-op-by-op-model-tests-nightly.yml**.

### Checklist
- [ ] New/Existing tests provide coverage for changes
