### PR TITLE
Fix newly added data parallel assert was always true

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -765,13 +765,9 @@ class ModelTester:
     def get_parallelism(self):
         parallelism = "single_device"
 
-        assert (
-            not (
-                self.data_parallel_mode
-                and self.compiler_config.automatic_parallelization
-            ),
-            "Cannot use runtime data parallel and automatic data parallel settings at the same time.",
-        )
+        assert not (
+            self.data_parallel_mode and self.compiler_config.automatic_parallelization
+        ), "Cannot use runtime data parallel and automatic data parallel settings at the same time."
 
         if self.data_parallel_mode:
             parallelism = "runtime_data_parallel"


### PR DESCRIPTION
### Ticket
None

### What's changed
- Fixed newly added assert was throwing warning: "tt-torch/tests/utils.py:768: SyntaxWarning: assertion is always true, perhaps remove parentheses?"

### Checklist
- [x] Test locally assert gone