### PR TITLE
Initial Model Variant changes for Bert/AlbertMaskedLM (update tt-forge-models version)

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -48,9 +48,9 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-vgg11]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-vgg13]
                   tests/models/dpr/test_dpr.py::test_dpr[single_device-full-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert/albert-xlarge-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert/albert-large-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert/albert-base-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert-xlarge-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert-large-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert-base-v2-eval]
                   tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[single_device-full-textattack/albert-base-v2-imdb-eval]
                   tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[single_device-full-albert/albert-base-v2-eval]
                   tests/models/mobilenet_ssd/test_mobilenet_ssd.py::test_mobilenet_ssd[single_device-full-eval]
@@ -89,9 +89,9 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[data_parallel-full-eval-vgg11]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[data_parallel-full-eval-vgg13]
                   tests/models/dpr/test_dpr.py::test_dpr[data_parallel-full-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert/albert-xlarge-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert/albert-large-v2-eval]
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert/albert-base-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert-xlarge-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert-large-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[data_parallel-full-albert-base-v2-eval]
                   tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[data_parallel-full-textattack/albert-base-v2-imdb-eval]
                   tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[data_parallel-full-albert/albert-base-v2-eval]
                   tests/models/roberta/test_roberta.py::test_roberta[data_parallel-full-eval]
@@ -177,7 +177,7 @@ jobs:
           {
             # Approximately 5 minutes.
             runs-on: wormhole_b0, name: "eval_7_bert_qrtn", tests: "
-                  tests/models/bert/test_bert.py::test_bert[full-eval]
+                  tests/models/bert/test_bert.py::test_bert[large-full-eval]
             "
           },
           # Approximately 180 minutes.

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -61,7 +61,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "eval_3", tests: "
-                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert/albert-xxlarge-v2-eval]
+                  tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert-xxlarge-v2-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_y_400mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_y_800mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_y_1_6gf]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -33,10 +33,10 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "albert", tests: "
-              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert/albert-base-v2-eval]
-              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert/albert-large-v2-eval]
-              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert/albert-xlarge-v2-eval]
-              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert/albert-xxlarge-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert-base-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert-large-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert-xlarge-v2-eval]
+              tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-op_by_op_torch-albert-xxlarge-v2-eval]
               tests/models/albert/test_albert_token_classification.py::test_albert_token_classification[single_device-op_by_op_torch-albert/albert-base-v2-eval]
               tests/models/albert/test_albert_sequence_classification.py::test_albert_sequence_classification[single_device-op_by_op_torch-textattack/albert-base-v2-imdb-eval]
               tests/models/albert/test_albert_question_answering.py::test_albert_question_answering[op_by_op_torch-twmkn9/albert-base-v2-squad2-eval]
@@ -50,7 +50,7 @@ jobs:
           {
             runs-on: wormhole_b0, name: "bert", tests: "
               tests/models/distilbert/test_distilbert.py::test_distilbert[op_by_op_torch-distilbert-base-uncased-eval]
-              tests/models/bert/test_bert.py::test_bert[op_by_op_torch-eval]
+              tests/models/bert/test_bert.py::test_bert[large-op_by_op_torch-eval]
               tests/models/bert/test_bert_turkish.py::test_bert_turkish[single_device-op_by_op_torch-eval]
               tests/models/squeeze_bert/test_squeeze_bert.py::test_squeeze_bert[single_device-op_by_op_torch-eval]
               "

--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -690,6 +690,12 @@ def generate_op_reports_xlsx():
         else:
             model_group = "unknown"
 
+        # Dirty-ish Workaround. Model names are quite long w/ get_model_info() so
+        # explicitly remove some known frameworks which are at the start of the name
+        model_name = model_name.replace("pytorch_", "")
+        model_name = model_name.replace("jax_", "")
+        model_name = model_name.replace("numpy_", "")
+
         # If invalid excel char in name: []:*?/\, replace with _
         model_name = re.sub(r"[^a-zA-Z0-9_]", "_", model_name)
         if len(model_name) > 28:

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -13,19 +13,16 @@ from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
 class ThisTester(ModelTester):
     def __init__(self, model_name, mode, variant=None, **kwargs):
         self.variant = variant
+        self.loader = ModelLoader(variant=variant)
         super().__init__(model_name, mode, **kwargs)
 
     def _load_model(self):
-        return ModelLoader.load_model(
-            variant=self.variant, dtype_override=torch.bfloat16
-        )
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        self.inputs = ModelLoader.load_inputs(
-            variant=self.variant, dtype_override=torch.bfloat16
-        )
-        self.text = ModelLoader.sample_text
-        self.tokenizer = ModelLoader.tokenizer
+        self.inputs = self.loader.load_inputs(dtype_override=torch.bfloat16)
+        self.text = ModelLoader.sample_text  # class attribute remains the same
+        self.tokenizer = ModelLoader.tokenizer  # class attribute remains the same
         return self.inputs
 
     def set_inputs_train(self, inputs):
@@ -94,7 +91,7 @@ def test_albert_masked_lm(
     results = tester.test_model()
 
     def print_result(result):
-        predicted_tokens = ModelLoader.decode_output(result, tester.inputs)
+        predicted_tokens = tester.loader.decode_output(result, tester.inputs)
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
 
     if mode == "eval":

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -68,7 +68,7 @@ def test_albert_masked_lm(
 
     variant, variant_config = variant_info
     loader = ModelLoader(variant=variant)
-    model_info = loader.get_model_info()
+    model_info = loader.get_model_info(variant=variant)
     model_name = model_info.name
 
     required_pcc = 0.98 if "xxlarge" in variant else 0.99

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -67,8 +67,9 @@ def test_albert_masked_lm(
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     variant, variant_config = variant_info
-    model_name = f"albert/{variant}-masked_lm"
     loader = ModelLoader(variant=variant)
+    model_info = loader.get_model_info()
+    model_name = model_info.name
 
     required_pcc = 0.98 if "xxlarge" in variant else 0.99
 

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -3,25 +3,29 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://huggingface.co/docs/transformers/v4.44.2/en/model_doc/albert#transformers.AlbertForMaskedLM
 
-from transformers import AutoTokenizer, AlbertForMaskedLM
 import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
+    def __init__(self, model_name, mode, variant=None, **kwargs):
+        self.variant = variant
+        super().__init__(model_name, mode, **kwargs)
+
     def _load_model(self):
-        return AlbertForMaskedLM.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
+        return ModelLoader.load_model(
+            variant=self.variant, dtype_override=torch.bfloat16
         )
 
     def _load_inputs(self):
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
+        self.inputs = ModelLoader.load_inputs(
+            variant=self.variant, dtype_override=torch.bfloat16
         )
-        self.text = "The capital of [MASK] is Paris."
-        self.inputs = self.tokenizer(self.text, return_tensors="pt")
+        self.text = ModelLoader.sample_text
+        self.tokenizer = ModelLoader.tokenizer
         return self.inputs
 
     def set_inputs_train(self, inputs):
@@ -35,18 +39,19 @@ class ThisTester(ModelTester):
     #     return
 
 
+# Print available variants for reference
+available_variants = ModelLoader.query_available_variants()
+print("Available variants:", available_variants)
+
+
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
 )
 @pytest.mark.parametrize(
-    "model_name",
-    [
-        "albert/albert-base-v2",
-        "albert/albert-large-v2",
-        "albert/albert-xlarge-v2",
-        "albert/albert-xxlarge-v2",
-    ],
+    "variant_info",
+    available_variants.items(),
+    ids=list(available_variants.keys()),
 )
 @pytest.mark.parametrize(
     "op_by_op",
@@ -57,7 +62,7 @@ class ThisTester(ModelTester):
     "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
 )
 def test_albert_masked_lm(
-    record_property, model_name, mode, op_by_op, data_parallel_mode
+    record_property, variant_info, mode, op_by_op, data_parallel_mode
 ):
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -69,21 +74,18 @@ def test_albert_masked_lm(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    assert_pcc = (
-        True
-        if model_name
-        in [
-            "albert/albert-base-v2",
-            "albert/albert-large-v2",
-            "albert/albert-xlarge-v2",
-        ]
-        else False
-    )
+    variant, variant_desc = variant_info
+    model_name = f"albert/{variant}-masked_lm"
+    print(f"Testing model_name: {model_name} variant_desc: {variant_desc}", flush=True)
+
+    required_pcc = 0.98 if "xxlarge" in variant else 0.99
 
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=assert_pcc,
+        variant=variant,
+        required_pcc=required_pcc,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
@@ -92,12 +94,7 @@ def test_albert_masked_lm(
     results = tester.test_model()
 
     def print_result(result):
-        logits = result.logits
-        mask_token_index = (tester.inputs.input_ids == tester.tokenizer.mask_token_id)[
-            0
-        ].nonzero(as_tuple=True)[0]
-        predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
-        predicted_tokens = tester.tokenizer.decode(predicted_token_id)
+        predicted_tokens = ModelLoader.decode_output(result, tester.inputs)
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
 
     if mode == "eval":

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -11,11 +11,6 @@ from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
-    def __init__(self, model_name, mode, variant=None, **kwargs):
-        self.variant = variant
-        self.loader = ModelLoader(variant=variant)
-        super().__init__(model_name, mode, **kwargs)
-
     def _load_model(self):
         return self.loader.load_model(dtype_override=torch.bfloat16)
 
@@ -73,14 +68,14 @@ def test_albert_masked_lm(
 
     variant, variant_config = variant_info
     model_name = f"albert/{variant}-masked_lm"
-    print(f"Testing model_name: {model_name} variant: {variant}", flush=True)
+    loader = ModelLoader(variant=variant)
 
     required_pcc = 0.98 if "xxlarge" in variant else 0.99
 
     tester = ThisTester(
         model_name,
         mode,
-        variant=variant,
+        loader=loader,
         required_pcc=required_pcc,
         assert_pcc=True,
         assert_atol=False,
@@ -91,7 +86,7 @@ def test_albert_masked_lm(
     results = tester.test_model()
 
     def print_result(result):
-        predicted_tokens = tester.loader.decode_output(result, tester.inputs)
+        predicted_tokens = loader.decode_output(result, tester.inputs)
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
 
     if mode == "eval":

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -21,8 +21,8 @@ class ThisTester(ModelTester):
 
     def _load_inputs(self):
         self.inputs = self.loader.load_inputs(dtype_override=torch.bfloat16)
-        self.text = ModelLoader.sample_text  # class attribute remains the same
-        self.tokenizer = ModelLoader.tokenizer  # class attribute remains the same
+        self.text = ModelLoader.sample_text
+        self.tokenizer = self.loader.tokenizer
         return self.inputs
 
     def set_inputs_train(self, inputs):
@@ -71,9 +71,9 @@ def test_albert_masked_lm(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    variant, variant_desc = variant_info
+    variant, variant_config = variant_info
     model_name = f"albert/{variant}-masked_lm"
-    print(f"Testing model_name: {model_name} variant_desc: {variant_desc}", flush=True)
+    print(f"Testing model_name: {model_name} variant: {variant}", flush=True)
 
     required_pcc = 0.98 if "xxlarge" in variant else 0.99
 

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -40,7 +40,7 @@ def test_bert(record_property, mode, op_by_op, variant_info):
     # Use variant in model name if specified
     variant, variant_config = variant_info
     loader = ModelLoader(variant=variant)
-    model_info = loader.get_model_info()
+    model_info = loader.get_model_info(variant=variant)
     model_name = model_info.name
 
     cc = CompilerConfig()

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -11,15 +11,14 @@ from third_party.tt_forge_models.bert.pytorch import ModelLoader
 class ThisTester(ModelTester):
     def __init__(self, model_name, mode, variant=None, **kwargs):
         self.variant = variant
+        self.loader = ModelLoader(variant=variant)
         super().__init__(model_name, mode, **kwargs)
 
     def _load_model(self):
-        return ModelLoader.load_model(
-            variant=self.variant, dtype_override=torch.bfloat16
-        )
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs()
+        return self.loader.load_inputs()
 
 
 # Print available variants for reference
@@ -69,7 +68,7 @@ def test_bert(record_property, mode, op_by_op, variant_info):
     results = tester.test_model()
 
     if mode == "eval":
-        answer = ModelLoader.decode_output(results, tester.inputs)
+        answer = tester.loader.decode_output(results, tester.inputs)
 
         print(
             f"""

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -39,8 +39,9 @@ def test_bert(record_property, mode, op_by_op, variant_info):
 
     # Use variant in model name if specified
     variant, variant_config = variant_info
-    model_name = f"BERT-{variant}"
     loader = ModelLoader(variant=variant)
+    model_info = loader.get_model_info()
+    model_name = model_info.name
 
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -43,9 +43,9 @@ print("Available variants:", available_variants)
 def test_bert(record_property, mode, op_by_op, variant_info):
 
     # Use variant in model name if specified
-    variant, variant_desc = variant_info
+    variant, variant_config = variant_info
     model_name = f"BERT-{variant}"
-    print(f"Testing model_name: {model_name} variant_desc: {variant_desc}", flush=True)
+    print(f"Testing model_name: {model_name} variant: {variant}", flush=True)
 
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -9,11 +9,6 @@ from third_party.tt_forge_models.bert.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
-    def __init__(self, model_name, mode, variant=None, **kwargs):
-        self.variant = variant
-        self.loader = ModelLoader(variant=variant)
-        super().__init__(model_name, mode, **kwargs)
-
     def _load_model(self):
         return self.loader.load_model(dtype_override=torch.bfloat16)
 
@@ -45,7 +40,7 @@ def test_bert(record_property, mode, op_by_op, variant_info):
     # Use variant in model name if specified
     variant, variant_config = variant_info
     model_name = f"BERT-{variant}"
-    print(f"Testing model_name: {model_name} variant: {variant}", flush=True)
+    loader = ModelLoader(variant=variant)
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -58,7 +53,7 @@ def test_bert(record_property, mode, op_by_op, variant_info):
     tester = ThisTester(
         model_name,
         mode,
-        variant=variant,
+        loader=loader,
         relative_atol=0.012,
         compiler_config=cc,
         record_property_handle=record_property,
@@ -68,7 +63,7 @@ def test_bert(record_property, mode, op_by_op, variant_info):
     results = tester.test_model()
 
     if mode == "eval":
-        answer = tester.loader.decode_output(results, tester.inputs)
+        answer = loader.decode_output(results, tester.inputs)
 
         print(
             f"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -97,6 +97,7 @@ class ModelTester:
         self,
         model_name,
         mode,
+        loader=None,
         required_pcc=0.99,
         required_atol=None,
         relative_atol=None,
@@ -116,6 +117,7 @@ class ModelTester:
         Args:
             model_name (str): Name of the model.
             mode (str): "train" or "eval" mode.
+            loader (ModelLoader, optional): TT-Forge-Models Loader for the model. Defaults to None.
             required_pcc (float, optional): Required Pearson Correlation Coefficient for verification. Defaults to 0.99.
             required_atol (float, optional): Required absolute tolerance for verification. Defaults to None.
             relative_atol (float, optional): Required relative absolute tolerance for verification. Defaults to None.
@@ -139,6 +141,7 @@ class ModelTester:
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
         self.model_name = model_name
+        self.loader = loader
         self.mode = mode
         self.data_parallel_mode = data_parallel_mode
         self.framework_model = self._load_model()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "94bb05f93479dab444db8d9b083d321489277008")
+    set(TT_FORGE_MODELS_VERSION "ce1eb728ec67732184cec29f9115b147fb389546")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "677d7ac45eec8afab0997b519504990f9892d4a7")
+    set(TT_FORGE_MODELS_VERSION "94bb05f93479dab444db8d9b083d321489277008")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
None

### Problem description
- We want to use model variant support from tt-forge-models in tt-torch (for bert/albert to start, as example)

### What's changed
 - Update tt-forge-models version to latest version with initial variant support, enums, ModelInfo, ModelConfig etc
 - Query available variants and use as pytest param to auto-discover available test variants
 - Make loader optional ModelTester constructor arg and member variable, simplifies variant tests
 - Use updated model names via ModelLoaders get_model_info() to be consistent with other FE's for reporting (example: albert/albert-base-v2-masked_lm => pytorch_albert_v2_albert-base-v2_nlp_masked_lm_huggingface)
 - For Albert, enable PCC check always, lower to 0.98 for xxlarge and update yaml files for shorter variant name being specified (without albert prefix)
 - Workaround in parse_op_by_op_results.py to remove prefixes from model_name to prevent long model names from being not-helpful in 31 character limit in op-by-op xlsx sheet names

### Checklist
- [x] Tested bert, albert modified tests locally, and other non-variant models (in onPR)
