### PR TITLE
Restore back tester.test_input variable in test_yolos*.py for ending summary

### DIFF
--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -26,8 +26,8 @@ class ThisTester(ModelTester):
 
     def _load_inputs(self):
         # Set up sample input
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.image = Image.open(str(image_file))
+        self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        self.image = Image.open(str(get_file(self.test_input)))
         inputs = self.image_processor(images=self.image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
         return inputs

--- a/tests/models/yolos/test_yolos_n300.py
+++ b/tests/models/yolos/test_yolos_n300.py
@@ -26,8 +26,8 @@ class ThisTester(ModelTester):
 
     def _load_inputs(self):
         # Set up sample input
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.image = Image.open(str(image_file))
+        self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        self.image = Image.open(str(get_file(self.test_input)))
         inputs = self.image_processor(images=[self.image] * 4, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
         return inputs


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Tiny refactor, removal of this variable caused single device and n300 to fail in nightly
 with error "AttributeError: 'ThisTester' object has no attribute 'test_input'"

### What's changed
- Add variable back to avoid error since it is used at end of test

### Checklist
- [x] Checked tests locally
