### PR TITLE
Misc small test/model/yml changes (ghostnetv2, xglm, llama7b, falcon3-1b, n300 tests)

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -53,7 +53,7 @@ jobs:
                   tests/models/llama/test_llama_7b.py::test_llama_7b[full-eval]
                   tests/models/falcon/test_falcon.py::test_falcon[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-googlenet]
-                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-op_by_op_torch-eval-ghostnetv2_100.in1k]
+                  tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-ghostnetv2_100.in1k]
                   tests/models/mistral/test_pixtral.py::test_pixtral[full-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-mistral7b-eval]
                   tests/models/mistral/test_mistral.py::test_mistral[full-ministral8b-eval]

--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -40,6 +40,7 @@ jobs:
               tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[full-eval]
               tests/models/flux/test_flux.py::test_flux[full-flux_schnell-eval]
               tests/models/flux/test_flux.py::test_flux[full-flux_dev-eval]
+              tests/models/xglm/test_xglm.py::test_xglm[full-eval]
             "
           },
           {

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -127,7 +127,6 @@ jobs:
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1-eval]
                   tests/models/clip/test_clip.py::test_clip[full-eval]
                   tests/models/gpt2/test_gpt2.py::test_gpt2[full-eval]
-                  tests/models/xglm/test_xglm.py::test_xglm[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_b]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-densenet201]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-ese_vovnet19b_dw.ra_in1k]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -52,11 +52,6 @@ jobs:
               ", sh-run: true
           },
           {
-            runs-on: wormhole_b0, name: "llama", tests: "
-              tests/models/llama/test_llama_7b.py::test_llama_7b[op_by_op_torch-eval]
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "openpose", tests: "
               tests/models/openpose/test_openpose.py::test_openpose[op_by_op_torch-eval]
               "

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -87,6 +87,11 @@ jobs:
               "
           },
           {
+            runs-on: wormhole_b0, name: "xglm", tests: "
+              tests/models/xglm/test_xglm.py::test_xglm[op_by_op_torch-eval]
+              "
+          },
+          {
             runs-on: wormhole_b0, name: "vision-misc", tests: "
               tests/models/glpn_kitti/test_glpn_kitti.py::test_glpn_kitti[op_by_op_torch-eval]
               tests/models/hand_landmark/test_hand_landmark.py::test_hand_landmark[op_by_op_torch-eval]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -133,11 +133,6 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "xglm", tests: "
-              tests/models/xglm/test_xglm.py::test_xglm[op_by_op_torch-eval]
-              "
-          },
-          {
             runs-on: wormhole_b0, name: "vision-misc", tests: "
               tests/models/perceiver_io/test_perceiver_io.py::test_perceiver_io[op_by_op_torch-eval]
               tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[op_by_op_torch-eval]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -73,6 +73,7 @@ jobs:
           {
             runs-on: wormhole_b0, name: "llama", tests: "
               tests/models/llama/test_llama_3b.py::test_llama_3b[op_by_op_torch-meta-llama/Llama-3.2-3B-eval]
+              tests/models/llama/test_llama_7b.py::test_llama_7b[op_by_op_torch-eval]
               "
           },
           {

--- a/tests/models/EfficientNet/test_EfficientNet_n300.py
+++ b/tests/models/EfficientNet/test_EfficientNet_n300.py
@@ -66,7 +66,7 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/MobileNetV2/test_MobileNetV2_n300.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_n300.py
@@ -46,7 +46,7 @@ def test_MobileNetV2(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
@@ -98,7 +98,7 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/falcon/test_falcon3.py
+++ b/tests/models/falcon/test_falcon3.py
@@ -79,6 +79,7 @@ def test_falcon(record_property, model_name, mode, op_by_op):
         if model_name
         in [
             "tiiuae/Falcon3-3B-Base",
+            "tiiuae/Falcon3-1B-Base",
         ]
         else False
     )

--- a/tests/models/hardnet/test_hardnet_n300.py
+++ b/tests/models/hardnet/test_hardnet_n300.py
@@ -66,7 +66,7 @@ def test_hardnet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/resnet50/test_resnet50_llmbox.py
+++ b/tests/models/resnet50/test_resnet50_llmbox.py
@@ -52,7 +52,7 @@ def test_resnet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 8]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/segformer/test_segformer_n300.py
+++ b/tests/models/segformer/test_segformer_n300.py
@@ -60,7 +60,7 @@ def test_segformer(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/vit/test_vit_n300.py
+++ b/tests/models/vit/test_vit_n300.py
@@ -49,7 +49,7 @@ def test_vit(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -49,9 +49,6 @@ def test_xglm(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    else:
-        cc.compile_depth = CompileDepth.TTNN_IR
-
     tester = ThisTester(
         model_name,
         mode,

--- a/tests/models/yolov4/test_yolov4_n300.py
+++ b/tests/models/yolov4/test_yolov4_n300.py
@@ -47,7 +47,7 @@ def test_yolov4(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_info = True
+
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:


### PR DESCRIPTION
### Ticket
None

### What's changed
- Remove test_xglm.py ancient hardcoded CompileDepth.TTNN_IR and put back to op-by-op nightly since an op fails at execute
 - Fix ghostnetv2_100.in1k in e2e-compile list was running op-by-op due to typo, passes (phew)
- Enable PCC checking in tiiuae/Falcon3-1B-Base, has been passing for a while
- Move tests/models/llama/test_llama_7b.py from op-by-op nightly to weekly since test_llama_7b_pipeline_parallel exists in nightly full-model-execute now and passes
- Remove cc.dump_info = True from bunch of newly added n300 tests, causes huge IR dumps, was for bringup/debug

### Checklist
- [x] Run tests locally