### PR TITLE
WIP/Draft: Report in dashboard on the model_group=red models that are NOT_STARTED

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -203,6 +203,7 @@ jobs:
           {
             # These are WIP model_group=red models, marked w/ pytest.skip with reasons, run here for reporting.
             runs-on: wormhole_b0, name: "skip_tests_red_models", tests: "
+                tests/models/wip_models.py::test_wip_priority_red_models
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-lstm]
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-gru]
                 tests/models/oft/test_oft.py::test_oft[full-eval]

--- a/tests/models/wip_models.py
+++ b/tests/models/wip_models.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.utils import skip_full_eval_test
+from tt_torch.tools.utils import CompilerConfig
+
+# List all priority red group models here that are not started or WIP for reporting purposes
+# Model names are best guesses, may change when tests are worked on, added.
+red_models = [
+    # PYTORCH Models ======================================================
+    # Phi Models - https://github.com/tenstorrent/tt-torch/issues/330
+    "microsoft/Phi-3-mini-128k-instruct",
+    "microsoft/Phi-3-mini-4k-instruct",
+    "microsoft/Phi-3.5-MoE-instruct",
+    "microsoft/Phi-3.5-vision-instruct",
+    "microsoft/phi-4",
+    # Surya-OCR Models - https://github.com/tenstorrent/tt-torch/issues/425
+    "surya-ocr-detection",
+    "surya-ocr-recognition",
+    "surya-ocr-layout",
+    "surya-ocr-table_recognition",
+    # ONNX Models =========================================================
+    "BEVDepth",  # https://github.com/tenstorrent/tt-torch/issues/348
+    # swin transformer v2 - https://github.com/tenstorrent/tt-torch/issues/333
+]
+
+# Generate XML report for red priority models
+def test_wip_priority_red_models(record_property):
+    for model_name in red_models:
+        print(f"Generating report for model_name: {model_name}", flush=True)
+        skip_full_eval_test(
+            record_property,
+            CompilerConfig(),
+            model_name,
+            bringup_status="NOT_STARTED",
+            reason="Model is not started or is WIP",
+            model_group="red",
+            skip=False,
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,7 @@ def skip_full_eval_test(
     reason,
     model_group="generality",
     model_name_filter=None,
+    skip=True,
 ):
     """
     Helper function to skip a test when frontend has issues and record properties.
@@ -72,13 +73,15 @@ def skip_full_eval_test(
         record_property(
             "tags",
             {
+                "parallelism": "single_device",
                 "bringup_status": bringup_status,
                 "model_name": model_name,
             },
         )
         record_property("group", model_group)
 
-        pytest.skip(reason=reason)
+        if skip:
+            pytest.skip(reason=reason)
         return True
     return False
 


### PR DESCRIPTION
### Ticket
None

### Problem description
- There is request from TPM for us to track all customer priority (red) models on dashboard even if not started

### What's changed
 - Add a single test called tests/models/wip_models.py to list all models that are not started or WIP that will be run in nightly regression for reporting purposes. When models are actually added, remove from this test at same time.
 - Add "parallelism": "single_device" tag in skip_full_eval_test for consistency
 - Add new optional "Skip=True" arg to skip_full_eval_test to be able to avoid pytest.skip, needed when looping across many model names here.
 - TODO - Need to add more models to list
 - TODO - Need to wait until this bringup_status="NOT_STARTED" is approved

### Checklist
- [x] Tested locally so far, outputs nice xml report
