### PR TITLE
Add working phi 3.5 moe test

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -286,6 +286,7 @@ jobs:
                 tests/models/beit/test_beit_image_classification_n300.py::test_beit_image_classification[full-microsoft/beit-large-patch16-224-eval]
                 tests/models/mgp-str-base/test_mgp_str_base_n300.py::test_mgp_str_base[full-eval]
                 tests/models/mlpmixer/test_mlpmixer_n300.py::test_mlpmixer[full-eval]
+                tests/models/phi/test_phi_3p5_moe.py::test_phi[full-microsoft/Phi-3.5-MoE-instruct-eval]
                 tests/models/EfficientNet/test_EfficientNet_n300.py::test_EfficientNet[full-efficientnet-b1-eval]
                 tests/models/EfficientNet/test_EfficientNet_n300.py::test_EfficientNet[full-efficientnet-b2-eval]
                 tests/models/EfficientNet/test_EfficientNet_n300.py::test_EfficientNet[full-efficientnet-b3-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -165,6 +165,11 @@ jobs:
               tests/models/d_fine/test_d_fine.py::test_d_fine[op_by_op_torch-dfine-xlarge-eval]
               "
           },
+          {
+            runs-on: wormhole_b0, name: "phi3p5", tests: "
+              tests/models/phi/test_phi_3p5_moe.py::test_phi[op_by_op_torch-microsoft/Phi-3.5-MoE-instruct-eval]
+            "
+          }
         ]
     runs-on:
       - ${{ matrix.build.sh-run && format('tt-beta-ubuntu-2204-{0}-large-stable', matrix.build.runs-on) ||  matrix.build.runs-on }}

--- a/tests/models/phi/test_phi_3p5_moe.py
+++ b/tests/models/phi/test_phi_3p5_moe.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Phi-3.5-MoE-instruct: https://huggingface.co/microsoft/Phi-3.5-MoE-instruct
+
+import torch
+import pytest
+
+from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
+from tests.utils import ModelTester, skip_full_eval_test
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name, torch_dtype=torch.bfloat16
+        )
+
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            return_dict=True,
+            torch_dtype=torch.bfloat16,
+        )
+        pipe = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            torch_dtype=torch.bfloat16,
+            pad_token_id=self.tokenizer.eos_token_id,
+        )
+        return pipe
+
+    def _load_inputs(self):
+        self.prompt = """
+        Write a short story about a cat:
+        """
+        arguments = {
+            "text_inputs": self.prompt,
+            "max_new_tokens": 120,
+            "do_sample": True,
+        }
+        return arguments
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "microsoft/Phi-3.5-MoE-instruct",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_phi(record_property, model_name, mode, op_by_op):
+    model_group = "red"
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    # consteval_parameters is disabled because it results in a memory related crash
+
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_FE_COMPILATION",
+        reason="failed to legalize operation 'stablehlo.reduce'",
+    )
+
+    tester = ThisTester(
+        model_name,
+        mode,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group=model_group,
+    )
+
+    results = tester.test_model()
+
+    if mode == "eval":
+        decoded_output = results[0]["generated_text"]
+        print(
+            f"""
+        model_name: {model_name}
+        input: {tester.prompt}
+        output: {decoded_output}
+        """
+        )
+    tester.finalize()


### PR DESCRIPTION
### Ticket
#330 

### Problem description
Add Phi 3.5 Mixture of Experts test
Note: the model cannot compile end-to-end due to `failed to legalize operation 'stablehlo.reduce'` error

### Checklist
- [ ] Add `tests/models/phi/test_phi_3p5_moe.py`
- [ ] Add `tests/models/phi/test_phi_3p5_moe.py` to nightly op-by-op test

