### PR TITLE
Uplift to latest tt-forge-models to get get_file(url) read-only cache fix

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "fffef9c66e85b886661c45d5403ead8568a5d1e3")
+    set(TT_FORGE_MODELS_VERSION "8d018cf5e8fac3aa3850029d34d1c75ab1c260af")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
None

### What's changed
- Update to latest tt-forge-models repo to get fix for "Add support in get_file() to handle when selected cache is read-only, fall back to home dir cache for writing", needed for folks using cloud VM machines.

### Checklist
- [x] Tested locally
