### PR TITLE
Fix flux-dev out-of-memory #912

### DIFF
--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -259,7 +259,8 @@ jobs:
               "
           },
           {
-            runs-on: wormhole_b0, name: "flux_schnell", tests: "
+            runs-on: wormhole_b0, name: "flux", tests: "
+              tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_dev-eval]
               tests/models/flux/test_flux.py::test_flux[op_by_op_torch-flux_schnell-eval]
             "
           },

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -194,7 +194,7 @@ def test_flux(record_property, model_name, mode, op_by_op, guidance_scale):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # cc.consteval_parameters = True
+    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -193,8 +193,8 @@ def test_flux(record_property, model_name, mode, op_by_op, guidance_scale):
     model_group = "red"
 
     cc = CompilerConfig()
-    cc.enable_consteval = False
-    cc.consteval_parameters = False
+    cc.enable_consteval = True
+    # cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:


### PR DESCRIPTION
### Ticket
#912 

### Problem description
`flux-dev` can compile end to end, but it gets killed when running op-by-op, which hints a memory problem. The error did not happen at a specific op.

### What's changed
The original test hadn't enabled consteval, and with consteval, the number of ops in graph has greatly reduced. `flux-dev` does not get killed anymore.