### PR TITLE
Edit phi 3.5 MoE to use model instead of pipeline

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -221,7 +221,7 @@ jobs:
                 tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-large-transformer-eval]
                 tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
                 tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-eval]
-                tests/models/phi/test_phi_3p5_moe.py::test_phi[full-phi3p5_moe-eval]
+                tests/models/phi/test_phi_3p5_moe.py::test_phi_3p5_moe[full-phi3p5_moe-eval]
             "
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -167,7 +167,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "phi3p5_moe", tests: "
-              tests/models/phi/test_phi_3p5_moe.py::test_phi[op_by_op_torch-phi3p5_moe-eval]
+            tests/models/phi/test_phi_3p5_moe.py::test_phi_3p5_moe[op_by_op_torch-phi3p5_moe-eval]
             "
           }
         ]

--- a/tests/models/phi/test_phi_3p5_moe.py
+++ b/tests/models/phi/test_phi_3p5_moe.py
@@ -13,33 +13,40 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
+            model_path, torch_dtype=torch.bfloat16
         )
 
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+
         self.model = AutoModelForCausalLM.from_pretrained(
-            self.model_name,
+            model_path,
             return_dict=True,
             torch_dtype=torch.bfloat16,
         )
-        pipe = pipeline(
-            "text-generation",
-            model=self.model,
-            tokenizer=self.tokenizer,
-            torch_dtype=torch.bfloat16,
-            pad_token_id=self.tokenizer.eos_token_id,
-        )
-        return pipe
+        self.model.eval()
+        return self.model
 
     def _load_inputs(self):
         self.prompt = """
         Write a short story about a cat:
         """
+        inputs = self.tokenizer(
+            self.prompt,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=self.tokenizer.model_max_length,
+        )
         arguments = {
-            "text_inputs": self.prompt,
+            "input_ids": inputs.input_ids,
+            "attention_mask": inputs.attention_mask,
             "max_new_tokens": 120,
             "do_sample": True,
+            "pad_token_id": self.tokenizer.pad_token_id,
         }
         return arguments
 
@@ -63,9 +70,10 @@ model_info_list = [
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
-def test_phi(record_property, model_info, mode, op_by_op):
+def test_phi_3p5_moe(record_property, model_info, mode, op_by_op):
     model_group = "red"
-    __, model_name = model_info
+    model_name, model_path = model_info
+
     cc = CompilerConfig()
     cc.enable_consteval = True
     # consteval_parameters is disabled because it results in a memory related crash
@@ -80,6 +88,7 @@ def test_phi(record_property, model_info, mode, op_by_op):
         cc,
         model_name,
         bringup_status="FAILED_FE_COMPILATION",
+        model_group=model_group,
         reason="failed to legalize operation 'stablehlo.reduce'",
     )
 
@@ -89,12 +98,13 @@ def test_phi(record_property, model_info, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         model_group=model_group,
+        run_generate=True,
     )
 
-    results = tester.test_model()
+    results = tester.test_model(assert_eval_token_mismatch=False)
 
     if mode == "eval":
-        decoded_output = results[0]["generated_text"]
+        decoded_output = tester.tokenizer.decode(results[0])
         print(
             f"""
         model_name: {model_name}


### PR DESCRIPTION
### Problem description
Changed `pipeline` implementation of phi 3.5 to `model` implementation. The key factor that `pipeline` ran is the `attention_mask` passed in explicitly. Without `attention_mask`, it seems like there isn't complete information for full computational graph resulting in `FakeTensors` 

### What's changed
Changed `tests/models/phi/test_phi_3p5_moe.py`
Renamed test name in tests
