### PR TITLE
Fix intermediate retention

### DIFF
--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -342,12 +342,14 @@ class TorchExecutor(OpByOpExecutor):
 
             out_degree[node] = len(node.users)
             if node.op == "placeholder":
-                node_to_tensor[node] = inputs[input_index]
+                if out_degree[node] > 0:
+                    node_to_tensor[node] = inputs[input_index]
                 input_index += 1
             elif node.op == "get_attr":
                 for buffer in self.program.graph_module.named_buffers():
                     if buffer[0] == node.target:
-                        node_to_tensor[node] = buffer[1]
+                        if out_degree[node] > 0:
+                            node_to_tensor[node] = buffer[1]
                         break
             elif node.op == "call_function":
                 args = []
@@ -439,11 +441,26 @@ class TorchExecutor(OpByOpExecutor):
                 output_tensors = [node_to_tensor[arg] for arg in args]
                 outputs = output_tensors
 
-            args_set = set()
-            for arg in node.args:
-                if arg in args_set:
-                    continue
-                args_set.add(arg)
+            def flatten_fx_nodes(*args):
+                result = []
+
+                def _flatten(arg):
+                    if isinstance(arg, torch.fx.node.Node):
+                        result.append(arg)
+                    elif isinstance(arg, (list, tuple)):
+                        for item in arg:
+                            _flatten(item)
+                    elif isinstance(arg, dict):
+                        for item in arg.values():
+                            _flatten(item)
+
+                for arg in args:
+                    _flatten(arg)
+
+                return result
+
+            args_set = set(flatten_fx_nodes(node.args))
+            for arg in args_set:
                 if isinstance(arg, torch.fx.node.Node):
                     out_degree[arg] -= 1
                     if out_degree[arg] == 0 and arg.op != "output":

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -434,8 +434,8 @@ class TorchExecutor(OpByOpExecutor):
                         self.print_marker(
                             "Failed to execute", idx, num_nodes, node.target, e_msg
                         )
-
-                node_to_tensor[node] = golden
+                if out_degree[node] > 0:
+                    node_to_tensor[node] = golden
             elif node.op == "output":
                 args = node.args[0]
                 output_tensors = [node_to_tensor[arg] for arg in args]


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/issues/943)

### Problem description
Intermediates were not being retained correctly causing to memory leaks as models ran. Additionally, intermediates weren't released if they weren't direct args to nodes (i.e. if they were args in a list). 

### What's changed
Don't retain intermediates for nodes that are not used in the graph. Flatten args so that simple iteration allows us to catch all users when deallocating intermediates.  


### Checklist
- [x] New/Existing tests provide coverage for changes
