### PR TITLE
Misc model changes (gpt_neo, bloom, efficientnet, falcon3, swin_t, centernet) promotions, pcc check, add, etc

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -201,6 +201,7 @@ jobs:
                 tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
                 tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-eval]
             "
           },
           {
@@ -223,7 +224,6 @@ jobs:
                 tests/models/stable_diffusion/test_stable_diffusion_3_5.py::test_stable_diffusion_3_5[full-SD3.5-large-eval]
                 tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-large-transformer-eval]
                 tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
-                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-eval]
                 tests/models/phi/test_phi_3p5_moe.py::test_phi_3p5_moe[full-phi3p5_moe-eval]
             "
           },

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -137,6 +137,7 @@ jobs:
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_v2_t]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_v2_b]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_v2_s]
+                  tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_t]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-densenet121]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-densenet169]
             "

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -127,6 +127,7 @@ jobs:
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1-eval]
                   tests/models/clip/test_clip.py::test_clip[full-eval]
                   tests/models/gpt2/test_gpt2.py::test_gpt2[full-eval]
+                  tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-swin_b]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-densenet201]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-ese_vovnet19b_dw.ra_in1k]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -147,6 +147,7 @@ jobs:
             runs-on: wormhole_b0, name: "eval_3", tests: "
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1.5-eval]
                   tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-1B-Base-eval]
+                  tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-1B-Instruct-eval]
             "
           },
           {
@@ -185,7 +186,7 @@ jobs:
                   tests/models/mamba/test_mamba.py::test_mamba[full-state-spaces/mamba-790m-hf-eval]
             "
           },
-          # Approximately 65 minutes.
+          # Approximately 70 minutes.
           {
             runs-on: wormhole_b0, name: "eval_9", tests: "
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
@@ -200,6 +201,7 @@ jobs:
                 tests/models/codegen/test_codegen_generate.py::test_codegen_generate[full-eval]
                 tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
+                tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Instruct-eval]
                 tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
                 tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-eval]
             "

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -189,14 +189,14 @@ jobs:
           # Approximately 70 minutes.
           {
             runs-on: wormhole_b0, name: "eval_9", tests: "
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
-                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b0-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b1-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b2-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b3-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b4-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b5-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b6-eval]
+                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b7-eval]
                 tests/models/codegen/test_codegen.py::test_codegen[full-eval]
                 tests/models/codegen/test_codegen_generate.py::test_codegen_generate[full-eval]
                 tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -47,11 +47,6 @@ jobs:
               "
           },
           {
-            runs-on: n300, name: "gpt", tests: "
-              tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[op_by_op_torch-eval]
-              ", sh-run: true
-          },
-          {
             runs-on: wormhole_b0, name: "openpose", tests: "
               tests/models/openpose/test_openpose.py::test_openpose[op_by_op_torch-eval]
               "

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -69,6 +69,7 @@ jobs:
           {
             runs-on: wormhole_b0, name: "gpt", tests: "
               tests/models/gpt2/test_gpt2.py::test_gpt2[op_by_op_torch-eval]
+              tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[op_by_op_torch-eval]
               "
           },
           {

--- a/tests/models/EfficientNet/test_EfficientNet_onnx.py
+++ b/tests/models/EfficientNet/test_EfficientNet_onnx.py
@@ -73,7 +73,7 @@ def test_EfficientNet_onnx(record_property, model_name, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -58,7 +58,7 @@ def test_bloom(record_property, mode, op_by_op):
         model_name,
         mode,
         relative_atol=0.01,
-        assert_pcc=False,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -58,7 +58,8 @@ def test_gpt_neo(record_property, mode, op_by_op):
         mode,
         compiler_config=cc,
         record_property_handle=record_property,
-        assert_pcc=False,
+        required_pcc=0.98,
+        assert_pcc=True,
         assert_atol=False,
         run_generate=False,
     )


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Bunch of misc changes from reviewing dashboard, depth benchmarks, op-by-op XLSX today

### What's changed
 - Enable PCC in gpt_neo and promote to full model execute
 - Enable PCC check in test_bloom.py passing lately
 - Switch to use test_EfficientNet_onnx.py for full model execute passing lately all variants w/ pcc (we always wanted to run onnx version all along)
 - Add Falcon3-1B/3B Instruct models to full model execute, passing
 - Add swin_t to full model execute nightly passing. We weren't running this variant.
 - Move test_centernet_onnx out of skip_tests_red_models was added there by accident

### Checklist
- [x] Run locally, run on branch CI : https://github.com/tenstorrent/tt-torch/actions/runs/15694348538/job/44216630986
