### PR TITLE
Disable consteval_parameters to reduce host RAM usage in SD3.5 Large Transformer test 

### DIFF
--- a/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
@@ -98,7 +98,7 @@ def test_stable_diffusion_transformer(record_property, model_info, mode, op_by_o
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
+    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:


### PR DESCRIPTION
### Ticket
#943 

### Problem description
- SD3.5 Large Transformer test still uses lots of memory even after intermediates fix and CI machines only have 32GB or 48GB

### What's changed
- Remove setting of consteval_parameters with same comment as other tests have, it's enough to solve problem
- Reduces memory from (65GB->32GB) when combined with recent merged intermediates fix

### Checklist
- [x] New/Existing tests provide coverage for changes
