### PR TITLE
Use changed tt runtime debug header location

### DIFF
--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -18,7 +18,7 @@
 
 // tt-mlir includes
 #if defined(TT_RUNTIME_DEBUG) && TT_RUNTIME_DEBUG == 1
-#include "tt/runtime/detail/debug.h"
+#include "tt/runtime/debug.h"
 #endif
 #include "tt/runtime/runtime.h"
 #include "tt/runtime/types.h"


### PR DESCRIPTION
### Ticket
None

### Problem description
June 17 nightlies failed due to misinclusion of tt runtime debug header, which was moved.

### What's changed
Change location of tt runtime debug header to correct location. Credit to @jnie-TT for this change.

### Checklist
- [x] New/Existing tests provide coverage for changes
