### PR TITLE
Add path to disable backend consteval pass from compiler config

### DIFF
--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -162,9 +162,11 @@ std::string compile_stable_hlo_to_ttir(std::string_view code) {
 std::tuple<py::bytes, std::string>
 compile_ttir_to_bytestream(std::string_view code,
                            std::string_view sys_desc_path,
-                           size_t len_activations, size_t len_graph_constants) {
-  auto [binary_ptr, ttnn] = tt::torch::compileTTIRToTTNN(
-      code, sys_desc_path, len_activations, len_graph_constants);
+                           size_t len_activations, size_t len_graph_constants,
+                           bool enable_consteval = true) {
+  auto [binary_ptr, ttnn] =
+      tt::torch::compileTTIRToTTNN(code, sys_desc_path, len_activations,
+                                   len_graph_constants, enable_consteval);
   auto size = ::flatbuffers::GetSizePrefixedBufferLength(
       static_cast<const uint8_t *>(binary_ptr->get()));
   tt::runtime::Binary binary = tt::runtime::Binary(*binary_ptr);
@@ -440,6 +442,7 @@ PYBIND11_MODULE(tt_mlir, m) {
   m.def("compile_ttir_to_bytestream", &compile_ttir_to_bytestream,
         py::arg("ttir"), py::arg("system_desc_path"),
         py::arg("len_activations") = 0, py::arg("len_graph_constants") = 0,
+        py::arg("enable_consteval") = true,
         "A function that compiles TTIR to a bytestream");
   m.def("stable_hlo_automatic_parallelization",
         &stable_hlo_automatic_parallelization,

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -191,7 +191,8 @@ void create_system_desc(tt::runtime::Device device,
 
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
-                  size_t len_activations, size_t len_graph_constants) {
+                  size_t len_activations, size_t len_graph_constants,
+                  bool enable_consteval) {
 
   mlir::MLIRContext context;
   mlir::DialectRegistry registry;
@@ -227,12 +228,8 @@ compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
 
   mlir::tt::ttnn::TTIRToTTNNBackendPipelineOptions options;
 
-  // boolean env var to override consteval
-  const char *consteval = std::getenv("TT_TORCH_CONSTEVAL");
-  if (consteval && std::string(consteval) == "1") {
-    options.enableConstEval = true;
-  }
   options.enableFusing = true;
+  options.enableConstEval = enable_consteval;
 
   if (len_activations > 0 || len_graph_constants > 0) {
     llvm::SmallVector<mlir::tt::ArgumentType> argTypes;

--- a/tt_torch/csrc/tt-mlir-interface.hpp
+++ b/tt_torch/csrc/tt-mlir-interface.hpp
@@ -17,7 +17,8 @@ std::string stableHLOAutomaticParallelization(std::string_view code,
 std::string compileStableHLOToTTIR(std::string_view code);
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
-                  size_t len_activations = 0, size_t len_graph_constants = 0);
+                  size_t len_activations = 0, size_t len_graph_constants = 0,
+                  bool enable_consteval = true);
 void create_system_desc(tt::runtime::Device device,
                         std::string_view descriptor_path);
 } // namespace tt::torch

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -213,7 +213,11 @@ def shlo_to_flatbuffer(
         )
 
     binary, ttnn = tt_mlir.compile_ttir_to_bytestream(
-        ttir, system_desc_path, len_activations, len_graph_constants
+        ttir,
+        system_desc_path,
+        len_activations,
+        len_graph_constants,
+        compiler_config.enable_consteval,
     )
     dump_module(module=ttnn, name="TTNN", compiler_config=compiler_config)
 


### PR DESCRIPTION
### Ticket
None

### Problem description
The default for the consteval option in compileTTIRToTTNN changed a month ago to default to true. This caused our consteval environment variable to be unable to suppress the backend consteval pass. We also didn't have a programmatic path to set the TTIRToTTNN consteval pass option without an env variable.

Required as a stopgap for #614 

### What's changed
Plumb the compiler_config.enable_consteval option through the backend to allow it to be disabled properly, remove the now invalid use of the env variable.

### Checklist
- [x] New/Existing tests provide coverage for changes
