### PR TITLE
Don't install pytorch in docker, use manylinux pytorch whl

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -40,8 +40,7 @@ RUN apt-get update && apt-get install -y \
 # Install python3.10 packages
 RUN python3.10 -m pip install \
     setuptools==59.6.0 \
-    wheel \
-    torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.7.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl
+    wheel
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
     },
     zip_safe=False,
     install_requires=[
-        "torch@https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.7.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl",
+        "torch@https://download.pytorch.org/whl/cpu/torch-2.7.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl",
         "stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp310-cp310-linux_x86_64.whl",
         "numpy",
         "onnx==1.17.0",


### PR DESCRIPTION
### Problem description
tt-torch and tt-forge-fe were not aligned in pytorch versions. 

### What's changed
Install the same pytorch version as tt-forge-fe uses. Also, don't install pytorch in docker, not sure why it was there to begin with. 


### Checklist
- [x] New/Existing tests provide coverage for changes
