### PR TITLE
Correctly install torch_mlir if it doesn't exist in package before python setup.py is called

### DIFF
--- a/tt_torch/__init__.py
+++ b/tt_torch/__init__.py
@@ -6,6 +6,7 @@
 #   - The backend will hang if attempting to retrieve the device descriptor from a forked process if there are multiple chips
 #   - torch tensors cannot be made contiguous in a forked process
 import multiprocessing as mp
+import torch
 
 if mp.get_start_method() != "forkserver":
     mp.set_start_method("forkserver", force=True)


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/issues/950)

### Problem description
On first build, python setup.py was not correctly installing torch_mlir

### What's changed
Changed setup to install torch_mlir as a package inside the wheel after setup runs. 

### Checklist
- [x] New/Existing tests provide coverage for changes
