### PR TITLE
Uplift third_party/tt-mlir to  2025-06-18

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "55cd22e7d0e691482a6b7b5d1cf67378a64098ed")
+set(TT_MLIR_VERSION "b75f21f615e2a03ae6d061fda05cf62290ec5fab")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -35,8 +35,8 @@
 #include "stablehlo/dialect/StablehloOps.h"  // from @stablehlo
 #include "stablehlo/transforms/Passes.h"     // from @stablehlo
 
-#include "ttmlir/Dialect/TT/IR/TTOps.h"
-#include "ttmlir/Dialect/TT/IR/TTTraits.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreOps.h"
+#include "ttmlir/Dialect/TTCore/IR/TTCoreTraits.h"
 
 #include "ttmlir/Dialect/StableHLO/Pipelines/StableHLOPipelines.h"
 #include "ttmlir/Dialect/TTIR/Pipelines/TTIRPipelines.h"


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the

- Rename files under TT to TTCore after dialect renamed in mlir commit 820a520