### PR TITLE
Add centernet onnx variants (object detection, human pose estimation, 3d-bounding box detection)

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -203,7 +203,8 @@ jobs:
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Instruct-eval]
                 tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
-                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-od-resdcn18-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-od-resdcn101-eval]
             "
           },
           {
@@ -228,6 +229,14 @@ jobs:
                 tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
                 tests/models/phi/test_phi_3p5_moe.py::test_phi_3p5_moe[full-phi3p5_moe-eval]
                 tests/models/phi/test_phi_3p5_vision.py::test_phi_3p5_vision[full-microsoft/Phi-3.5-vision-instruct-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-od-dla1x-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-od-dla2x-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-od-hg-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-hpe-dla1x-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-hpe-dla3x-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-hpe-hg3x-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-3d_bb-ddd_3dop-eval]
+                tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-3d_bb-ddd_sub-eval]
             "
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -166,17 +166,10 @@ jobs:
             "
           },
           {
-            runs-on: wormhole_b0, name: "centernet_1", tests: "
-            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla1x-eval]
-            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla2x-eval]
+            # Only testing few variants since runtime on these is long. Increase when more mahcines or priority increases.
+            runs-on: wormhole_b0, name: "centernet", tests: "
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla1x-eval]
-            "
-          },
-          {
-            runs-on: wormhole_b0, name: "centernet_2", tests: "
-            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla3x-eval]
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_3dop-eval]
-            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_sub-eval]
             "
           },
           {

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -166,6 +166,16 @@ jobs:
             "
           },
           {
+            runs-on: wormhole_b0, name: "centernet", tests: "
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla1x-eval]
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla2x-eval]
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla1x-eval]
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla3x-eval]
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_3dop-eval]
+            tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_sub-eval]
+            "
+          },
+          {
             runs-on: wormhole_b0, name: "phi3p5_vision", tests: "
               tests/models/phi/test_phi_3p5_vision.py::test_phi_3p5_vision[op_by_op_torch-microsoft/Phi-3.5-vision-instruct-eval]
             "

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -166,10 +166,14 @@ jobs:
             "
           },
           {
-            runs-on: wormhole_b0, name: "centernet", tests: "
+            runs-on: wormhole_b0, name: "centernet_1", tests: "
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla1x-eval]
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-dla2x-eval]
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla1x-eval]
+            "
+          },
+          {
+            runs-on: wormhole_b0, name: "centernet_2", tests: "
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-hpe-dla3x-eval]
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_3dop-eval]
             tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-3d_bb-ddd_sub-eval]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -257,7 +257,8 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "centernet", tests: "
-              tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-eval]
+              tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-resdcn18-eval]
+              tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[op_by_op_stablehlo-centernet-od-resdcn101-eval]
               "
           },
           {

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -93,7 +93,6 @@ def test_centernet_onnx(record_property, model_info, mode, op_by_op):
         model_group=model_info.group,
     )
 
-    print(f"KCM model_name: {model_name} model_group: {model_info.group}", flush=True)
     results = tester.test_model()
 
     if mode == "eval":

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -2,17 +2,35 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from tests.utils import OnnxModelTester
+from tests.utils import OnnxModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.centernet.pytorch import ModelLoader
 
 
 class ThisTester(OnnxModelTester):
     def _load_model(self):
-        return self.loader.load_model(variant_name="resdcn18_od")
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        return self.loader.load_model(variant_name=model_path)
 
     def _load_torch_inputs(self):
-        return self.loader.load_inputs(variant_name="resdcn18_od")
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        return self.loader.load_inputs(variant_name=model_path)
+
+
+model_info_list = [
+    ("centernet-od-dla1x", "dla1x_od"),
+    ("centernet-od-dla2x", "dla2x_od"),
+    ("centernet-od-resdcn18", "resdcn18_od"),
+    ("centernet-od-resdcn101", "resdcn101_od"),
+    ("centernet-od-hg", "hg_od"),
+    ("centernet-hpe-dla1x", "dla1x_hpe"),
+    ("centernet-hpe-dla3x", "dla3x_hpe"),
+    ("centernet-hpe-hg3x", "hg3x_hpe"),
+    ("centernet-3d_bb-ddd_3dop", "ddd_3dop_3d_bb"),
+    ("centernet-3d_bb-ddd_sub", "ddd_sub_3d_bb"),
+]
 
 
 @pytest.mark.parametrize(
@@ -20,11 +38,18 @@ class ThisTester(OnnxModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize(
+    "model_info",
+    model_info_list,
+    ids=[model_info[0] for model_info in model_info_list],
+)
+@pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, None],
     ids=["op_by_op_stablehlo", "full"],
 )
-def test_centernet_onnx(record_property, mode, op_by_op):
+def test_centernet_onnx(record_property, model_info, mode, op_by_op):
+    model_group = "red"
+    model_name, _ = model_info
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -33,8 +58,28 @@ def test_centernet_onnx(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = op_by_op
 
+    # TODO - update this once centernet ModelLoader is updated to properly support variants
     loader = ModelLoader(variant=None)
     model_info = loader.get_model_info(variant=None)
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_name,
+        bringup_status="FAILED_RUNTIME",
+        reason="'ttir.conv_transpose2d' op Number of input channels from input tensor must match the first dimension of the weight tensor. Got 256 input channels and 1 in the weight tensor.",
+        model_group=model_group,
+        model_name_filter=[
+            "centernet-od-dla1x",
+            "centernet-od-dla2x",
+            "centernet-od-hg",
+            "centernet-hpe-dla1x",
+            "centernet-hpe-dla3x",
+            "centernet-hpe-hg3x",
+            "centernet-3d_bb-ddd_3dop",
+            "centernet-3d_bb-ddd_sub",
+        ],
+    )
 
     # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/976
     tester = ThisTester(


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/353

### Problem description
Adds CenterNet ONNX models for various tasks including object detection, human pose estimation, and 3D bounding box detection.
Supported model variants for each task are:

- **Object Detection**: dla1x, dla2x, resdcn101, resdcn18
- **Human Pose Estimation**: dla1x, dla3x
- **3D Bounding Box Detection**: ddd_3dop, ddd_sub

### What's changed
 - Edited the existing `test_centernet_onnx.py` file to implement ONNX model testing for CenterNet.
 - Add few variants to op-by-op nightly, and full-model-execute nightly. Reduce number in op-by-op nightly for now since long runtime.

### Checklist
- [x] New/Existing tests provide coverage for changes
