### PR TITLE
Compile both tt-xla and tt-mlir

### DIFF
--- a/env/activate
+++ b/env/activate
@@ -31,6 +31,7 @@ else
 
 fi
 export TTTORCH_ENV_ACTIVATED=1
+export TTXLA_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1
 export PATH=$TT_TORCH_HOME/third_party/tt-mlir/src/tt-mlir-build/bin:$TT_TORCH_HOME/env/venv/lib/python3.10/site-packages/tt_mlir:$TTMLIR_TOOLCHAIN_DIR/bin:$PATH
 export TOKENIZERS_PARALLELISM=false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.0
+torch-xla==2.7.0
 torchvision
 torchaudio
 black

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 
 set(TT_MLIR_VERSION "0423379b588df28faaee598274a33fe0fff7c013")
+set(TTXLA_VERSION "0f40e574a1bc22e86692bd3d3b41c9b03dbd8e22")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
@@ -76,6 +77,51 @@ else()
     add_dependencies(TTMLIRRuntime tt-mlir)
 
     install(DIRECTORY ${TTMLIR_INSTALL_PREFIX}/ DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
+
+    set(TTXLA_PREFIX ${TTTORCH_SOURCE_DIR}/third_party/tt-xla)
+    set(TTXLA_INSTALL_PREFIX ${TTXLA_PREFIX}/src/tt-xla/install)
+    set(TTXLA_PJRT_DYLIB ${TTXLA_INSTALL_PREFIX}/lib/pjrt_plugin_tt.so)
+    set(TTNN_DYLIB ${TTXLA_INSTALL_PREFIX}/lib/_ttnncpp.so)
+    set(TTXLA_LIBDEVICE_DYLIB ${TTXLA_INSTALL_PREFIX}/lib/libdevice.so)
+    set(TTMETAL_DYLIB ${TTXLA_INSTALL_PREFIX}/lib/libtt_metal.so)
+    set(TTXLA_BUILD_DIR ${TTXLA_PREFIX}/src/tt-xla-build)
+
+    set(TTXLA_TTMLIR_COMPILER_LIBRARY_PATH ${TTXLA_INSTALL_PREFIX}/lib/libTTMLIRCompiler.so)
+    set(TTXLA_TTMLIR_RUNTIME_LIBRARY_PATH ${TTXLA_INSTALL_PREFIX}/lib/libTTMLIRRuntime.so)
+
+    ExternalProject_Add(
+        tt-xla
+        PREFIX ${TTXLA_PREFIX}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} --install ${TTXLA_BUILD_DIR} --prefix ${TTXLA_INSTALL_PREFIX} &&
+            chmod -R +x ${TTXLA_INSTALL_PREFIX}
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS
+            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_C_COMPILER=clang-17
+            -DCMAKE_CXX_COMPILER=clang++-17
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+            -DCMAKE_INSTALL_PREFIX=${TTXLA_INSTALL_PREFIX}
+        GIT_REPOSITORY https://github.com/tenstorrent/tt-xla.git
+        GIT_TAG ${TTXLA_VERSION}
+        GIT_PROGRESS ON
+        BUILD_BYPRODUCTS
+            ${TTXLA_PJRT_DYLIB}
+            ${TTNN_DYLIB}
+            ${TTXLA_LIBDEVICE_DYLIB}
+            ${TTMETAL_DYLIB}
+            ${TTXLA_TTMLIR_COMPILER_LIBRARY_PATH}
+            ${TTXLA_TTMLIR_RUNTIME_LIBRARY_PATH}
+    )
+
+    add_library(TTXLA_TTMLIRCompiler SHARED IMPORTED GLOBAL)
+    set_target_properties(TTXLA_TTMLIRCompiler PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TTXLA_TTMLIR_COMPILER_LIBRARY_PATH})
+    add_dependencies(TTXLA_TTMLIRCompiler tt-xla)
+    add_library(TTXLA_TTMLIRRuntime SHARED IMPORTED GLOBAL)
+    set_target_properties(TTXLA_TTMLIRRuntime PROPERTIES EXCLUDE_FROM_ALL TRUE IMPORTED_LOCATION ${TTXLA_TTMLIR_RUNTIME_LIBRARY_PATH})
+    add_dependencies(TTXLA_TTMLIRRuntime tt-xla)
+    install(DIRECTORY ${TTXLA_INSTALL_PREFIX}/ DESTINATION "${CMAKE_INSTALL_PREFIX}/tt-xla" USE_SOURCE_PERMISSIONS)
+
 
     # torch-mlir build
     # torch-mlir is using branch tt_torch/main

--- a/tt_torch/__init__.py
+++ b/tt_torch/__init__.py
@@ -7,6 +7,7 @@
 #   - torch tensors cannot be made contiguous in a forked process
 import multiprocessing as mp
 import torch
+from typing import Union
 
 if mp.get_start_method() != "forkserver":
     mp.set_start_method("forkserver", force=True)
@@ -14,9 +15,66 @@ if mp.get_start_method() != "forkserver":
 import os
 import importlib.util
 
-# find the tt-metal directory, it can either be in the venv if installed from a wheel or in the third_party source tree
-package_name = "tt-metal"
-spec = importlib.util.find_spec(package_name)
-if spec is not None:
-    tt_metal_home = os.path.abspath(spec.submodule_search_locations[0])
-    os.environ["TT_METAL_HOME"] = tt_metal_home
+from torch_xla.experimental import plugins
+
+
+class TTPjrtPlugin(plugins.DevicePlugin):
+    def library_path(self):
+        # This is where the pjrt plugin will be located if you've built and installed tt-torch according to the instructions in README.md
+        direct_build_install_path = os.path.join(
+            os.path.dirname(__file__), "../install/tt-xla/lib/pjrt_plugin_tt.so"
+        )
+        if os.path.exists(direct_build_install_path):
+            return direct_build_install_path
+
+        # This is where the pjrt plugin will be located if you've installed the tt-torch wheel in another project environment
+        env_path = os.path.join(
+            os.path.dirname(__file__), "../../../tt-xla/lib/pjrt_plugin_tt.so"
+        )
+        if os.path.exists(env_path):
+            return env_path
+
+        # This is where the pjrt plugin will be located if you've only built and installed the wheel - but you're running your code with the root of the source tree (CI does this)
+        source_path = os.path.join(
+            os.path.dirname(__file__), "../env/venv/tt-xla/lib/pjrt_plugin_tt.so"
+        )
+        if os.path.exists(source_path):
+            return source_path
+
+        assert False, "Could not find pjrt_plugin_tt.so"
+
+
+plugins.register_plugin("TT", TTPjrtPlugin())
+os.environ["XLA_STABLEHLO_COMPILE"] = "1"
+os.environ["PJRT_DEVICE"] = "TT"
+
+
+def set_tt_metal_home(*, device_api: str = None):
+    """
+    This function will correctly set the TT_METAL_HOME directory depending on which device API you use ("tt-xla" or "tt-torch").
+    Each device api has a different underlying tt-metal build that currently cannot be used interchangeably.
+    Parameters:
+        device_api: str | Either "tt-torch" or "tt-xla"
+    """
+    assert device_api in [
+        "tt-xla",
+        "tt-torch",
+    ], f"Invalid device API: {device_api}. Expecting one of ['tt-torch', 'tt-xla']"
+
+    if device_api == "tt-xla":
+        spec = importlib.util.find_spec("tt-xla")
+        assert spec is not None, "tt-xla directory not found"
+        tt_xla_path = os.path.abspath(spec.submodule_search_locations[0])
+        os.environ["TT_METAL_HOME"] = f"{tt_xla_path}/tt-metal"
+    elif device_api == "tt-torch":
+        spec = importlib.util.find_spec("tt-metal")
+        assert spec is not None, "tt-metal directory not found"
+        tt_metal_path = os.path.abspath(spec.submodule_search_locations[0])
+        os.environ["TT_METAL_HOME"] = tt_metal_path
+    else:
+        assert (
+            False
+        ), "device_api should have already been asserted to be one of ['tt_torch', 'tt_xla']"
+
+
+set_tt_metal_home(device_api="tt-torch")


### PR DESCRIPTION
- Compile both tt-xla and tt-mlir
- Add function to configure which the TT_METAL_HOME path depending on which device api the user plans to use

### Ticket
N/A

### Problem description
N/A

### What's changed
- Compile tt-xla as a third party
- add `torch_xla==2.7.0` as a requirement
- Register tt-xla PJRT plugin in `tt_torch/__init__.py`
- Create function to set TT_METAL_HOME based on which device api we are using. Either the default "tt-torch", or "tt-xla"
    - tt-xla installs some objects from tt-metal to itself that are not installed by our build of tt-mlir
    - default = "tt-torch"


### Checklist
- [ ] New/Existing tests provide coverage for changes
