### PR TITLE
Register backend as `tt` #963

### DIFF
--- a/demos/resnet/README.md
+++ b/demos/resnet/README.md
@@ -35,7 +35,7 @@ options = BackendOptions()
 options.compiler_config = cc
 # We didn't provide any explicit device while
 # compiling the model.
-tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
+tt_model = torch.compile(model, backend="tt", dynamic=False, options=options)
 ```
 This causes the model to be compiled onto the default device present in the board. The device acquisition and release get handled automatically.
 
@@ -43,6 +43,7 @@ This causes the model to be compiled onto the default device present in the boar
 This file shows how to split multiple model requests across all available devices on the board using the `DeviceManager` module. The relevant device management code is:
 
 ```Python
+import tt_torch
 from tt_torch.tools.device_manager import DeviceManager
 ...
 def main():
@@ -58,7 +59,7 @@ def main():
         options.compiler_config = cc
         options.device = device # Explicitly compile the model for a specific device
         tt_models.append(
-            torch.compile(model, backend=backend, dynamic=False, options=options)
+            torch.compile(model, backend="tt", dynamic=False, options=options)
         )
     ...
     # Release all acquired devices after use

--- a/demos/resnet/resnet50_data_parallel_async.py
+++ b/demos/resnet/resnet50_data_parallel_async.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_torch
 from tt_torch.tools.utils import CompilerConfig
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from PIL import Image
 from torchvision import transforms
 import torchvision.models as models
@@ -45,7 +46,7 @@ def main():
         options.async_mode = True
 
         tt_models.append(
-            torch.compile(model, backend=backend, dynamic=False, options=options)
+            torch.compile(model, backend="tt", dynamic=False, options=options)
         )
 
     # List of image URLs to be processed

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import torch
+import tt_torch
 from tt_torch.tools.utils import CompilerConfig
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from PIL import Image
 from torchvision import transforms
 import torchvision.models as models
@@ -102,7 +103,7 @@ def main(use_simplified_manager):
         options.devices = [device]
         # Compile the model for each device
         tt_models.append(
-            torch.compile(model, backend=backend, dynamic=False, options=options)
+            torch.compile(model, backend="tt", dynamic=False, options=options)
         )
 
     # List of image URLs to be processed

--- a/demos/resnet/resnet50_demo.py
+++ b/demos/resnet/resnet50_demo.py
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import argparse
 import torch
+import tt_torch
 from tt_torch.tools.utils import CompilerConfig
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from PIL import Image
 from torchvision import transforms
 import torchvision.models as models
@@ -25,7 +26,7 @@ def main(run_default_img):
 
     options = BackendOptions()
     options.compiler_config = cc
-    tt_model = torch.compile(model, backend=backend, dynamic=False, options=options)
+    tt_model = torch.compile(model, backend="tt", dynamic=False, options=options)
 
     headers = ["Top 5 Predictions"]
     topk = 5

--- a/demos/resnet/resnet50_single_vs_multi_device_compare.py
+++ b/demos/resnet/resnet50_single_vs_multi_device_compare.py
@@ -2,8 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import tt_torch
 from tt_torch.tools.utils import CompilerConfig
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from PIL import Image
 from torchvision import transforms
 import torchvision.models as models
@@ -130,7 +131,7 @@ if __name__ == "__main__":
     single_options = BackendOptions()
     single_options.compiler_config = cc
     single_model = torch.compile(
-        model, backend=backend, dynamic=False, options=single_options
+        model, backend="tt", dynamic=False, options=single_options
     )
     print("Compiled model for single device")
     # Execute this once to get the compilation overhead out of the way
@@ -155,7 +156,7 @@ if __name__ == "__main__":
         multi_options.compiler_config = cc
         multi_options.devices = [device]
         multi_models.append(
-            torch.compile(model, backend=backend, dynamic=False, options=multi_options)
+            torch.compile(model, backend="tt", dynamic=False, options=multi_options)
         )
     print("Compiled models for multi device")
     # Execute this once to get the compilation overhead out of the way

--- a/docs/src/controlling.md
+++ b/docs/src/controlling.md
@@ -18,8 +18,9 @@ Instead of using the above environment variables, compiler behavior can be confi
 
 Here is an example of enabling consteval:
 ```py
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from tt_torch.tools.utils import CompilerConfig
+import tt_torch
 import torch
 
 class MyModel(torch.nn.Module):
@@ -37,7 +38,7 @@ cc.consteval_parameters = True # This will enable constant folding on the parame
 
 options = BackendOptions()
 options.compiler_config = cc
-model = torch.compile(model, backend=backend, options=options)
+model = torch.compile(model, backend="tt", options=options)
 
 inputs = ...
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -185,7 +185,6 @@ python demos/resnet/resnet50_demo.py
 
 Once you have your `torch.nn.Module` compile the model:
 ```py
-from tt_torch.dynamo.backend import backend
 import torch
 
 class MyModel(torch.nn.Module):
@@ -197,7 +196,7 @@ class MyModel(torch.nn.Module):
 
 model = MyModel()
 
-model = torch.compile(model, backend=backend)
+model = torch.compile(model, backend="tt")
 
 inputs = ...
 
@@ -209,8 +208,8 @@ outputs = model(inputs)
 Here is an exampe of a small model which adds its inputs running through tt-torch. Try it out!
 
 ```py
-from tt_torch.dynamo.backend import backend
 import torch
+import tt_torch
 
 class AddTensors(torch.nn.Module):
   def forward(self, x, y):
@@ -218,7 +217,7 @@ class AddTensors(torch.nn.Module):
 
 
 model = AddTensors()
-tt_model = torch.compile(model, backend=backend)
+tt_model = torch.compile(model, backend="tt")
 
 x = torch.ones(5, 5)
 y = torch.ones(5, 5)

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -2,9 +2,9 @@
 
 ## Introduction
 
-tt-torch uses the [tt-metal Tracy fork](https://github.com/tenstorrent-metal/tracy) to collect profiling data. Tracy is a single process profiler, and uses a client-server model to trace both host calls and on-device operation performance. tt-torch implements a wrapper called `profile.py` with custom orchestration logic to handle the spawning of the Tracy capture server and the client workload to be profiled, as well as report generation and data postprocessing functionality.
+tt-torch uses the [tt-metal Tracy fork](https://github.com/tenstorrent-metal/tracy) to collect profiling data. Tracy is a single process profiler, and uses a client-server model to trace both host calls and on-device operation performance. tt-torch implements a wrapper called `tt_profile.py` with custom orchestration logic to handle the spawning of the Tracy capture server and the client workload to be profiled, as well as report generation and data postprocessing functionality.
 
-The output of `profile.py` is a CSV report displaying a table of operations executed on device and rich timing, memory usage and configuration data associated with them.
+The output of `tt_profile.py` is a CSV report displaying a table of operations executed on device and rich timing, memory usage and configuration data associated with them.
 
 Note: Paths in this document are given relative to the repo root.
 
@@ -14,17 +14,17 @@ In the tt-torch building step ([Getting Started](https://docs.tenstorrent.com/tt
 
 ## Usage
 
-The `profile.py` tool is the recommended entrypoint for profiling workloads in tt-torch.
+The `tt_profile.py` tool is the recommended entrypoint for profiling workloads in tt-torch.
 
 ```
-profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
+tt_profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
 ```
 **Note: The `test_command` must be quoted!**
 
 
-As a minimal example, the following command will run and profile the MNIST test:
+As a minimal example, the following command will run and tt_profile the MNIST test:
 ```
-python tt_torch/tools/profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
+python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
 ```
 
 The report is created at `results/perf/device_ops_perf_trace.csv` by default, unless an output path is specified.
@@ -43,4 +43,4 @@ The report is created at `results/perf/device_ops_perf_trace.csv` by default, un
     - Tracy uses a client-server model to communicate profiling data between the Tracy capture server and the client being profiled.
     - Communication between client and server is done on a given port (default: 8086) as specified with the `-p` option.
     - If there are multiple tracy clients/server processes active at once or previous processes are left dangling, or other processes on host occupying port 8086, there may be contention and unexpected behaviour including capture server timeouts.
-    - This may be addressed by manually specifying an unused port with the -p option to `profile.py`.
+    - This may be addressed by manually specifying an unused port with the -p option to `tt_profile.py`.

--- a/setup.py
+++ b/setup.py
@@ -182,4 +182,9 @@ setup(
         "ml_dtypes",
     ],
     include_package_data=True,
+    entry_points={
+        "torch_dynamo_backends": [
+            "tt = tt_torch.dynamo.backend:backend",
+        ]
+    },
 )

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -4,9 +4,10 @@
 import pytest
 import torch
 import torch.nn as nn
+import tt_torch
 from tt_torch.tools.device_manager import DeviceManager
 from tt_torch.tools.utils import CompilerConfig
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from transformers.modeling_outputs import (
     CausalLMOutputWithPast,
@@ -85,9 +86,7 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     cc.enable_consteval = True
     cc.consteval_parameters = True
     options.devices = [device1, device2]
-    compiled_model = torch.compile(
-        model, backend=backend, dynamic=False, options=options
-    )
+    compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
     out = compiled_model(**test_input)
     golden = model(**test_input)
     verify_against_golden(

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from torch import nn
 import torch
+import tt_torch
 from tt_torch.tools.utils import CompilerConfig
 from tt_torch.tools.device_manager import DeviceManager
 from tt_torch.tools.verify import verify_against_golden
@@ -34,7 +35,7 @@ def test_pipeline_parallel():
 
     host_model = Basic()
 
-    model = torch.compile(host_model, backend=backend, options=options)
+    model = torch.compile(host_model, backend="tt", options=options)
     x = torch.rand(32, 32)
     y = torch.rand(32, 64)
     calculated = model(x, y)

--- a/tests/torch/test_basic_multiple_execution.py
+++ b/tests/torch/test_basic_multiple_execution.py
@@ -4,7 +4,6 @@
 import torch
 from torch import nn
 import tt_torch
-from tt_torch.dynamo.backend import backend
 
 
 def test_multiple_execution():
@@ -17,7 +16,7 @@ def test_multiple_execution():
             return self.linear(x)
 
     model = Basic()
-    model = torch.compile(model, backend=backend)
+    model = torch.compile(model, backend="tt")
     inputs = torch.randn(32, 32)
 
     for _ in range(10):

--- a/tests/torch/tools/test_profiler.py
+++ b/tests/torch/tools/test_profiler.py
@@ -5,7 +5,7 @@ import pytest
 import tt_torch
 import subprocess
 import os
-from tt_torch.tools.profile import profile
+from tt_torch.tools.tt_profile import tt_profile
 from tt_torch.tools.profile_util import Profiler
 import csv
 
@@ -15,7 +15,7 @@ expected_report_path = f"results/perf/{Profiler.DEFAULT_OUTPUT_FILENAME}"
 
 
 def test_profiler_cli():
-    profiler_command = f'python tt_torch/tools/profile.py "{test_command_add}"'
+    profiler_command = f'python tt_torch/tools/tt_profile.py "{test_command_add}"'
     profiler_subprocess = subprocess.run(profiler_command, shell=True)
 
     # Check return code
@@ -40,7 +40,7 @@ def test_profiler_cli():
 
 
 def test_profiler_module():
-    profile(test_command_add)
+    tt_profile(test_command_add)
 
     assert os.path.exists(
         expected_report_path

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,13 +6,14 @@ import torch
 import pytest
 import requests
 import onnx
+import tt_torch
 from transformers.cache_utils import DynamicCache, _flatten_dynamic_cache
 from onnx.tools import update_model_dims
 import gc
 import onnxruntime
 import numpy as np
 import collections
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from tt_torch.onnx_compile import compile_onnx
 from tt_torch.tools.utils import (
     CompilerConfig,
@@ -319,12 +320,10 @@ class ModelTester:
         # compile forward pass for generative models, the model itself for discriminative
         if self.run_generate:
             model.forward = torch.compile(
-                model.forward, backend=backend, dynamic=False, options=options
+                model.forward, backend="tt", dynamic=False, options=options
             )
         else:
-            model = torch.compile(
-                model, backend=backend, dynamic=False, options=options
-            )
+            model = torch.compile(model, backend="tt", dynamic=False, options=options)
         self.compiled_models.append(model)
         return model
 

--- a/tt_torch/__init__.py
+++ b/tt_torch/__init__.py
@@ -20,3 +20,5 @@ spec = importlib.util.find_spec(package_name)
 if spec is not None:
     tt_metal_home = os.path.abspath(spec.submodule_search_locations[0])
     os.environ["TT_METAL_HOME"] = tt_metal_home
+
+import tt_torch.dynamo.backend

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -7,6 +7,7 @@ import warnings
 import tt_mlir
 import sys
 import torch_mlir
+from torch._dynamo import register_backend
 
 from tt_torch.tools.utils import (
     OpByOpBackend,
@@ -250,6 +251,7 @@ def _base_backend(gm, example_inputs, compiler_config, devices, async_mode):
 
 
 @tt_torch_error_message
+@register_backend(name="tt")
 def backend(gm, example_inputs, options: BackendOptions = None):
     warnings.filterwarnings("ignore", message="Failed to fetch module*")
     assert isinstance(gm, torch.fx.GraphModule), "Backend only supports torch graphs"

--- a/tt_torch/tools/tt_profile.py
+++ b/tt_torch/tools/tt_profile.py
@@ -9,7 +9,7 @@ import sys
 from argparse import ArgumentParser
 
 
-def profile(
+def tt_profile(
     test_command: str,
     output_filename: str = Profiler.DEFAULT_OUTPUT_FILENAME,
     port: int = 8086,
@@ -61,10 +61,10 @@ if __name__ == "__main__":
     gathering device-side performance data associated with individual torchfx ops.
 
     Usage:
-        python profile.py test_command -o output_name
+        python tt_profile.py test_command -o output_name
 
     Examples:
-        python tt_torch/tools/profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
+        python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
 
     Notes:
         Providing an output name is optional and defaults to 'device_ops_perf_trace.csv'."""
@@ -88,4 +88,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    profile(args.test_command, args.output_path, args.port)
+    tt_profile(args.test_command, args.output_path, args.port)

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -12,7 +12,7 @@ from tt_torch.tools.utils import (
     prepare_inference_session,
     run_model_proto,
 )
-from tt_torch.dynamo.backend import backend, BackendOptions
+from tt_torch.dynamo.backend import BackendOptions
 from tt_torch.tools.utils import (
     calculate_atol,
     calculate_pcc,
@@ -28,7 +28,7 @@ def compile_model(model, compiler_config, device, async_mode):
     torch_options.compiler_config = compiler_config
     torch_options.devices = [device]
     torch_options.async_mode = async_mode
-    return torch.compile(model, backend=backend, options=torch_options)
+    return torch.compile(model, backend="tt", options=torch_options)
 
 
 def generate_inputs(input_shapes, input_data_types, input_range, input_range_int):


### PR DESCRIPTION
### Ticket
#963 

### Problem description
Register backend as `tt` so users can simply do:
```
import tt_torch
...
tt_model = torch.compile(..., backend="tt", ...)
```

### Checklist
- [X] Registered backend
- [X] Imported backend in tt_torch
- [X] Updated demos/ tests which use `torch.compile(..., backend=backend, ...)`
