### PR TITLE
Topological Sort of device_map in Pipeline Parallel 

### DIFF
--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -77,7 +77,7 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     # That is, device 1 would need to run rotart_emb, device 0 the full graph, device 1,
     # the remainder of the graph. We should extend the pass to be able to automatically
     # handle this: https://github.com/tenstorrent/tt-torch/issues/779
-    device_map["model.rotary_emb"] = 0
+    # device_map["model.rotary_emb"] = 0
 
     options = BackendOptions()
     cc = CompilerConfig()

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -71,13 +71,6 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     device_map = infer_auto_device_map(
         model, max_memory={0: "8GiB", 1: "8GiB"}, no_split_module_classes=dont_split
     )
-    # The device map shards model chunks based on the order they're defined in the model
-    # not based on the topological order of the graph. We need to move rotary embeddings
-    # to the first device, otherwise we wouldn't be able to execute each device in full.
-    # That is, device 1 would need to run rotart_emb, device 0 the full graph, device 1,
-    # the remainder of the graph. We should extend the pass to be able to automatically
-    # handle this: https://github.com/tenstorrent/tt-torch/issues/779
-    # device_map["model.rotary_emb"] = 0
 
     options = BackendOptions()
     cc = CompilerConfig()

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -42,3 +42,39 @@ def test_pipeline_parallel():
     golden = host_model(x, y)
     verify_against_golden((golden,), (calculated,), True, True, required_atol=0.1)
     DeviceManager.release_parent_device(parent_device, True)
+
+
+def test_pipeline_parallel_topological_sort():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = nn.Linear(32, 32)
+            self.l2 = nn.Linear(64, 32)
+            self.l3 = nn.Linear(32, 32)
+
+        def forward(self, x, y):
+            x = self.l1(x)
+            y = self.l2(y)
+            z = self.l3(y)
+            return x + y + z
+
+    options = BackendOptions()
+    cc = CompilerConfig()
+    options.compiler_config = cc
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    cc.device_map = {"l1": 0, "l2": 1, "l3": 0}
+    parent_device = DeviceManager.create_parent_mesh_device([1, 2])
+    device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
+    device2 = DeviceManager.create_sub_mesh_device(parent_device, (0, 1))
+    options.devices = [device1, device2]
+
+    host_model = Basic()
+
+    model = torch.compile(host_model, backend=backend, options=options)
+    x = torch.rand(32, 32)
+    y = torch.rand(32, 64)
+    calculated = model(x, y)
+    golden = host_model(x, y)
+    verify_against_golden((golden,), (calculated,), True, True, required_atol=0.1)
+    DeviceManager.release_parent_device(parent_device, True)

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -82,7 +82,7 @@ def test_pipeline_parallel_topological_sort():
 
     host_model = Basic()
 
-    model = torch.compile(host_model, backend=backend, options=options)
+    model = torch.compile(host_model, backend="tt", options=options)
     x = torch.rand(32, 32)
     y = torch.rand(32, 64)
     calculated = model(x, y)

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -44,17 +44,16 @@ def test_pipeline_parallel():
     DeviceManager.release_parent_device(parent_device, True)
 
 
-class L3(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.linear = nn.Linear(32, 32)
-
-    def forward(self, a, b):
-        # Example: add the two inputs, then apply linear
-        return self.linear(a + b)
-
-
 def test_pipeline_parallel_topological_sort():
+    class L3(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(32, 32)
+
+        def forward(self, a, b):
+            # Example: add the two inputs, then apply linear
+            return self.linear(a + b)
+
     class Basic(nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -44,26 +44,38 @@ def test_pipeline_parallel():
     DeviceManager.release_parent_device(parent_device, True)
 
 
+class L3(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(32, 32)
+
+    def forward(self, a, b):
+        # Example: add the two inputs, then apply linear
+        return self.linear(a + b)
+
+
 def test_pipeline_parallel_topological_sort():
     class Basic(nn.Module):
         def __init__(self):
             super().__init__()
             self.l1 = nn.Linear(32, 32)
             self.l2 = nn.Linear(64, 32)
-            self.l3 = nn.Linear(32, 32)
+            self.l3 = L3()
+            self.l4 = nn.Linear(32, 32)
 
         def forward(self, x, y):
             x = self.l1(x)
             y = self.l2(y)
-            z = self.l3(y)
-            return x + y + z
+            z = self.l3(x, y)
+            a = self.l4(z)
+            return a
 
     options = BackendOptions()
     cc = CompilerConfig()
     options.compiler_config = cc
     cc.enable_consteval = True
     cc.consteval_parameters = True
-    cc.device_map = {"l1": 0, "l2": 1, "l3": 0}
+    cc.device_map = {"l1": 0, "l2": 1, "l3": 1, "l4": 0}
     parent_device = DeviceManager.create_parent_mesh_device([1, 2])
     device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
     device2 = DeviceManager.create_sub_mesh_device(parent_device, (0, 1))

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -299,6 +299,8 @@ def sort_device_map(gm, compiler_config):
     # - Calculate the cost to move the input vs consumer and choose the cheaper option.
 
     device_map = compiler_config.device_map.copy()
+    device_map_was_modified = False
+
     for node in gm.graph.nodes:
         node_device, _ = node_to_device(node, device_map)
         for input_node in node.all_input_nodes:
@@ -309,6 +311,12 @@ def sort_device_map(gm, compiler_config):
                 and input_device > node_device
             ):
                 device_map = move_device_map_key(gm, input_key, node_device, device_map)
+                device_map_was_modified = True
+
+    if device_map_was_modified:
+        print(
+            "\033[93m\nWARNING: Device map was modified to ensure topological ordering. This may cause memory on earlier devices to become full.\n\033[0m"
+        )
 
     return device_map
 

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -293,6 +293,11 @@ def move_device_map_key(gm, node_key, target_device, device_map, call_stack=None
 
 def sort_device_map(gm, compiler_config):
     # Check that the device map is consistent with topological ordering of the graph module
+    # Current implementation moved inputs to the device of the node that consumes them if
+    # the input is on a later device.
+    # If this causes the first device to become full, an alternative approach could be to
+    # consider moving the consuming node to the device of the input.
+    # - Calculate the cost to move the input vs consumer and choose the cheaper option.
 
     device_map = compiler_config.device_map.copy()
     for node in gm.graph.nodes:

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -262,12 +262,17 @@ def check_device_map(gm, compiler_config):
                 and input_device is not None
                 and input_device > node_device
             ):
-                raise RuntimeError(
-                    f"Device map error: Node '{node.name}' (device {node_device}, map key '{node_key}') "
-                    f"depends on '{input_node.name}' (device {input_device}, map key '{input_key}'), "
-                    "which is assigned to a later device.\n"
-                    f"Check your device_map assignments: {input_key} -> {input_device}, {node_key} -> {node_device}"
-                )
+                # Move the key to the device that depends on it
+                device_map[input_key] = node_device
+
+                # Need to add a check here to see if the change is allowed
+
+                # raise RuntimeError(
+                #     f"Device map error: Node '{node.name}' (device {node_device}, map key '{node_key}') "
+                #     f"depends on '{input_node.name}' (device {input_device}, map key '{input_key}'), "
+                #     "which is assigned to a later device.\n"
+                #     f"Check your device_map assignments: {input_key} -> {input_device}, {node_key} -> {node_device}"
+                # )
 
 
 # The following function splits the graph onto the devices specified in the device_map


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/779

### Problem description
The transformers library infer_auto_device_map sorts modules on separate devices based on where they're defined in the model, not topological order. Thus requiring manual overrides to some modules to allow the graph to execute fully on each device. The pipeline parallel pass should automatically handle this.

### What's changed
The approach to ensure the device_map assigned devices in topological order was to continue to call infer_auto_device_map and then check for any instances when the input to a node (determined by the gm) comes from a later device. If such a case is encountered, then the node providing the input should be moved to the lowest device index that satisfies all its consumers. The inputs to the moved node are recursively checked to ensure moving the node doesn't introduce new issues.

While this approach works for the issue seen in **tests/models/llama/test_llama_7b_pipeline_parallel.py**
it could introduce the possibility of the first device(s) becoming overloaded and running out of memory if the initial device_map is very disorganized. 
This can be seen in **tests/torch/test_basic_multichip.py::test_pipeline_parallel_topological_sort** as all the modules are moved to the first device despite there being alternate device_maps that could work and would be more balanced. 
A possible way to reduce the chance of this happening is mentioned in `sort_device_map()`. I chose not to implement this as it would add complexity that I think is unnecessary unless we encounter this issue. Also, it doesn't guarantee the devices will be balanced.

This is what changed specifically:
- **dynamo/passes.py**
  - `node_to_device()` takes in `key` (default `False`) and `verbose` (default `True`). This allows it to return the key from device_map along with the device if `key=True` and disables the printed warning if `verbose=False`
  - NEW `sort_device_map()` finds nodes that are out of topological order in the device_map and calls `move_device_map_key()` to fix the issue
  - NEW `move_device_map_key()` changes the device_map to assign a new device to the module that is causing an issue. It also moves any inputs to that modules nodes that need to be moved as well
  - `split_onto_devices()` calls `sort_device_map()` before splitting the graph onto the devices
- **tests/torch/test_basic_multichip.py**
  - NEW `test_pipeline_parallel_topological_sort()` tests that incorrect device maps will be fixed (also checks the recursive functionality of `move_device_map_key()`)
- **tests/models/llama/test_llama_7b_pipeline_parallel.py**
  - removed manual change of device_map

### Checklist
- [x] New/Existing tests provide coverage for changes
