### PR TITLE
Benchmark Fixes

### DIFF
--- a/tt_torch/tools/benchmark_promotion.py
+++ b/tt_torch/tools/benchmark_promotion.py
@@ -37,7 +37,11 @@ def enumerate_all_tests(filter_full_eval=True, test_dir="tests/models", dry_run=
         test_cases = re.findall(r"(\S+::\S+)", result.stdout)
 
         return (
-            [tc for tc in test_cases if "full" in tc and "eval" in tc]
+            [
+                tc
+                for tc in test_cases
+                if "full" in tc and "eval" in tc and "data_parallel" not in tc
+            ]
             if filter_full_eval
             else test_cases
         )


### PR DESCRIPTION
### Ticket
None

### Problem description
- Benchmarks do not extract target architecture from a testlist -> For now filter out the data parallel tests which are meant to run on n300
- Benchmarks upload more than 100 artifacts per workflow, and DownloadArtifact's default and non-overridable behaviour is to only download the first 100 before applying the filter. This causes some artifacts to fall outside the download window and not show up in the report. The above change to avoid data parallel tests will reduce the number of generated artifacts so we will come under this limit this week.

### Checklist
- [x] New/Existing tests provide coverage for changes
