### PR TITLE
Add buffer semantics and cross-executor runtime tensor caches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pybind11
 pytest
 pytest-cov
 tabulate
-transformers>=4.50.0
+transformers>=4.50.0,<4.53.0
 protobuf
 tiktoken
 sentencepiece

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -289,6 +289,7 @@ class ModelTester:
 
     def get_golden_outputs(self, model, inputs):
         if self.golden_outputs is not None:
+            print("Reusing cached golden outputs instead of rerunning the model.")
             return self.golden_outputs
 
         self.golden_outputs = self.run_model(model, inputs)

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -37,14 +37,16 @@ class BackendOptions:
         self.constant_cache = constant_cache if constant_cache is not None else {}
 
     def clear_caches(self):
-        # Deallocate runtime tensors when the BackendOptions object is deleted
-        for device_weights in self.constant_cache.keys():
-            for runtime_weight in device_weights.keys():
-                tt_mlir.deallocate_tensor(runtime_weight, force=True)
+        # Deallocate runtime tensors when the BackendOptions object is deleted\
+        if self.constant_cache is not None:
+            for device_weights in self.constant_cache.keys():
+                for runtime_weight in device_weights.keys():
+                    tt_mlir.deallocate_tensor(runtime_weight, force=True)
 
-        for device_buffers in self.buffer_cache.keys():
-            for runtime_buffer in device_buffers.keys():
-                tt_mlir.deallocate_tensor(runtime_buffer, force=True)
+        if self.buffer_cache is not None:
+            for device_buffers in self.buffer_cache.keys():
+                for runtime_buffer in device_buffers.keys():
+                    tt_mlir.deallocate_tensor(runtime_buffer, force=True)
 
     def __del__(self):
         self.clear_caches()

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -118,11 +118,9 @@ def rectify_buffer_inplace_copy(gm):
     for node in gm.graph.nodes:
         if node.op == "call_function" and node.target == torch.ops.aten.copy_.default:
             # Detect inplace copy with buffer destination
-            # destination_node = node.args[0]
-            # if destination_node.op != "get_attr":
-            #     continue
-            # source_node = node.args[1]
-            # output_cache.append(source_node)
+            destination_node = node.args[0]
+            if destination_node.op != "get_attr":
+                continue
             gm.graph.erase_node(node)
     return gm
 

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -353,7 +353,6 @@ def split_onto_devices(gm, compiler_config):
     if len(device_indices) == 0:
         device_indices = [0]
     mcg = MultiChipGraph(device_indices)
-    # gm.graph.print_tabular()
     if len(device_indices) == 1:
         mcg.device_graphs = {0: gm.graph}
         input_index = 0

--- a/tt_torch/dynamo/shlo_backend.py
+++ b/tt_torch/dynamo/shlo_backend.py
@@ -324,7 +324,7 @@ class StablehloExecutor(OpByOpExecutor):
         )
 
         assert (
-            len(mcg.programs) == 0
+            len(mcg.programs) == 1
         ), "SHLO OpbyOpExecutor does not support multichip pipeline parallel execution"
 
         self.program = mcg.programs[0]

--- a/tt_torch/dynamo/torch_backend.py
+++ b/tt_torch/dynamo/torch_backend.py
@@ -207,6 +207,7 @@ class TorchExecutor(OpByOpExecutor):
             if isinstance(mcg.constant_inputs[0], (int, float))
             else tuple(mcg.constant_inputs[0])
         )
+        self.buffers = list(self.mcg.buffers.values())[0]
         if self.compiler_config is None:
             compiler_config = CompilerConfig()
         self.compiler_config = compiler_config
@@ -488,7 +489,7 @@ class TorchExecutor(OpByOpExecutor):
             CompileDepth.COMPILE_OP_BY_OP,
         ):
             return self.run_gm_op_by_op(
-                *(self.graph_constants + tuple(self.program.buffers()) + inputs)
+                *(self.graph_constants + tuple(self.buffers) + inputs)
             )
         else:
             inputs = self.typecast_inputs(inputs)

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -108,6 +108,7 @@ class MultiChipGraph:
         self.programs = {}
         self.binaries = {}
         self.constant_inputs = {}
+        self.buffers = {}
         self.example_inputs = {}
         self.shlo_modules = {}
 


### PR DESCRIPTION
### Ticket
#614 

### Problem description
This PR is the basis for generative models through tt-torch, providing the semantic framework for efficiently expressing inplace static cache updates.

### What's changed
- Express buffer entities "properly", i.e. not as graph constant inputs, but as distinct entities in the mcg and executor treated as tt::argumentType::Input
- Delete illegal aten.copy_ from graphs involving inplace static cache updates
- Move preprocessed_graph_constants runtime tensor cache into a cross-executor scope, so graph constants can be reused between different compiled graphs (i.e. prefill and decode MLP weights)
  - Change this from a flat list to a nested dictionary from device -> torch_tensor_id ->  runtime constant tensor
- Create a cache linking pytorch tensors representing buffers in the FX graph to runtime tensors, so buffers can be reused between same executor invocations and multi-executor runtime stitched workflows (i.e. transfer prefilled kv static caches to decode)
  - This is also a nested dictionary from device -> torch_tensor_id -> runtime buffer tensor
-  Add cache initialization and destruction logic in BackendOptions object, a class that can persist information between multiple executors

### Checklist
- [x] OnPR checks pass including some op-by-op and execution tests. Compile tests still work, with local testing.
- [x] Distilbert multiloop test, which uses runtime-stitched cached graph constants, still works and has no perf difference compared to from before this change. Local testing shows same reuse pattern for preprocessed_graph_constants with new cross-executor cache 