### PR TITLE
Disable PCC check in centernet_onnx, vovnet_onnx and switch back to EfficientNet torch after OnnxModelTester fix

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -189,14 +189,14 @@ jobs:
           # Approximately 70 minutes.
           {
             runs-on: wormhole_b0, name: "eval_9", tests: "
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b0-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b1-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b2-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b3-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b4-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b5-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b6-eval]
-                tests/models/EfficientNet/test_EfficientNet_onnx.py::test_EfficientNet_onnx[full-efficientnet-b7-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b3-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b4-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b5-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b6-eval]
+                tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
                 tests/models/codegen/test_codegen.py::test_codegen[full-eval]
                 tests/models/codegen/test_codegen_generate.py::test_codegen_generate[full-eval]
                 tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]

--- a/tests/models/EfficientNet/test_EfficientNet_onnx.py
+++ b/tests/models/EfficientNet/test_EfficientNet_onnx.py
@@ -73,7 +73,7 @@ def test_EfficientNet_onnx(record_property, model_name, mode, op_by_op):
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=True,
+        assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -41,11 +41,12 @@ def test_centernet_onnx(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = op_by_op
 
+    # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/976
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=True,
-        assert_atol=True,
+        assert_pcc=False,
+        assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
         model_group=model_group,

--- a/tests/models/vovnet/test_vovnet_onnx.py
+++ b/tests/models/vovnet/test_vovnet_onnx.py
@@ -66,10 +66,11 @@ def test_vovnet_onnx(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = op_by_op
 
+    # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/975 (regressed)
     tester = ThisTester(
         model_name,
         mode,
-        assert_pcc=True,
+        assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,


### PR DESCRIPTION
### Ticket
None

### Problem description
Need to revert some recent changes, tests were falsely passing last few weeks due to OnnxModelTester bug. Issues opened for PCC re-enablement

### What's changed
 - Back to efficientnet torch tests (onnx failing) and revert back to assert_pcc=False like before
 - Disable PCC check in test_vovnet_onnx.py
 - Disable PCC/ATOL Checking in test_centernet_onnx.py
 
### Checklist
- [x] Tested locally and on branch CI https://github.com/tenstorrent/tt-torch/actions/runs/15788116944/job/44509212878
