### PR TITLE
Disable perf build as it breaks whl

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -104,7 +104,7 @@ jobs:
     with:
       mlir_override: ${{ github.event.inputs.mlir_override }}
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--build_perf --include-models" #TODO - This should be toggleable?
+      setup-args: "--include-models" #TODO - This should be toggleable?
   test:
     needs: [build, docker-build]
     if: github.event.pull_request.draft == false

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -25,7 +25,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--build_perf --include-models" #TODO - This should be toggleable?
+      setup-args: "--include-models" #TODO - This should be toggleable?
   test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-tests.yml


### PR DESCRIPTION
### Ticket
#950 

### Problem description
libtracy not found when installing wheel in clean venv

### What's changed
Disabled --build-perf in on PR and on push

### Checklist
- [x] New/Existing tests provide coverage for changes
