### PR TITLE
Remove codecov from release builds

### DIFF
--- a/.github/workflows/depth-benchmarks.yml
+++ b/.github/workflows/depth-benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--include-models"
+      setup-args: "--code_coverage --include-models"
   generate-matrix:
     needs: [build]
     uses: ./.github/workflows/generate-benchmark-matrix.yml

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--include-models"
+      setup-args: "--code_coverage --include-models"
   test_op_by_op:
     needs: [docker-build, build]
     uses: ./.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -74,7 +74,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--build_runtime_debug --include-models"
+      setup-args: "--code_coverage --build_runtime_debug --include-models"
       artifact-key: "-debug" # avoid name collision for generated artifact
   test-tools:
     needs: [docker-build, build-debug]

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -104,7 +104,7 @@ jobs:
     with:
       mlir_override: ${{ github.event.inputs.mlir_override }}
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--include-models" #TODO - This should be toggleable?
+      setup-args: "--code_coverage --include-models" #TODO - This should be toggleable?
   test:
     needs: [build, docker-build]
     if: github.event.pull_request.draft == false

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -25,7 +25,15 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      setup-args: "--code_coverage --include-models" #TODO - This should be toggleable?
+  build-release:
+    needs: [pre-commit, spdx, docker-build]
+    uses: ./.github/workflows/run-build.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
       setup-args: "--include-models" #TODO - This should be toggleable?
+      artifact-key: "-release"
   test:
     needs: [build, docker-build]
     uses: ./.github/workflows/run-tests.yml

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -75,7 +75,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        python setup.py bdist_wheel --code_coverage ${{ inputs.setup-args }}
+        python setup.py bdist_wheel ${{ inputs.setup-args }}
 
     - name: Verify tt-mlir SHA override
       if: ${{ inputs.mlir_override }}

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      setup-args: "--include-models"
+      setup-args: "--code_coverage --include-models"
 
   # Just run weekly set of op-by-op tests which are op-by-op models that are already
   # covered in full-model-execute, and in general should remain passing. Don't bother


### PR DESCRIPTION
### Ticket
None

### Problem description
--codecov is passed to our wheel build without a way to disable it. This means our release wheels have codecov baked in, and also all the files inside tt_torch/csrc are built with debug flags on.
  
### What's changed
Create a second wheel build job with --codecov disabled for onPush. Nightly releases are sourced from this install-artifacts-release wheel.

### Checklist
- [x] New/Existing tests provide coverage for changes
