### PR TITLE
Add Falcon3 7B and 10B Pipeline Parallel Tests

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -118,6 +118,8 @@ jobs:
                 tests/models/vit/test_vit_n300.py::test_vit[full-eval]
                 tests/models/segformer/test_segformer_n300.py::test_segformer[full-eval]
                 tests/models/hardnet/test_hardnet_n300.py::test_hardnet[full-eval]
+                tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-7B-Base-eval]
+                tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-10B-Base-eval]
             "
           },
           {

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -118,13 +118,13 @@ jobs:
                 tests/models/vit/test_vit_n300.py::test_vit[full-eval]
                 tests/models/segformer/test_segformer_n300.py::test_segformer[full-eval]
                 tests/models/hardnet/test_hardnet_n300.py::test_hardnet[full-eval]
-                tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-7B-Base-eval]
-                tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-10B-Base-eval]
             "
           },
           {
             runs-on: high-memory-n300, name: "eval_6_highmem_quarantine", tests: "
               tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]
+              tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-7B-Base-eval]
+              tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-10B-Base-eval]
             "
           }
         ]

--- a/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
+++ b/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
@@ -58,13 +58,10 @@ def test_falcon_pipeline_parallel(record_property, model_name, mode, op_by_op):
     dont_split = (
         model._no_split_modules if hasattr(model, "_no_split_modules") else None
     )
-    max_memory = (
-        {0: "10GiB", 1: "10GiB"}
-        if model_name == "tiiuae/Falcon3-10B-Base"
-        else {0: "8GiB", 1: "8GiB"}
-    )
+    # The devices have 12GB of memory each, but we set it to 11GB to ensure
+    # there's enough room for activation tensors and other overhead.
     device_map = infer_auto_device_map(
-        model, max_memory=max_memory, no_split_module_classes=dont_split
+        model, max_memory={0: "11GiB", 1: "11GiB"}, no_split_module_classes=dont_split
     )
 
     options = BackendOptions()

--- a/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
+++ b/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from tests.utils import ModelTester, skip_full_eval_test
+from tt_torch.tools.device_manager import DeviceManager
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from tt_torch.dynamo.backend import BackendOptions
+from accelerate import infer_auto_device_map
+from tt_torch.tools.verify import verify_against_golden
+
+
+def load_model(model_name):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name, padding_side="left", torch_dtype=torch.bfloat16
+    )
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+    for param in model.parameters():
+        param.requires_grad = False
+    return model, tokenizer
+
+
+def load_inputs(tokenizer, prompt):
+    inputs = tokenizer(prompt, return_tensors="pt", return_token_type_ids=False)
+    return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "tiiuae/Falcon3-7B-Base",
+        "tiiuae/Falcon3-10B-Base",
+    ],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+)
+def test_falcon_pipeline_parallel(record_property, model_name, mode, op_by_op):
+    model_group = "red"
+
+    prompt = "Hey, are you conscious? Can you talk to me?"
+    model, tokenizer = load_model(model_name)
+    test_input = load_inputs(tokenizer, prompt)
+    parent_device = DeviceManager.create_parent_mesh_device([1, 2])
+
+    # Create submeshes that target different devices
+    device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
+    device2 = DeviceManager.create_sub_mesh_device(parent_device, (0, 1))
+
+    dont_split = (
+        model._no_split_modules if hasattr(model, "_no_split_modules") else None
+    )
+    device_map = infer_auto_device_map(
+        model, max_memory={0: "8GiB", 1: "8GiB"}, no_split_module_classes=dont_split
+    )
+
+    options = BackendOptions()
+    cc = CompilerConfig()
+    options.compiler_config = cc
+    cc.device_map = device_map
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    options.devices = [device1, device2]
+    compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
+    print(f"Device map: {device_map}")
+
+    out = compiled_model(**test_input)
+    golden = model(**test_input)
+    verify_against_golden(
+        tuple([golden.logits]), tuple([out.logits]), True, False, required_atol=0.1
+    )
+
+    DeviceManager.release_sub_mesh_device(device1)
+    DeviceManager.release_sub_mesh_device(device2)
+    DeviceManager.release_parent_device(parent_device)

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -68,8 +68,10 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     dont_split = (
         model._no_split_modules if hasattr(model, "_no_split_modules") else None
     )
+    # The devices have 12GB of memory each, but we set it to 11GB to ensure
+    # there's enough room for activation tensors and other overhead.
     device_map = infer_auto_device_map(
-        model, max_memory={0: "8GiB", 1: "8GiB"}, no_split_module_classes=dont_split
+        model, max_memory={0: "11GiB", 1: "11GiB"}, no_split_module_classes=dont_split
     )
 
     options = BackendOptions()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -588,8 +588,10 @@ class ModelTester:
         else:
             raise ValueError(f"Current mode is not supported: {self.mode}")
 
-    def filter_nan_inf_for_record(self, metric_key):
-        metric_list = self.record_tag_cache.get(metric_key, [])
+    @staticmethod
+    def filter_nan_inf_for_record(record_tag_cache, metric_key):
+        # Filters record_tag_cache inplace to strip out nan/inf which break serialization and reporting
+        metric_list = record_tag_cache.get(metric_key, [])
         if metric_list:
             metric_list = [
                 -1
@@ -606,12 +608,13 @@ class ModelTester:
                 for x in metric_list
                 if isinstance(x, (int, float)) or isinstance(x, str)
             ]
-        self.record_tag_cache[metric_key] = metric_list
+        record_tag_cache[metric_key] = metric_list
 
-    def record_aggregate_model_metric(self, metric_key, default_value=-1):
+    @staticmethod
+    def record_aggregate_model_metric(record_tag_cache, metric_key, default_value=-1):
         # read a metric from the tag cache and write out the average and min values
 
-        metric_list = self.record_tag_cache.get(metric_key, [])
+        metric_list = record_tag_cache.get(metric_key, [])
         avg_metric = default_value
         min_metric = default_value
         max_metric = default_value
@@ -627,11 +630,12 @@ class ModelTester:
             min_metric = min(filtered_metrics)
             max_metric = max(filtered_metrics)
 
-        self.record_tag_cache["avg_" + metric_key] = avg_metric
-        self.record_tag_cache["min_" + metric_key] = min_metric
-        self.record_tag_cache["max_" + metric_key] = max_metric
+        record_tag_cache["avg_" + metric_key] = avg_metric
+        record_tag_cache["min_" + metric_key] = min_metric
+        record_tag_cache["max_" + metric_key] = max_metric
 
-    def remap_compile_depth(self, compile_depth, min_pcc):
+    @staticmethod
+    def remap_compile_depth(compile_depth, min_pcc, required_pcc):
         compile_depth_translation_table = {
             CompileDepth.TORCH_FX: "FAILED_TTMLIR_COMPILATION",
             CompileDepth.STABLEHLO: "FAILED_RUNTIME",
@@ -644,7 +648,7 @@ class ModelTester:
         if compile_depth is not CompileDepth.EXECUTE:
             return compile_depth_translation_table[compile_depth]
 
-        return "PASSED" if min_pcc >= self.required_pcc else "INCORRECT_RESULT"
+        return "PASSED" if min_pcc >= required_pcc else "INCORRECT_RESULT"
 
     def flush_tag_cache_to_record(self):
         # record the tags property at the very end of the test as data may
@@ -655,11 +659,11 @@ class ModelTester:
     def finalize(self):
         # to be called at the end of the test
 
-        self.filter_nan_inf_for_record("pccs")
-        self.filter_nan_inf_for_record("atols")
+        filter_nan_inf_for_record(self.record_tag_cache, "pccs")
+        filter_nan_inf_for_record(self.record_tag_cache, "atols")
 
-        self.record_aggregate_model_metric("pccs")
-        self.record_aggregate_model_metric("atols")
+        record_aggregate_model_metric(self.record_tag_cache, "pccs")
+        record_aggregate_model_metric(self.record_tag_cache, "atols")
 
         # FE standardization - pack a single PCC & ATOL into the tag record
         # use cached metrics. Guaranteed to be init'd to the default value
@@ -668,11 +672,11 @@ class ModelTester:
 
         # Compile depth is remapped post-execution to FE-standardized format
         # based on actual execution result.
-        self.record_tag_cache["bringup_status"] = self.remap_compile_depth(
-            self.compiler_config.compile_depth, self.record_tag_cache["min_pccs"]
+        self.record_tag_cache["bringup_status"] = remap_compile_depth(
+            self.compiler_config.compile_depth, self.record_tag_cache["min_pccs"], self.required_pcc
         )
 
-        self.flush_tag_cache_to_record()
+        flush_tag_cache_to_record(self.record_tag_cache)
 
     def verify_intermediates_after_execution(self):
         # Prepare CSV output
@@ -758,20 +762,77 @@ class ModelTester:
             print_fn(results)
 
     def get_parallelism(self):
+        return _get_parallelism(self.data_parallel_mode, self.compiler_config.automatic_parallelization)
+    
+    @staticmethod
+    def _get_parallelism(data_parallel_mode, automatic_parallelization):
         parallelism = "single_device"
 
         assert not (
-            self.data_parallel_mode and self.compiler_config.automatic_parallelization
+            data_parallel_mode and automatic_parallelization
         ), "Cannot use runtime data parallel and automatic data parallel settings at the same time."
 
-        if self.data_parallel_mode:
+        if data_parallel_mode:
             parallelism = "runtime_data_parallel"
 
-        if self.compiler_config.automatic_parallelization:
+        if automatic_parallelization:
             parallelism = "data_parallel"
 
         return parallelism
 
+    @staticmethod
+    def GenerateCustomTestReport(record_property, model_name, compiler_config,  test_pcc, test_atol, model_group="generality",required_pcc=0.99, required_atol=None, relative_atol=None, assert_pcc=True, assert_atol=True, data_parallel_mode=False, automatic_parallelization=False):
+        '''
+        Test reporting is tightly coupled to the ModelTester, under the assumption that almost all
+        tests go through the ModelTester. For those tests that do not go through the ModelTester,
+        this function can be used to generate a custom test report.
+        
+        It imitates the mechanics of ModelTester.finalize() and ModelTester ctor
+        '''
+        record_tag_cache = {}  # Holds for tags to be written out at finalize()
+
+        record_property("model_name", model_name)
+        record_property("frontend", "tt-torch")
+        record_property("owner", "tt-torch")
+        record_property("group", model_group)
+
+        record_tag_cache["note"] = "Using custom test report generation path, not tt-torch ModelTester."
+        record_tag_cache["required_pcc"] = required_pcc
+
+        record_tag_cache["required_atol"] = (
+            required_atol if required_atol is not None else relative_atol
+        )
+
+        record_tag_cache["is_asserting_pcc"] = assert_pcc
+        record_tag_cache["is_asserting_atol"] = assert_atol
+        
+        record_tag_cache["parallelism"] = _get_parallelism(data_parallel_mode, automatic_parallelization)
+
+        # configs should be set at test start, so they can be flushed immediately
+        record_property(
+            "config",
+            {"compiler_config": compiler_config.to_dict()},
+        )
+        
+        filter_nan_inf_for_record(record_tag_cache, "pccs")
+        filter_nan_inf_for_record(record_tag_cache, "atols")
+
+        record_aggregate_model_metric(record_tag_cache, "pccs")
+        record_aggregate_model_metric(record_tag_cache, "atols")
+
+        # FE standardization - pack a single PCC & ATOL into the tag record
+        # use cached metrics. Guaranteed to be init'd to the default value
+        record_tag_cache["pcc"] = record_tag_cache["min_pccs"]
+        record_tag_cache["atol"] = record_tag_cache["max_atols"]
+
+        # Compile depth is remapped post-execution to FE-standardized format
+        # based on actual execution result.
+        record_tag_cache["bringup_status"] = remap_compile_depth(
+            compile_depth, record_tag_cache["min_pccs"], required_pcc
+        )
+
+        record_property("tags", record_tag_cache)
+        
 
 # TODO - hshahTT: Add support for data parallel mode for onnx models
 class OnnxModelTester(ModelTester):

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -328,18 +328,10 @@ def split_onto_devices(gm, compiler_config):
 
     device_indices = set(compiler_config.device_map.values())
 
-    # If "disk" is in the device indices, throw warning and move it's modules to the last device
-    # Moving all disk modules to the last device may cause the last device to become full,
-    #  - in some cases increasing the max_memory per device may help
-    if "disk" in device_indices:
-        print(
-            "\033[93m\nWARNING: 'disk' device found in device_map. This may cause memory on later devices to become full. \nIf an out of memory error occurs, consider increasing max_memory per device -- infer_auto_device_map may not fully utilize available device memory.\n\033[0m"
-        )
-        device_indices.discard("disk")
-        highest_device = len(device_indices) - 1
-        for key, value in compiler_config.device_map.items():
-            if value == "disk":
-                compiler_config.device_map[key] = highest_device
+    # If "disk" is in the device indices, assert that the model is too large for the available devices
+    assert (
+        "disk" not in device_indices
+    ), f"Model too large for {len(device_indices) - 1} devices. Consider increasing max_memory per device to 12GiB"
 
     if len(device_indices) == 0:
         device_indices = [0]


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/922 

### Problem description
Add N300 pipeline parallel tests for falcon 3 models that don't fit on one device.

### What's changed
Added pipeline parallel tests for falcon3 7B and 10B. 

**Issue**: The 10B model introduced a new error where `infer_auto_device_map()` assigns modules to device `"disk"` when it estimates devices 0 and 1 will be full. This causes `split_onto_devices()` to fail since it expects only integer device assignments. Additionally, manual changes to `device_map` proved that this model can fit on 2 devices and so the prediction that device 0 and 1 will be full is not always correct.

[EDIT]: This has changed to be a much simpler solution, see comment below

**Solution**: Added logic to `split_onto_devices()` that:
1. Moves all `"disk"` modules to the last device in `device_map`
2. Warns user that this change may cause OOM error and suggests increasing the `max_memory` per device if needed

This approach is a simple solution that allows the device map to be balanced by manually increasing the max_memory. The added test shows this by using higher `max_memory` values (10GiB vs 8GiB) for the 10B model to create a more balanced device map which allows the test to pass.

**Alternate approach**: Balance `device_map` in the pass instead of manually changing `max_memory`. If this approach is preferred I can make an issue to implement it and could work on that next.

[EDIT]: A self contained path to creating a junitxml report for tests that bypass the ModelTester was also added, which extracts the common logic from ModelTester report generation and exposes it as a new static function ModelTester.GenerateCustomTestReport 

Summary:
- **tt-torch/backend/passes.py**
  - move modules assigned to `"disk"` to the last device
  - warn user that increasing max_memory might be necessary
- **tests/falcon/test_falcon3_7b_10b_pipeline_parallel.py**
  - replicates format of **tests/llama/test_llama_7b_pipeline_parallel.py**
  - Falcon3 10B `max_memory` increased to 10GiB per device
- **.github/workflows/run-full-model-execution-tests.yml**
  - added tests to on-pr high-mem quarantine since they fail on lower memory n300s (same as the llama test)
 

### Checklist
- [x] New/Existing tests provide coverage for changes
