### PR TITLE
Update 5 Models from tt-forge-models

### DIFF
--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -3,23 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 import pytest
-from gliner import GLiNER
 from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.gliner.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = GLiNER.from_pretrained("urchade/gliner_largev2")
-        return model.predict_entities
+        return ModelLoader.load_model()
 
     def _load_inputs(self):
-        text = """
-        Cristiano Ronaldo dos Santos Aveiro (Portuguese pronunciation: [kɾiʃˈtjɐnu ʁɔˈnaldu]; born 5 February 1985) is a Portuguese professional footballer who plays as a forward for and captains both Saudi Pro League club Al Nassr and the Portugal national team. Widely regarded as one of the greatest players of all time, Ronaldo has won five Ballon d'Or awards,[note 3] a record three UEFA Men's Player of the Year Awards, and four European Golden Shoes, the most by a European player. He has won 33 trophies in his career, including seven league titles, five UEFA Champions Leagues, the UEFA European Championship and the UEFA Nations League. Ronaldo holds the records for most appearances (183), goals (140) and assists (42) in the Champions League, goals in the European Championship (14), international goals (128) and international appearances (205). He is one of the few players to have made over 1,200 professional career appearances, the most by an outfield player, and has scored over 850 official senior career goals for club and country, making him the top goalscorer of all time.
-        """
-
-        labels = ["person", "award", "date", "competitions", "teams"]
-        return (text, labels)
+        return ModelLoader.load_inputs()
 
 
 @pytest.mark.parametrize(

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -58,6 +58,7 @@ def test_gliner(record_property, mode, op_by_op):
 
     entities = tester.test_model()
     if mode == "eval":
-        for entity in entities:
-            print(entity["text"], "=>", entity["label"])
+        for batch_entities in entities:
+            for entity in batch_entities:
+                print(entity["text"], "=>", entity["label"])
     tester.finalize()

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -15,7 +15,9 @@ class ThisTester(ModelTester):
         return ModelLoader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        inputs = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        self.image = ModelLoader.image
+        return inputs
 
 
 @pytest.mark.parametrize(

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -4,28 +4,18 @@
 import torch
 import numpy as np
 from PIL import Image
-from transformers import GLPNImageProcessor, GLPNForDepthEstimation
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.tools.utils import get_file
+from third_party.tt_forge_models.glpn_kitti.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        self.processor = GLPNImageProcessor.from_pretrained("vinvino02/glpn-kitti")
-        model = GLPNForDepthEstimation.from_pretrained(
-            "vinvino02/glpn-kitti", torch_dtype=torch.bfloat16
-        )
-        return model
+        return ModelLoader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        self.image = Image.open(str(image_file))
-        # prepare image for the model
-        inputs = self.processor(images=self.image, return_tensors="pt")
-        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
-        return inputs
+        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -3,34 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://huggingface.co/docs/transformers/v4.44.2/en/model_doc/gpt_neo#overview
 
-from transformers import GPTNeoForCausalLM, GPT2Tokenizer, GenerationConfig
 import pytest
 from tests.utils import ModelTester
 import torch
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.gpt_neo.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = GPTNeoForCausalLM.from_pretrained(
-            "EleutherAI/gpt-neo-125M", torch_dtype=torch.bfloat16
-        )
-        self.tokenizer = GPT2Tokenizer.from_pretrained("EleutherAI/gpt-neo-125M")
-        return model
+        return ModelLoader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        prompt = (
-            "In a shocking finding, scientists discovered a herd of unicorns living in a remote, "
-            "previously unexplored valley, in the Andes Mountains. Even more surprising to the "
-            "researchers was the fact that the unicorns spoke perfect English."
-        )
-
-        input_ids = self.tokenizer(prompt, return_tensors="pt").input_ids
-        generation_config = GenerationConfig(
-            max_length=100, do_sample=True, temperature=0.9
-        )
-        arguments = {"input_ids": input_ids, "generation_config": generation_config}
-        return arguments
+        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -65,8 +50,6 @@ def test_gpt_neo(record_property, mode, op_by_op):
     )
     results = tester.test_model()
     if mode == "eval":
-        logits = results.logits if hasattr(results, "logits") else results[0]
-        token_ids = torch.argmax(logits, dim=-1)
-        gen_text = tester.tokenizer.batch_decode(token_ids, skip_special_tokens=True)[0]
+        gen_text = ModelLoader.decode_output(results)
 
     tester.finalize()

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -4,47 +4,20 @@
 # Reference: https://pytorch.org/hub/pytorch_vision_hardnet/
 # Reference: https://github.com/PingoLH/Pytorch-HarDNet
 
-from PIL import Image
-from torchvision import transforms
-import requests
+
 import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
-        model = torch.hub.load("PingoLH/Pytorch-HarDNet", "hardnet68", pretrained=False)
-        checkpoint = "https://github.com/PingoLH/Pytorch-HarDNet/raw/refs/heads/master/hardnet68.pth"
-        model.load_state_dict(
-            torch.hub.load_state_dict_from_url(
-                checkpoint, progress=False, map_location="cpu"
-            )
-        )
-        model = model.to(torch.bfloat16)
-        return model
+        return ModelLoader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
-        input_image = Image.open(requests.get(url, stream=True).raw)
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(
-            0
-        )  # create a mini-batch as expected by the model
-        input_batch = input_batch.to(torch.bfloat16)
-        return input_batch
+        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/hardnet/test_hardnet_n300.py
+++ b/tests/models/hardnet/test_hardnet_n300.py
@@ -4,47 +4,20 @@
 # Reference: https://pytorch.org/hub/pytorch_vision_hardnet/
 # Reference: https://github.com/PingoLH/Pytorch-HarDNet
 
-from PIL import Image
-from torchvision import transforms
-import requests
+
 import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
-        model = torch.hub.load("PingoLH/Pytorch-HarDNet", "hardnet68", pretrained=False)
-        checkpoint = "https://github.com/PingoLH/Pytorch-HarDNet/raw/refs/heads/master/hardnet68.pth"
-        model.load_state_dict(
-            torch.hub.load_state_dict_from_url(
-                checkpoint, progress=False, map_location="cpu"
-            )
-        )
-        model = model.to(torch.bfloat16)
-        return model
+        return ModelLoader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
-        input_image = Image.open(requests.get(url, stream=True).raw)
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-                ),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = torch.stack(
-            [input_tensor] * 32
-        )  # create a mini-batch as expected by the model
-        input_batch = input_batch.to(torch.bfloat16)
-        return input_batch
+        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
 
 
 @pytest.mark.parametrize(

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "9fff722ad84cd0e63964fe1194c5f697bd85ac92")
+    set(TT_FORGE_MODELS_VERSION "3b8b567bb82f8dd573adc6d6ca819fa3d32b7c62")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "677d7ac45eec8afab0997b519504990f9892d4a7")
+    set(TT_FORGE_MODELS_VERSION "9fff722ad84cd0e63964fe1194c5f697bd85ac92")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
#920 

### Problem description
Move model implementation from tt-torch into tt-forge-models repo

### What's changed
- Update version of tt-forge-models in **third_party/CMakeLists.txt**
- Update flan_t5, glider, glen-kitti, gpt-neo and hardnet models to import from tt-forge-models
- Passed in optional `batch_size=1` argument to each `load_inputs()` function for these 5 models

### Checklist
- [x] New/Existing tests provide coverage for changes
