### PR TITLE
Fix OnnxModelTester -> ModelTester init missing new loader arg from prev commit (onnx model fails in nightly)

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -43,6 +43,7 @@ jobs:
                   tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[full-eval]
                   tests/models/yolov3/test_yolov3.py::test_yolov3[full-eval]
                   tests/models/yolov4/test_yolov4.py::test_yolov4[full-eval]
+                  tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
             "
           },
           {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -782,6 +782,7 @@ class OnnxModelTester(ModelTester):
         self,
         model_name,
         mode,
+        loader=None,
         required_pcc=0.99,
         required_atol=None,
         relative_atol=None,
@@ -800,6 +801,7 @@ class OnnxModelTester(ModelTester):
         super().__init__(
             model_name,
             mode,
+            loader,
             required_pcc,
             required_atol,
             relative_atol,


### PR DESCRIPTION
### Ticket
None

### Problem description
 - The few onnx tests we have are failing with "AttributeError: 'bool' object has no attribute 'model_name'"  or "AssertionError: Exactly one of required_atol or relative_atol should be provided."
 - It's due to change yesterday to add optional "loader" arg to ModelTester's init function but missed an update.

### What's changed
 - Fix missing argument in ModelTester init call from OnnxModelTester init
 - And add a 10 second onnx test to onPR/onPush list for coverage, was only caught in nightly

### Checklist
- [x] Tested all onnx tests locally, passing now
