### PR TITLE
Pin transformers to <4.53.0 due to CI break for llama and mistral tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pybind11
 pytest
 pytest-cov
 tabulate
-transformers>=4.50.0
+transformers>=4.50.0,<4.53.0
 protobuf
 tiktoken
 sentencepiece


### PR DESCRIPTION
### Ticket
None

### Problem description
Transformers python package updated from 4.52.4 to 4.53.0 on June 26 12PM EST, which caused failures in graph tracing for llama and mistral models in onPR checks. 

### What's changed
Pin transformers to < 4.53.0

### Checklist
- [ ] New/Existing tests provide coverage for changes
