### PR TITLE
Update to latest tt-forge-models to get ModelLoader instance change and get_model_info() and fix centernet variant

### DIFF
--- a/results/parse_op_by_op_results.py
+++ b/results/parse_op_by_op_results.py
@@ -692,9 +692,8 @@ def generate_op_reports_xlsx():
 
         # Dirty-ish Workaround. Model names are quite long w/ get_model_info() so
         # explicitly remove some known frameworks which are at the start of the name
-        model_name = model_name.replace("pytorch_", "")
-        model_name = model_name.replace("jax_", "")
-        model_name = model_name.replace("numpy_", "")
+        for prefix in ("pytorch_", "jax_", "numpy_", "onnx_"):
+            model_name = model_name.removeprefix(prefix)
 
         # If invalid excel char in name: []:*?/\, replace with _
         model_name = re.sub(r"[^a-zA-Z0-9_]", "_", model_name)

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -13,10 +13,10 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -31,8 +31,6 @@ class ThisTester(ModelTester):
 def test_autoencoder_linear(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    model_name = "Autoencoder (linear)"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -41,8 +39,16 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_info.name,
+        mode,
+        loader=loader,
+        model_info=model_info,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 

--- a/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
@@ -13,10 +13,10 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
 
 
 @pytest.mark.parametrize(
@@ -31,8 +31,6 @@ class ThisTester(ModelTester):
 def test_autoencoder_linear(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    model_name = "Autoencoder (linear)"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -44,8 +42,16 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_info.name,
+        mode,
+        loader=loader,
+        model_info=model_info,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
 

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -53,7 +53,7 @@ def test_bloom(record_property, mode, op_by_op):
     results = tester.test_model()
 
     if mode == "eval":
-        decoded_output = ModelLoader.decode_output(results)
+        decoded_output = loader.decode_output(results)
 
         print(f"model_name: {model_name}")
         for i, (inp, out) in enumerate(zip(ModelLoader.test_input, decoded_output)):

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -12,10 +12,10 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_bloom(record_property, mode, op_by_op):
-    model_name = "Bloom"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -38,9 +36,14 @@ def test_bloom(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         relative_atol=0.01,
         assert_pcc=True,
         assert_atol=False,

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -55,7 +55,7 @@ def test_bloom(record_property, mode, op_by_op):
     if mode == "eval":
         decoded_output = loader.decode_output(results)
 
-        print(f"model_name: {model_name}")
+        print(f"model_name: {model_info.name}")
         for i, (inp, out) in enumerate(zip(ModelLoader.test_input, decoded_output)):
             print(f"input {i}: {inp}\noutput {i}: {out}\n")
 

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -13,11 +13,11 @@ class ThisTester(OnnxModelTester):
         The model is from https://github.com/xingyizhou/CenterNet
         """
         # Model
-        return ModelLoader.load_model()
+        return self.loader.load_model()
 
     def _load_torch_inputs(self):
         # Images
-        return ModelLoader.load_inputs()
+        return self.loader.load_inputs()
 
 
 @pytest.mark.parametrize(
@@ -30,9 +30,6 @@ class ThisTester(OnnxModelTester):
     ids=["op_by_op_stablehlo", "full"],
 )
 def test_centernet_onnx(record_property, mode, op_by_op):
-    model_name = "CENTERNET_ONNX"
-    model_group = "red"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -41,15 +38,19 @@ def test_centernet_onnx(record_property, mode, op_by_op):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = op_by_op
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/976
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group=model_group,
     )
     results = tester.test_model()
 

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -9,15 +9,10 @@ from third_party.tt_forge_models.centernet.pytorch import ModelLoader
 
 class ThisTester(OnnxModelTester):
     def _load_model(self):
-        """
-        The model is from https://github.com/xingyizhou/CenterNet
-        """
-        # Model
-        return self.loader.load_model()
+        return self.loader.load_model(variant_name="resdcn18_od")
 
     def _load_torch_inputs(self):
-        # Images
-        return self.loader.load_inputs()
+        return self.loader.load_inputs(variant_name="resdcn18_od")
 
 
 @pytest.mark.parametrize(

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -10,10 +10,10 @@ from third_party.tt_forge_models.clip.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
 
     def set_inputs_train(self, inputs):
         inputs["pixel_values"].requires_grad_(True)
@@ -49,7 +49,6 @@ class ThisTester(ModelTester):
 def test_clip(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    model_name = "CLIP"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -59,9 +58,14 @@ def test_clip(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -12,12 +12,12 @@ from third_party.tt_forge_models.codegen.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = ModelLoader.load_model(dtype_override=torch.bfloat16)
-        self.tokenizer = ModelLoader.tokenizer
+        model = self.loader.load_model(dtype_override=torch.bfloat16)
+        self.tokenizer = self.loader.tokenizer
         return model
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
 
 
 @pytest.mark.parametrize(
@@ -30,16 +30,20 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_codegen(record_property, mode, op_by_op):
-    model_name = "codegen"
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
         run_generate=False,

--- a/tests/models/codegen/test_codegen_generate.py
+++ b/tests/models/codegen/test_codegen_generate.py
@@ -56,7 +56,7 @@ def test_codegen_generate(record_property, mode, op_by_op):
     )  # don't validate token output
 
     if mode == "eval":
-        decoded_outputs = ModelLoader.decode_outputs(results)
+        decoded_outputs = loader.decode_outputs(results)
         for i, text in enumerate(decoded_outputs):
             print(f"Output {i}: {text}")
 

--- a/tests/models/codegen/test_codegen_generate.py
+++ b/tests/models/codegen/test_codegen_generate.py
@@ -12,12 +12,12 @@ from third_party.tt_forge_models.codegen.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = ModelLoader.load_model(dtype_override=torch.bfloat16)
-        self.tokenizer = ModelLoader.tokenizer
+        model = self.loader.load_model(dtype_override=torch.bfloat16)
+        self.tokenizer = self.loader.tokenizer
         return model
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=2)
 
 
 @pytest.mark.parametrize(
@@ -30,16 +30,20 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_codegen_generate(record_property, mode, op_by_op):
-    model_name = "codegen_generate"
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
         is_token_output=True,

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -52,6 +52,6 @@ def test_flan_t5(record_property, mode, op_by_op):
     )
     results = tester.test_model()
     if mode == "eval":
-        results = ModelLoader.decode_output(results)
+        results = loader.decode_output(results)
 
     tester.finalize()

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -12,10 +12,10 @@ from third_party.tt_forge_models.flan_t5.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_flan_t5(record_property, mode, op_by_op):
-    model_name = "FLAN-T5"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -38,9 +36,14 @@ def test_flan_t5(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
         assert_pcc=False,

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -5,15 +5,15 @@ import torch
 import pytest
 from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.gliner.pytorch import ModelLoader
+from third_party.tt_forge_models.gliner_model.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model()
+        return self.loader.load_model()
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs()
+        return self.loader.load_inputs()
 
 
 @pytest.mark.parametrize(
@@ -26,9 +26,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_gliner(record_property, mode, op_by_op):
-    model_name = "gliner-v2"
-    model_group = "red"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -37,14 +34,18 @@ def test_gliner(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         assert_pcc=False,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,
-        model_group=model_group,
     )
 
     skip_full_eval_test(

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -51,10 +51,10 @@ def test_gliner(record_property, mode, op_by_op):
     skip_full_eval_test(
         record_property,
         cc,
-        model_name,
+        model_info.name,
         bringup_status="FAILED_TTMLIR_COMPILATION",
         reason="moreh_softmax_device_operation.cpp Inputs must be of bfloat16 or bfloat8_b type - https://github.com/tenstorrent/tt-torch/issues/732",
-        model_group=model_group,
+        model_group=model_info.group,
     )
 
     entities = tester.test_model()

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -12,11 +12,11 @@ from third_party.tt_forge_models.glpn_kitti.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        inputs = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
-        self.image = ModelLoader.image
+        inputs = self.loader.load_inputs(dtype_override=torch.bfloat16)
+        self.image = self.loader.image
         return inputs
 
 
@@ -30,8 +30,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_glpn_kitti(record_property, mode, op_by_op):
-    model_name = "GLPN-KITTI"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -40,9 +38,14 @@ def test_glpn_kitti(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         relative_atol=0.013,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -53,6 +53,6 @@ def test_gpt_neo(record_property, mode, op_by_op):
     )
     results = tester.test_model()
     if mode == "eval":
-        gen_text = ModelLoader.decode_output(results)
+        gen_text = loader.decode_output(results)
 
     tester.finalize()

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -12,10 +12,10 @@ from third_party.tt_forge_models.gpt_neo.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_gpt_neo(record_property, mode, op_by_op):
-    model_name = "GPTNeo"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -38,9 +36,14 @@ def test_gpt_neo(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
         required_pcc=0.98,

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -14,10 +14,10 @@ from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -35,7 +35,6 @@ class ThisTester(ModelTester):
 def test_hardnet(record_property, mode, op_by_op, data_parallel_mode):
     if mode == "train":
         pytest.skip()
-    model_name = "HardNet"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -47,9 +46,14 @@ def test_hardnet(record_property, mode, op_by_op, data_parallel_mode):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         required_pcc=0.98,
         relative_atol=0.01,
         compiler_config=cc,

--- a/tests/models/hardnet/test_hardnet_n300.py
+++ b/tests/models/hardnet/test_hardnet_n300.py
@@ -14,10 +14,10 @@ from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
 
 
 @pytest.mark.parametrize(
@@ -32,7 +32,6 @@ class ThisTester(ModelTester):
 def test_hardnet(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    model_name = "HardNet"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -45,9 +44,14 @@ def test_hardnet(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         required_pcc=0.98,
         relative_atol=0.01,
         compiler_config=cc,

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -9,10 +9,10 @@ from third_party.tt_forge_models.oft.pytorch import ModelLoader
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model()
+        return self.loader.load_model()
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs()
+        return self.loader.load_inputs()
 
 
 @pytest.mark.parametrize(

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -27,8 +27,6 @@ class ThisTester(ModelTester):
 def test_oft(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()
-    model_name = "OFT"
-    model_group = "red"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -38,22 +36,26 @@ def test_oft(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     skip_full_eval_test(
         record_property,
         cc,
-        model_name,
+        model_info.name,
         bringup_status="FAILED_RUNTIME",
         reason="Out of Memory: Not enough space to allocate 2902982656 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-torch/issues/727",
-        model_group=model_group,
+        model_group=model_info.group,
     )
 
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         assert_atol=False,
         record_property_handle=record_property,
-        model_group=model_group,
     )
 
     results = tester.test_model()

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -11,14 +11,14 @@ from third_party.tt_forge_models.tools.utils import get_file
 
 
 class ThisTester(ModelTester):
-    # pass model_info instead of model_name
-    def __init__(self, model_info, mode, *args, **kwargs):
+    # pass model_info_tuple instead of model_name
+    def __init__(self, model_info_tuple, mode, *args, **kwargs):
         # model name in model_info[0]
-        self.model_info = model_info
-        super().__init__(model_info[0], mode, *args, **kwargs)
+        self.model_info_tuple = model_info_tuple
+        super().__init__(model_info_tuple[0], mode, *args, **kwargs)
 
     def _load_model(self):
-        model_name, weights_name = self.model_info
+        model_name, weights_name = self.model_info_tuple
         self.weights = getattr(models, weights_name).DEFAULT
         model = models.get_model(model_name, weights=self.weights).to(torch.bfloat16)
         return model

--- a/tests/models/torchvision/test_torchvision_image_classification_n300.py
+++ b/tests/models/torchvision/test_torchvision_image_classification_n300.py
@@ -11,14 +11,14 @@ from third_party.tt_forge_models.tools.utils import get_file
 
 
 class ThisTester(ModelTester):
-    # pass model_info instead of model_name
-    def __init__(self, model_info, mode, *args, **kwargs):
+    # pass model_info_tuple instead of model_name
+    def __init__(self, model_info_tuple, mode, *args, **kwargs):
         # model name in model_info[0]
-        self.model_info = model_info
-        super().__init__(model_info[0], mode, *args, **kwargs)
+        self.model_info_tuple = model_info_tuple
+        super().__init__(model_info_tuple[0], mode, *args, **kwargs)
 
     def _load_model(self):
-        model_name, weights_name = self.model_info
+        model_name, weights_name = self.model_info_tuple
         self.weights = getattr(models, weights_name).DEFAULT
         model = models.get_model(model_name, weights=self.weights).to(torch.bfloat16)
         return model

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -12,14 +12,14 @@ from third_party.tt_forge_models.tools.utils import get_file
 
 # TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
 class ThisTester(ModelTester):
-    # pass model_info instead of model_name
-    def __init__(self, model_info, mode, *args, **kwargs):
-        # model name in model_info[0]
-        self.model_info = model_info
-        super().__init__(model_info[0], mode, *args, **kwargs)
+    # pass model_info_tuple instead of model_name
+    def __init__(self, model_info_tuple, mode, *args, **kwargs):
+        # model name in model_info_tuple[0]
+        self.model_info_tuple = model_info_tuple
+        super().__init__(model_info_tuple[0], mode, *args, **kwargs)
 
     def _load_model(self):
-        model_name, weights_name = self.model_info
+        model_name, weights_name = self.model_info_tuple
         self.weights = getattr(models.detection, weights_name).DEFAULT
         model = getattr(models.detection, model_name)(
             weights=self.weights

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -11,10 +11,10 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -27,7 +27,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_yolov3(record_property, mode, op_by_op):
-    model_name = "YOLOv3"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -37,9 +36,14 @@ def test_yolov3(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         required_pcc=0.97,
         assert_pcc=True,
         assert_atol=False,

--- a/tests/models/yolov3/test_yolov3_n300.py
+++ b/tests/models/yolov3/test_yolov3_n300.py
@@ -14,7 +14,7 @@ from third_party.tt_forge_models.tools.utils import get_file
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
         image_file = get_file(
@@ -46,7 +46,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_yolov3(record_property, mode, op_by_op):
-    model_name = "YOLOv3"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -59,9 +58,14 @@ def test_yolov3(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         required_pcc=0.97,
         assert_pcc=True,
         assert_atol=False,

--- a/tests/models/yolov4/test_yolov4.py
+++ b/tests/models/yolov4/test_yolov4.py
@@ -12,10 +12,10 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return ModelLoader.load_model(dtype_override=torch.bfloat16)
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        return ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -28,8 +28,6 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_yolov4(record_property, mode, op_by_op):
-    model_name = "YOLOv4"
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -38,9 +36,14 @@ def test_yolov4(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
+        model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
         model_group="red",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,6 +98,7 @@ class ModelTester:
         model_name,
         mode,
         loader=None,
+        model_info=None,
         required_pcc=0.99,
         required_atol=None,
         relative_atol=None,
@@ -118,6 +119,8 @@ class ModelTester:
             model_name (str): Name of the model.
             mode (str): "train" or "eval" mode.
             loader (ModelLoader, optional): TT-Forge-Models Loader for the model. Defaults to None.
+            model_info(ModelInfo, optional): TT-Forge-Models ModelInfo object for the model. Defaults to None.
+                                             When provided is used to extract model_name, model_group, etc.
             required_pcc (float, optional): Required Pearson Correlation Coefficient for verification. Defaults to 0.99.
             required_atol (float, optional): Required absolute tolerance for verification. Defaults to None.
             relative_atol (float, optional): Required relative absolute tolerance for verification. Defaults to None.
@@ -140,6 +143,14 @@ class ModelTester:
         """
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
+
+        # ModelInfo object is what we eventually want to move towards using always.
+        # If it is provided, use it to extract important fields and override.
+        self.model_info = model_info
+        if self.model_info is not None:
+            model_name = self.model_info.name
+            model_group = self.model_info.group
+
         self.model_name = model_name
         self.loader = loader
         self.mode = mode
@@ -859,6 +870,7 @@ class OnnxModelTester(ModelTester):
         model_name,
         mode,
         loader=None,
+        model_info=None,
         required_pcc=0.99,
         required_atol=None,
         relative_atol=None,
@@ -878,6 +890,7 @@ class OnnxModelTester(ModelTester):
             model_name,
             mode,
             loader,
+            model_info,
             required_pcc,
             required_atol,
             relative_atol,

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "3b8b567bb82f8dd573adc6d6ca819fa3d32b7c62")
+    set(TT_FORGE_MODELS_VERSION "3d9787c2205d224eb9f1864437c77dba6fa18676")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Want to get a newer tt-forge-models verson to get the recent changes I released to make ModelLoader instance based and contain ModelInfo / get_model_info() support for all (currently 60) models. This will allow upcoming automatic model discovery test to work consistently across models.

### What's changed
 - Pull in latest and greatest tt-forge-models for the changes
 - Update our 22 tests that use ModelLoader to use instance methods and get_model_info() to get updated model_name and model_group
 - Add optional ModelInfo arg to ModelTester, OnnxModelTester init and use in tests for simplification
 - Change model_info to model_into_tuple in torchvision tests now that model_info is actual ModelTester arg
 - Update framework prefix removal workaround in op-by-op XLS gen script to contain onnx_ too
 - Semi Unrelated: Specify variant resdcn18_od in test_centernet_onnx.py to solve nightly failure since recent tt-forge-models uplift that brought more variants and changed default variant to one that fails compile.

### Checklist
- [x] Tested modified tests locally, and branch CI: https://github.com/tenstorrent/tt-torch/actions/runs/15914404804
