### PR TITLE
Cast model_group to str in case a ModelGroup StrEnum is passed to ModelTester, and skip_full_eval_test()

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,6 +57,8 @@ def skip_full_eval_test(
     Returns:
         bool: True if test was skipped, False otherwise
     """
+    # Make sure model_group is string for json serializing. It may come from ModelGroup StrEnum.
+    model_group = str(model_group)
 
     # If there is a model name filter applied, and the model name passed herein does not match,
     #   then run the test as normal. Useful for parameterized tests.
@@ -154,6 +156,10 @@ class ModelTester:
         self.model_name = model_name
         self.loader = loader
         self.mode = mode
+
+        # Make sure model_group is string for json serializing. It may come from ModelGroup StrEnum.
+        model_group = str(model_group)
+
         self.data_parallel_mode = data_parallel_mode
         self.framework_model = self._load_model()
         self.is_token_output = is_token_output


### PR DESCRIPTION
### Ticket
None

### Problem description
- Change in #1002 added few cases where we pass model_group=model_info.group to ModelTester which does not automatically get converted to str before unique_ops json file written out for op-by-op flow leading to "TypeError: Object of type ModelGroup is not JSON serializable"

### What's changed
- Cast model_group to str explicitly in ModelTester and skip_full_eval_test() for good measure, the ModelGroup StrEnum class used already has to-string support.

### Checklist
- [x] Tested few op-by-op tests locally that hit the error