### PR TITLE
Fix test_bloom.py fail after tt-forge-models updates (loader.test_input instead of ModelLoader.test_input)

### DIFF
--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -56,7 +56,7 @@ def test_bloom(record_property, mode, op_by_op):
         decoded_output = loader.decode_output(results)
 
         print(f"model_name: {model_info.name}")
-        for i, (inp, out) in enumerate(zip(ModelLoader.test_input, decoded_output)):
+        for i, (inp, out) in enumerate(zip(loader.test_input, decoded_output)):
             print(f"input {i}: {inp}\noutput {i}: {out}\n")
 
     tester.finalize()


### PR DESCRIPTION
### Ticket
None

### Problem description
- Test failed on Nightly with "AttributeError: type object 'ModelLoader' has no attribute 'test_input'" after tt-forge-models update

### What's changed
- Need to use loader.test_input instead of ModelLoader.test_input

### Checklist
- [x] Passes locally now
