### PR TITLE
Move implicit executor device acquisition to start of executor __call__

### DIFF
--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -379,6 +379,8 @@ class Executor:
                 ):
                     device_constant_cache[torch_tensor] = runtime_tensor
 
+        device = self.devices[device_idx]
+
         input_len = len(inputs)
         tensor_start_idx = 0
 
@@ -392,7 +394,6 @@ class Executor:
         #   input torch tensor
 
         if self.constant_cache is not None:
-            device = self.devices[device_idx]
             device_constant_cache = self.constant_cache.get(device, {})
             for i in range(len(constants)):
                 cached_constant = device_constant_cache.get(
@@ -403,7 +404,6 @@ class Executor:
                     tensor_start_idx += 1
 
         if self.buffer_cache is not None:
-            device = self.devices[device_idx]
             device_buffer_cache = self.buffer_cache.get(device, {})
             for i in range(len(constants), len(constants) + len(buffers)):
                 cached_buffer = device_buffer_cache.get(
@@ -424,7 +424,7 @@ class Executor:
 
         # execute conversion from torch tensors to runtime tensors
         runtime_activations_and_weights = tt_mlir.preprocess_inputs(
-            self._get_device(device_idx=device_idx),
+            device,
             torch_weights_and_activations,
             binary,
             program_idx,
@@ -485,6 +485,8 @@ class Executor:
         final_outputs = [None] * num_outputs
         for device_idx, binary in self.mcg.binaries.items():
             device_inputs = graph_inputs[device_idx]
+
+            self._get_device(device_idx=device_idx)
             device = self.devices[device_idx]
 
             # initialize buffers by iterating over known mcg.buffers and creating


### PR DESCRIPTION
### Ticket
None

### Problem description
Automatic device acquisition via _get_device() happens after cache initialization, so if the device is not specified, the first executor __call__ acquires a device during get_inputs(). This causes the initial constant / buffer cache to be attached to a None device. 

At the first cache insertion time, the device _is_ initialized by automatic device acquisition, so the cache has two incoherent perspectives on the device to attach the cache to - the list of tensors to cache is attached to a None device while the actual allocated runtime tensors are attached to a real device. The caching operation "misses" due to device mismatch.

Then, at destruction time, a runtime error is encountered due to attempted deallocation of uncached (None) runtime tensors.

### What's changed
- Move automatic device acquisition to the start of the Executor __call__ so the device exists before cache initialization time.
- (minor) Add output filtering to llama demo so it only prints output tokens to stdout.
### Checklist
- [x] New/Existing tests provide coverage for changes
