### PR TITLE
Fix - replace matrix.build entry with correct runner name

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -314,7 +314,7 @@ jobs:
           },
         ]
     runs-on: ${{ matrix.runner == 'wormhole' && matrix.build.wh-runner || matrix.runner == 'blackhole' && matrix.build.bh-runner  || 'wormhole_b0'}}
-    name: "test execution on ${{ matrix.runner }} (${{ matrix.build.name }})"
+    name: "test execution_nightly on ${{ matrix.runner }} (${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
@@ -344,7 +344,7 @@ jobs:
       if: ${{ env.RUN_TEST != 'skip' }}
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "test execution on ${{ matrix.runner }} (${{ matrix.build.name }})" # reference above tests.name
+        job_name: "test execution_nightly on ${{ matrix.runner }} (${{ matrix.build.name }})" # reference above tests.name
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -106,7 +106,7 @@ jobs:
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780
           {
-            runs-on: n300, name: "eval_6", tests: "
+            wh-runner: n300, name: "eval_6", tests: "
                 tests/torch/test_basic_async.py
                 tests/torch/test_basic_multichip.py
                 tests/models/mnist/test_mnist.py::test_mnist_train[data_parallel-full-eval]


### PR DESCRIPTION
### Ticket
Follow-up fix for #993 

### Problem description
Missed one of the matrix.build 'eval_6' test entries and it was skipping the tests all together.

### What's changed
Replaces 'runs-on: n300' with 'wh-runner: n300' and updated the test names for nightlies to avoid conflict

### Checklist
- [x] New/Existing tests provide coverage for changes
- [x] Passed 'eval_6' without skipping tests
