### PR TITLE
Update tt-forge-models version and update centernet import directory change

### DIFF
--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -4,7 +4,7 @@
 import pytest
 from tests.utils import OnnxModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.centernet.pytorch import ModelLoader
+from third_party.tt_forge_models.centernet.onnx import ModelLoader
 
 
 class ThisTester(OnnxModelTester):

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "3d9787c2205d224eb9f1864437c77dba6fa18676")
+    set(TT_FORGE_MODELS_VERSION "00993ec6823f68f0a2a50ad82868cd4fa40fa67a")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
None

### Problem Description
- 3 errors seen when running models via upcoming test_models.py auto model discovery test

### What's changed
- Brings fix from tt-forge-models to vilt/whisper models and move centernet/pytorch -> centernet/onnx
- Update our import of centernet accordingly.

### Checklist
- [x] Tested centernet locally, tested vilt/whisper locally with upcomiing test_models.py, errors gone
