### PR TITLE
Fix tt-mlir override commit in the workflow log

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -82,7 +82,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-          cd third_party/tt-mlir
+          cd third_party/tt-mlir/src/tt-mlir
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)
@@ -90,7 +90,7 @@ jobs:
           echo "Commit SHA: $commit_sha"
           echo "Commit title: $commit_title"
           echo "::notice::Using tt-mlir: $branch_name, commit: $commit_sha, title: $commit_title"
-          cd ../..
+          cd ../../../..
 
 
     - name: Copy wheel and env directories


### PR DESCRIPTION
### Ticket
/

### Problem description
Workflow logged out tt-torch's commit instead of the submodule's (tt-mlir's) commit.
That happened because wrong git context was used.

### What's changed
I have corrected the path to tt-mlir.
Now the directory is the actual tt-mlir so the git context is correct.

### Checklist
- [ ] New/Existing tests provide coverage for changes
