### PR TITLE
Disable detr single device + data parallel tests due to nightly dram oom failure

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -399,7 +399,7 @@ jobs:
 
     - name: Upload Test Report Models
       uses: actions/upload-artifact@v4
-      if: ${{ success() || failure() && env.RUN_TEST != 'skip' }}
+      if: ${{ (success() || failure()) && env.RUN_TEST != 'skip' }}
       with:
         name: test-reports-models-${{ matrix.runner }}-${{ matrix.build.name }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path_models }}

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -56,6 +56,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
 )
+@pytest.mark.skip(reason="Skipping test_detr due to DRAM OOM; see issue #1024")
 def test_detr(record_property, mode, op_by_op, data_parallel_mode):
     model_name = "DETR"
 


### PR DESCRIPTION
### Ticket
Follow up in #1024 

Data parallel detr test on n300 is failing consistently in nightly due to DRAM OOM leading to segfault and test group not being reported.

The test in question is tests/models/detr/test_detr.py::test_detr[data_parallel-full-eval] and causing failures in the full eval nightly data parallel 1 group.

Edit. looks like the single device test also hits OOM and segfaults, so both test groups are not reporting.
tests/models/detr/test_detr.py::test_detr[single_device-full-eval] 