### PR TITLE
Fix a prametrize of mnist test for perf

### DIFF
--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -24,7 +24,7 @@ tt_profile.py [-h] [-o OUTPUT_PATH] [-p PORT] "test_command"
 
 As a minimal example, the following command will run and tt_profile the MNIST test:
 ```
-python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
+python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[single_device-full-eval]"
 ```
 
 The report is created at `results/perf/device_ops_perf_trace.csv` by default, unless an output path is specified.

--- a/tests/torch/tools/test_profiler.py
+++ b/tests/torch/tools/test_profiler.py
@@ -9,7 +9,6 @@ from tt_torch.tools.tt_profile import tt_profile
 from tt_torch.tools.profile_util import Profiler
 import csv
 
-test_command_mnist = "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
 test_command_add = "pytest -svv tests/torch/test_basic.py::test_add"
 expected_report_path = f"results/perf/{Profiler.DEFAULT_OUTPUT_FILENAME}"
 

--- a/tt_torch/tools/tt_profile.py
+++ b/tt_torch/tools/tt_profile.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         python tt_profile.py test_command -o output_name
 
     Examples:
-        python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[full-eval-single_device]"
+        python tt_torch/tools/tt_profile.py "pytest -svv tests/models/mnist/test_mnist.py::test_mnist_train[single_device-full-eval]"
 
     Notes:
         Providing an output name is optional and defaults to 'device_ops_perf_trace.csv'."""


### PR DESCRIPTION
### Ticket
N/A

### Problem description
At test_mnist_train, a `full-eval-single_device` parametrize is not correct. The decorators of python are evaluated from the bottom up.

```python
@pytest.mark.parametrize(
    "mode",
    ["train", "eval"],
)
@pytest.mark.parametrize(
    "op_by_op",
    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
)
@pytest.mark.parametrize(
    "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
)
def test_mnist_train(record_property, mode, op_by_op, data_parallel_mode):
...
```

### What's changed
- updated to `single_device-full-eval`
- removed unused `test_command_mnist` in test_profiler.py

### Checklist
- [ ] New/Existing tests provide coverage for changes
