### PR TITLE
Pass expansion_factor_token=1 to avoid breaking mlpmixer after update 0.2.0 => 0.3.0

### DIFF
--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -20,6 +20,7 @@ class ThisTester(ModelTester):
             dim=512,
             depth=12,
             num_classes=1000,
+            expansion_factor_token=1,  # see mlpmixer package issue #17 https://github.com/lucidrains/mlp-mixer-pytorch/issues/17
         )
         model = model.to(torch.bfloat16)
         return model


### PR DESCRIPTION
### Ticket
None 

### Problem description
OnPR and nightly CI is failing due to MLPMixer update from July 6th breaking tests on main.

### What's changed
Change expansion_factor_token to 1, to avoid using default 0.5 which causes a typecast to float in the mlpmixer package and breaks their example / default library usage. 

### Checklist
- [x] New/Existing tests provide coverage for changes
