### PR TITLE
Uplift third_party/tt-mlir to 42332a2b361f458595be7b91769a17b9a92b2fc7 2025-07-10

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "7b568d066adf131d537bee718cc75886077eb18d")
+set(TT_MLIR_VERSION "42332a2b361f458595be7b91769a17b9a92b2fc7")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 42332a2b361f458595be7b91769a17b9a92b2fc7