### PR TITLE
Enable PCC check for blackhole models

### DIFF
--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -8,7 +8,6 @@ import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
-import tt_mlir
 
 
 class ThisTester(ModelTester):
@@ -72,9 +71,8 @@ def test_albert_masked_lm(
     model_info = loader.get_model_info(variant=variant)
     model_name = model_info.name
 
-    # TODO: Remove this once PCC ATOL is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-    required_pcc = 0.98 if "xxlarge" in variant else 0.99
+    assert_pcc = True
+    required_pcc = 0.98
 
     tester = ThisTester(
         model_name,

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -10,7 +10,6 @@ import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.hardnet.pytorch import ModelLoader
-import tt_mlir
 
 
 class ThisTester(ModelTester):
@@ -50,9 +49,6 @@ def test_hardnet(record_property, mode, op_by_op, data_parallel_mode):
     loader = ModelLoader(variant=None)
     model_info = loader.get_model_info(variant=None)
 
-    # TODO: Remove this once PCC ATOL is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-
     tester = ThisTester(
         model_info.name,
         mode,
@@ -63,7 +59,7 @@ def test_hardnet(record_property, mode, op_by_op, data_parallel_mode):
         compiler_config=cc,
         record_property_handle=record_property,
         # TODO Enable checking - https://github.com/tenstorrent/tt-torch/issues/488
-        assert_pcc=assert_pcc,
+        assert_pcc=True,
         assert_atol=False,
         data_parallel_mode=data_parallel_mode,
     )

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -10,7 +10,6 @@ import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.tools.utils import get_file
-import tt_mlir
 
 
 class ThisTester(ModelTester):
@@ -61,14 +60,14 @@ def test_resnet(record_property, mode, op_by_op, data_parallel_mode):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO: Remove this once PCC ATOL is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
+    assert_pcc = True
+    required_pcc = 0.97
 
     tester = ThisTester(
         model_name,
         mode,
         required_atol=0.03,
-        required_pcc=0.98,
+        required_pcc=required_pcc,
         compiler_config=cc,
         assert_pcc=assert_pcc,
         assert_atol=False,

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -10,7 +10,6 @@ import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-import tt_mlir
 
 dependencies = ["timm==1.0.9"]
 
@@ -105,8 +104,6 @@ def test_timm_image_classification(
             "xception71.tf_in1k",
             "inception_v4.tf_in1k",
         ]
-        and tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-        # TODO: Remove this once PCC ATOL is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
         else False
     )
 

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -8,7 +8,6 @@ import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.tools.utils import get_file
-import tt_mlir
 
 
 class ThisTester(ModelTester):
@@ -122,13 +121,8 @@ def test_torchvision_image_classification(
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
     # TODO Enable checking (vit_h_14) - https://github.com/tenstorrent/tt-torch/issues/491
-    # TODO Enable PCC/ATOL once issue is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
     model_name = model_info[0]
-    assert_pcc = (
-        False
-        if model_name in ["vit_h_14"] or tt_mlir.get_arch() == tt_mlir.Arch.BLACKHOLE
-        else True
-    )
+    assert_pcc = False if model_name in ["vit_h_14"] else True
     assert_atol = False
 
     model_group = "red" if model_name == "swin_v2_s" else "generality"

--- a/tests/models/yolov4/test_yolov4.py
+++ b/tests/models/yolov4/test_yolov4.py
@@ -8,7 +8,6 @@ import pytest
 from third_party.tt_forge_models.yolov4.pytorch import ModelLoader
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-import tt_mlir
 
 
 class ThisTester(ModelTester):
@@ -40,18 +39,14 @@ def test_yolov4(record_property, mode, op_by_op):
     loader = ModelLoader(variant=None)
     model_info = loader.get_model_info(variant=None)
 
-    # TODO: Remove this once PCC ATOL is fixed for yolov4 on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-    assert_atol = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-
     tester = ThisTester(
         model_info.name,
         mode,
         loader=loader,
         model_info=model_info,
         compiler_config=cc,
-        assert_pcc=assert_pcc,
-        assert_atol=assert_atol,
+        assert_pcc=True,
+        assert_atol=True,
         record_property_handle=record_property,
         model_group="red",
     )


### PR DESCRIPTION
### Ticket
[1003](https://github.com/tenstorrent/tt-torch/issues/1003)

### Problem description
For certain models using bfloat16 (not models that are entirely bfloat16, but those with specific bfloat16 usage), there is an issue with untilize on the device.

### What's changed
The workaround in [PR #4024](https://github.com/tenstorrent/tt-mlir/pull/4024) applies running untilize on the host. This commit resolves the issue for the following models:
 - VGG series models
 - hardnet
 - dla34.in1k
 - yolov4

Also, there are two models with a slight difference compared to the target PCC. We can enable a tolerance for these, and the target can be updated for the BH architecture.
 - albert_masked_lm (pcc  = 0.9865)
 - resnet50 (pcc = 0.9762)

### Checklist
- [ ] New/Existing tests provide coverage for changes
