### PR TITLE
Install ffmpeg and torchcodec for Whisper, misc nightly fixes

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -5,6 +5,7 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
+# ffmpeg required for torchcodec, required for Whisper tests
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     build-essential \
@@ -35,7 +36,8 @@ RUN apt-get update && apt-get install -y \
     lcov \
     libgl1 \
     libglx-mesa0 \
-    unzip
+    unzip \
+    ffmpeg
 
 # Install python3.10 packages
 RUN python3.10 -m pip install \

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -317,7 +317,7 @@ jobs:
           },
         ]
     runs-on: ${{ matrix.runner == 'wormhole' && matrix.build.wh-runner || matrix.runner == 'blackhole' && matrix.build.bh-runner  || 'wormhole_b0'}}
-    name: "test execution_nightly on ${{ matrix.runner }} (${{ matrix.build.name }})"
+    name: "test exec nightly ${{ matrix.runner == 'wormhole' && 'wh' || matrix.runner == 'blackhole' && 'bh' || 'unk' }} (${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
@@ -347,7 +347,7 @@ jobs:
       if: ${{ env.RUN_TEST != 'skip' }}
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "test execution_nightly on ${{ matrix.runner }} (${{ matrix.build.name }})" # reference above tests.name
+        job_name: "test exec nightly ${{ matrix.runner == 'wormhole' && 'wh' || matrix.runner == 'blackhole' && 'bh' || 'unk' }} (${{ matrix.build.name }})" # reference above tests.name
 
     - name: Set reusable strings
       id: strings

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -39,6 +39,7 @@ jobs:
         build: [
           {
             wh-runner: wormhole_b0, bh-runner: p150, name: "eval_1", tests: "
+                  tests/models/whisper/test_whisper.py::test_whisper[single_device-full-eval]
                   tests/models/autoencoder_linear/test_autoencoder_linear.py::test_autoencoder_linear[full-eval]
                   tests/models/distilbert/test_distilbert.py::test_distilbert[full-distilbert-base-uncased-eval]
                   tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[full-eval]

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -133,7 +133,7 @@ jobs:
           }
         ]
     runs-on: ${{ matrix.runner == 'wormhole' && matrix.build.wh-runner || matrix.runner == 'blackhole' && matrix.build.bh-runner  || 'wormhole_b0'}}
-    name: "test execution on ${{ matrix.runner }} (${{ matrix.build.name }})"
+    name: "test exec ${{ matrix.runner == 'wormhole' && 'wh' || matrix.runner == 'blackhole' && 'bh' || 'unk' }} (${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
@@ -163,7 +163,7 @@ jobs:
       if: ${{ env.RUN_TEST != 'skip' }}
       uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
       with:
-        job_name: "test execution on ${{ matrix.runner }} (${{ matrix.build.name }})" # reference above tests.name
+        job_name: "test exec ${{ matrix.runner == 'wormhole' && 'wh' || matrix.runner == 'blackhole' && 'bh' || 'unk' }} (${{ matrix.build.name }})" # reference above tests.name
 
     - name: Set reusable strings
       if: ${{ env.RUN_TEST != 'skip' }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ gliner
 ultralytics
 efficientnet_pytorch
 stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp310-cp310-linux_x86_64.whl
+torchcodec # required for whisper test. Requires system dep ffmpeg.


### PR DESCRIPTION
### Ticket
None.

### Problem description
- Whisper tests are failing due to missing torchcodec dependency, which requires system dependency ffmpeg
- mlpmixer test in batch parallel hits out of DRAM and crashes test group
- execution test group names are too long and get clipped by github GUI

### What's changed
- Install torchcodec in requirements, ffmpeg in container
- Disable mlpmixer, follow up in #1055
- Truncate test group names 

### Checklist
- [x] New/Existing tests provide coverage for changes
