### PR TITLE
Add permission block

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     timeout-minutes: 10


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-torch/security/code-scanning/660)
Closes #1050

### Problem description
Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}

### What's changed
To fix the issue, we will add a permissions block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow involves pre-commit checks, it likely only needs read access to the repository contents. We will set contents: read as the permission. This change ensures that the workflow does not have unnecessary write access, improving security.

### Checklist
- [ ] New/Existing tests provide coverage for changes
