### PR TITLE
Initial followup changes ModelVariant(StrEnum) change in tt-forge-models

### DIFF
--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -7,7 +7,10 @@ import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
+from third_party.tt_forge_models.albert.masked_lm.pytorch import (
+    ModelLoader,
+    ModelVariant,
+)
 
 
 class ThisTester(ModelTester):
@@ -33,7 +36,7 @@ class ThisTester(ModelTester):
 
 # Print available variants for reference
 available_variants = ModelLoader.query_available_variants()
-print("Available variants:", available_variants)
+print("Available variants: ", [str(k) for k in available_variants.keys()])
 
 
 @pytest.mark.parametrize(
@@ -41,9 +44,9 @@ print("Available variants:", available_variants)
     ["eval"],
 )
 @pytest.mark.parametrize(
-    "variant_info",
+    "variant,variant_config",
     available_variants.items(),
-    ids=list(available_variants.keys()),
+    ids=[str(k) for k in available_variants.keys()],
 )
 @pytest.mark.parametrize(
     "op_by_op",
@@ -54,7 +57,7 @@ print("Available variants:", available_variants)
     "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
 )
 def test_albert_masked_lm(
-    record_property, variant_info, mode, op_by_op, data_parallel_mode
+    record_property, variant, variant_config, mode, op_by_op, data_parallel_mode
 ):
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -66,7 +69,6 @@ def test_albert_masked_lm(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    variant, variant_config = variant_info
     loader = ModelLoader(variant=variant)
     model_info = loader.get_model_info(variant=variant)
     model_name = model_info.name

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -5,7 +5,7 @@ import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.bert.pytorch import ModelLoader
+from third_party.tt_forge_models.bert.pytorch import ModelLoader, ModelVariant
 
 
 class ThisTester(ModelTester):
@@ -18,7 +18,7 @@ class ThisTester(ModelTester):
 
 # Print available variants for reference
 available_variants = ModelLoader.query_available_variants()
-print("Available variants:", available_variants)
+print("Available variants: ", [str(k) for k in available_variants.keys()])
 
 
 @pytest.mark.parametrize(
@@ -31,14 +31,12 @@ print("Available variants:", available_variants)
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 @pytest.mark.parametrize(
-    "variant_info",
+    "variant,variant_config",
     available_variants.items(),
-    ids=list(available_variants.keys()),
+    ids=[str(k) for k in available_variants.keys()],
 )
-def test_bert(record_property, mode, op_by_op, variant_info):
+def test_bert(record_property, mode, op_by_op, variant, variant_config):
 
-    # Use variant in model name if specified
-    variant, variant_config = variant_info
     loader = ModelLoader(variant=variant)
     model_info = loader.get_model_info(variant=variant)
     model_name = model_info.name

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -117,7 +117,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "7c28702b0be94ac5cbdd561abc55f2d1e4f546e7")
+    set(TT_FORGE_MODELS_VERSION "9b3eaf7e14af81fd54bf643b833cca3245663186")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Want to update tt-forge-models to latest version to get changes for https://github.com/tenstorrent/tt-forge-models/issues/27 here

### What's changed
 - Update tt-forge-models version to latest 9b3eaf
 - Update test_bert.py and test_albert_masked_lm.py w/ cosmetic changes for printing and useing variants
 - Test changes not required but nice to have, would like other models to follow that use variants

### Checklist
- [x] Run affected tests locally. And CI : https://github.com/tenstorrent/tt-torch/actions/runs/16330254771/job/46131485428
