### PR TITLE
Added option to enable optimizer and build with tt-mlir op model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,6 +178,10 @@ if "--build_runtime_debug" in sys.argv:
     ]
     sys.argv.remove("--build_runtime_debug")
 
+if "--build_op_model" in sys.argv:
+    cmake_args += ["-DTTMLIR_ENABLE_OPMODEL=ON"]
+    sys.argv.remove("--build_op_model")
+
 
 # Include Models, for CI only - not for release.
 include_models = False

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -34,6 +34,9 @@ else()
     set(TT_RUNTIME_ENABLE_PERF_TRACE OFF CACHE BOOL "Enable runtime Tracy perf tracing")
     message(STATUS "TT_RUNTIME_ENABLE_PERF_TRACE is set to: ${TT_RUNTIME_ENABLE_PERF_TRACE}")
 
+    set(TTMLIR_ENABLE_OPMODEL OFF CACHE BOOL "Enable op model for optimized compile")
+    message(STATUS "TTMLIR_ENABLE_OPMODEL is set to: ${TTMLIR_ENABLE_OPMODEL}")
+
     include(ExternalProject)
     set(TTMLIR_PREFIX ${TTTORCH_SOURCE_DIR}/third_party/tt-mlir)
     set(TTMLIR_INSTALL_PREFIX ${TTMLIR_PREFIX}/install)
@@ -58,6 +61,7 @@ else()
           -DTTMLIR_ENABLE_STABLEHLO=ON
           -DTTMLIR_ENABLE_RUNTIME=ON
           -DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF
+          -DTTMLIR_ENABLE_OPMODEL=${TTMLIR_ENABLE_OPMODEL}
           -DTT_RUNTIME_DEBUG=${TT_RUNTIME_DEBUG}
           -DCMAKE_INSTALL_PREFIX=${TTMLIR_INSTALL_PREFIX}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-mlir.git

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -44,11 +44,16 @@ find_package(Torch REQUIRED)
 find_library(TORCH_PYTHON_LIBRARY torch_python PATH "${TORCH_INSTALL_PREFIX}/lib")
 set(TARGET_NAME tt_mlir)
 
-pybind11_add_module(${TARGET_NAME} bindings.cpp)
 add_compile_definitions(TTMLIR_ENABLE_STABLEHLO=1)
-if (${TT_RUNTIME_DEBUG} MATCHES "ON")
+if (TT_RUNTIME_DEBUG)
     add_compile_definitions(TT_RUNTIME_DEBUG=1)
 endif()
+
+if (TTMLIR_ENABLE_OPMODEL)
+    add_compile_definitions(TTMLIR_ENABLE_OPMODEL=1)
+endif()
+
+pybind11_add_module(${TARGET_NAME} bindings.cpp)
 
 add_dependencies(${TARGET_NAME}
     TT_TORCH_MLIR

--- a/tt_torch/csrc/tt-mlir-interface.cpp
+++ b/tt_torch/csrc/tt-mlir-interface.cpp
@@ -193,7 +193,7 @@ void create_system_desc(tt::runtime::Device device,
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
                   size_t len_activations, size_t len_graph_constants,
-                  bool enable_consteval) {
+                  bool enable_consteval, bool enable_optimizer) {
 
   mlir::MLIRContext context;
   mlir::DialectRegistry registry;
@@ -231,6 +231,7 @@ compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
 
   options.enableFusing = true;
   options.enableConstEval = enable_consteval;
+  options.optimizerPassEnabled = enable_optimizer;
 
   if (len_activations > 0 || len_graph_constants > 0) {
     llvm::SmallVector<mlir::tt::ttcore::ArgumentType> argTypes;

--- a/tt_torch/csrc/tt-mlir-interface.hpp
+++ b/tt_torch/csrc/tt-mlir-interface.hpp
@@ -18,7 +18,7 @@ std::string compileStableHLOToTTIR(std::string_view code);
 std::tuple<std::shared_ptr<void> *, std::string>
 compileTTIRToTTNN(std::string_view code, std::string_view system_desc_path,
                   size_t len_activations = 0, size_t len_graph_constants = 0,
-                  bool enable_consteval = true);
+                  bool enable_consteval = true, bool enable_optimizer = false);
 void create_system_desc(tt::runtime::Device device,
                         std::string_view descriptor_path);
 } // namespace tt::torch

--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -250,6 +250,7 @@ def shlo_to_flatbuffer(
         len_activations,
         len_graph_constants,
         compiler_config.enable_consteval,
+        compiler_config.enable_optimizer,
     )
     dump_module(module=ttnn, name="TTNN", compiler_config=compiler_config)
 

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -311,6 +311,7 @@ class CompilerConfig:
         self.single_op_timeout = 30
         self.op_by_op_backend = OpByOpBackend.TORCH
         self.enable_consteval = False
+        self.enable_optimizer = False
         self._consteval_parameters = False
         self._enable_intermediate_verification = False
         self.dump_debug = False
@@ -417,6 +418,9 @@ class CompilerConfig:
         enable_consteval = os.environ.get("TT_TORCH_CONSTEVAL")
         if enable_consteval and int(enable_consteval):
             self.enable_consteval = True
+        enable_optimizer = os.environ.get("TT_TORCH_OPTIMIZER")
+        if enable_optimizer and int(enable_optimizer):
+            self.enable_optimizer = True
         consteval_parameters = os.environ.get("TT_TORCH_CONSTEVAL_PARAMETERS")
         if consteval_parameters and int(consteval_parameters):
             self.consteval_parameters = True
@@ -541,6 +545,7 @@ class CompilerConfig:
             "results_path": self.results_path,
             "single_op_timeout": self.single_op_timeout,
             "enable_consteval": self.enable_consteval,
+            "enable_optimizer": self.enable_optimizer,
             "_consteval_parameters": self._consteval_parameters,
             "_enable_intermediate_verification": self._enable_intermediate_verification,
             "_verify_op_by_op": self._verify_op_by_op,


### PR DESCRIPTION
### Problem description
Currently there's no way for the user to enable optimizer and build tt-mlir with op model.

### What's changed
Added a compiler config flag to enable optimizer, and cmake config flag to build with op model, both defaulting to false.
