### PR TITLE
Uplift third_party/tt-mlir to 55732d09089f8f094d358c9072f83c6807b40dd8 2025-07-17

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-set(TT_MLIR_VERSION "3c646022e568cb36408324b41982b079739b85b6")
+set(TT_MLIR_VERSION "55732d09089f8f094d358c9072f83c6807b40dd8")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 55732d09089f8f094d358c9072f83c6807b40dd8