### PR TITLE
Refactoring tests with tt-forge-models compatibility

### DIFF
--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -36,7 +36,6 @@ jobs:
             runs-on: wormhole_b0, name: "compile_1", tests: "
               tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-7B-Base-eval]
               tests/models/detr/test_detr_onnx.py::test_detr_onnx[full-eval]
-              tests/models/oft/test_oft.py::test_oft[full-eval]
               tests/models/autoencoder_conv/test_autoencoder_conv_v2.py::test_autoencoder_conv_v2[full-eval]
               tests/models/flux/test_flux.py::test_flux[full-flux_schnell-eval]
               tests/models/flux/test_flux.py::test_flux[full-flux_dev-eval]

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -213,7 +213,7 @@ jobs:
             wh-runner: wormhole_b0, bh-runner: p150, name: "skip_tests_red_models", tests: "
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-lstm]
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-eval-gru]
-                tests/models/oft/test_oft.py::test_oft[full-eval]
+                tests/models/oft/test_oft.py::test_oft[full-eval-base]
                 tests/models/vgg19_unet/test_vgg19_unet.py::test_vgg19_unet[full-eval]
                 tests/models/yolov10/test_yolov10.py::test_yolov10[full-eval]
                 tests/models/flux/test_flux.py::test_flux[full-flux_schnell-eval]

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -118,7 +118,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "OFT", tests: "
-              tests/models/oft/test_oft.py::test_oft[op_by_op_torch-eval]
+              tests/models/oft/test_oft.py::test_oft[op_by_op-eval-base]
               "
           },
           {

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -6,11 +6,9 @@
 import torch
 import pytest
 from tests.utils import ModelTester
-from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.albert.masked_lm.pytorch import (
-    ModelLoader,
-    ModelVariant,
-)
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, ModelMetadata
+from tt_torch.tools.utils import construct_metadata_from_variants
+from third_party.tt_forge_models.albert.masked_lm.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
@@ -34,43 +32,55 @@ class ThisTester(ModelTester):
     #     return
 
 
-# Print available variants for reference
-available_variants = ModelLoader.query_available_variants()
-print("Available variants: ", [str(k) for k in available_variants.keys()])
+OVERRIDE_VARIANTS = {
+    "albert-base-v2": ModelMetadata(
+        variant_name="albert-base-v2",
+        assert_atol=False,
+    ),
+}
+
+variant_metadata_list, variant_ids = construct_metadata_from_variants(
+    ModelLoader, OVERRIDE_VARIANTS
+)
 
 
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
 )
+# variant_info is a ModelMetadata object with ModelInfo, variant_config
+# and other tt-forge-models FE agnostic info embedded in it
 @pytest.mark.parametrize(
-    "variant,variant_config",
-    available_variants.items(),
-    ids=[str(k) for k in available_variants.keys()],
+    "variant_info",
+    variant_metadata_list,
+    ids=variant_ids,
 )
 @pytest.mark.parametrize(
-    "op_by_op",
-    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
-    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+    "execute_mode",
+    [CompileDepth.EXECUTE_OP_BY_OP, CompileDepth.EXECUTE],
+    ids=["op_by_op", "full"],
 )
 @pytest.mark.parametrize(
     "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
 )
 def test_albert_masked_lm(
-    record_property, variant, variant_config, mode, op_by_op, data_parallel_mode
+    record_property, variant_info, mode, execute_mode, data_parallel_mode
 ):
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
-    if op_by_op:
-        if data_parallel_mode:
-            pytest.skip("Op-by-op not supported in data parallel mode")
-        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
-        if op_by_op == OpByOpBackend.STABLEHLO:
-            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    loader = ModelLoader(variant=variant)
-    model_info = loader.get_model_info(variant=variant)
+    cc.op_by_op_backend = variant_info.op_by_op_backend
+    if execute_mode == CompileDepth.EXECUTE_OP_BY_OP:
+        cc.compile_depth = execute_mode
+    else:
+        cc.compile_depth = variant_info.compile_depth
+
+    variant = variant_info.variant_name
+    variant_config = variant_info.variant_config
+
+    # loader = ModelLoader(variant=variant)
+    model_info = variant_info.loader.get_model_info(variant=variant)
     model_name = model_info.name
 
     assert_pcc = True
@@ -79,7 +89,7 @@ def test_albert_masked_lm(
     tester = ThisTester(
         model_name,
         mode,
-        loader=loader,
+        loader=variant_info.loader,
         required_pcc=required_pcc,
         assert_pcc=assert_pcc,
         assert_atol=False,
@@ -90,7 +100,7 @@ def test_albert_masked_lm(
     results = tester.test_model()
 
     def print_result(result):
-        predicted_tokens = loader.decode_output(result, tester.inputs)
+        predicted_tokens = variant_info.loader.decode_output(result, tester.inputs)
         print(f"Model: {model_name} | Input: {tester.text} | Mask: {predicted_tokens}")
 
     if mode == "eval":

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -79,20 +79,19 @@ def test_albert_masked_lm(
     variant = variant_info.variant_name
     variant_config = variant_info.variant_config
 
-    # loader = ModelLoader(variant=variant)
     model_info = variant_info.loader.get_model_info(variant=variant)
     model_name = model_info.name
 
-    assert_pcc = True
-    required_pcc = 0.98
+    variant_info.assert_pcc = True
+    variant_info.required_pcc = 0.98
 
     tester = ThisTester(
         model_name,
         mode,
         loader=variant_info.loader,
-        required_pcc=required_pcc,
-        assert_pcc=assert_pcc,
-        assert_atol=False,
+        required_pcc=variant_info.required_pcc,
+        assert_pcc=variant_info.assert_pcc,
+        assert_atol=variant_info.assert_atol,
         compiler_config=cc,
         record_property_handle=record_property,
         data_parallel_mode=data_parallel_mode,

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -21,12 +21,10 @@ class ThisTester(ModelTester):
 
 
 OVERRIDE_VARIANTS = {
-    "base": {
-        ModelMetadata(
-            variant_name="base",
-            assert_atol=False,
-        )
-    }
+    "base": ModelMetadata(
+        variant_name="base",
+        assert_atol=False,
+    )
 }
 
 variant_metadata_list, variant_ids = construct_metadata_from_variants(
@@ -62,22 +60,25 @@ def test_oft(record_property, mode, execute_mode, variant_info):
     else:
         cc.compile_depth = variant_info.compile_depth
 
-    loader = ModelLoader(variant=None)
-    model_info = loader.get_model_info(variant=None)
+    variant = variant_info.variant_name
+    variant_config = variant_info.variant_config
+
+    model_info = variant_info.loader.get_model_info(variant=variant)
+    model_name = model_info.name
 
     skip_full_eval_test(
         record_property,
         cc,
-        model_info.name,
+        model_name,
         bringup_status="FAILED_RUNTIME",
         reason="Out of Memory: Not enough space to allocate 2902982656 B DRAM buffer across 12 banks - https://github.com/tenstorrent/tt-torch/issues/727",
         model_group=model_info.group,
     )
 
     tester = ThisTester(
-        model_info.name,  # name of model
+        model_name,  # name of model
         mode,
-        loader=loader,
+        loader=variant_info.loader,
         model_info=model_info,
         compiler_config=cc,
         assert_atol=variant_info.assert_atol,

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from tests.utils import ModelTester, skip_full_eval_test
-from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from tt_torch.tools.utils import (
+    CompilerConfig,
+    CompileDepth,
+    ModelMetadata,
+)
+from tt_torch.tools.utils import construct_metadata_from_variants
 from third_party.tt_forge_models.oft.pytorch import ModelLoader
 
 
@@ -15,26 +20,47 @@ class ThisTester(ModelTester):
         return self.loader.load_inputs()
 
 
+OVERRIDE_VARIANTS = {
+    "base": {
+        ModelMetadata(
+            variant_name="base",
+            assert_atol=False,
+        )
+    }
+}
+
+variant_metadata_list, variant_ids = construct_metadata_from_variants(
+    ModelLoader, OVERRIDE_VARIANTS
+)
+
+
+@pytest.mark.parametrize(
+    "variant_info",
+    variant_metadata_list,
+    ids=variant_ids,
+)
 @pytest.mark.parametrize(
     "mode",
     ["train", "eval"],
 )
 @pytest.mark.parametrize(
-    "op_by_op",
-    [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
-    ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+    "execute_mode",
+    [CompileDepth.EXECUTE_OP_BY_OP, CompileDepth.EXECUTE],
+    ids=["op_by_op", "full"],
 )
-def test_oft(record_property, mode, op_by_op):
+def test_oft(record_property, mode, execute_mode, variant_info):
     if mode == "train":
         pytest.skip()
 
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
-    if op_by_op:
-        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
-        if op_by_op == OpByOpBackend.STABLEHLO:
-            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    cc.op_by_op_backend = variant_info.op_by_op_backend
+    if execute_mode == CompileDepth.EXECUTE_OP_BY_OP:
+        cc.compile_depth = execute_mode
+    else:
+        cc.compile_depth = variant_info.compile_depth
 
     loader = ModelLoader(variant=None)
     model_info = loader.get_model_info(variant=None)
@@ -49,12 +75,12 @@ def test_oft(record_property, mode, op_by_op):
     )
 
     tester = ThisTester(
-        model_info.name,
+        model_info.name,  # name of model
         mode,
         loader=loader,
         model_info=model_info,
         compiler_config=cc,
-        assert_atol=False,
+        assert_atol=variant_info.assert_atol,
         record_property_handle=record_property,
     )
 

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -70,6 +70,28 @@ class OpByOpBackend(Enum):
     STABLEHLO = 2
 
 
+class ModelMetadata:
+    def __init__(
+        self,
+        variant_name=None,
+        model_info=None,
+        variant_config=None,
+        loader=None,
+        compile_depth=CompileDepth.EXECUTE,
+        op_by_op_backend=OpByOpBackend.TORCH,
+        assert_pcc=False,
+        assert_atol=False,
+    ):
+        self.variant_name = variant_name
+        self.model_info = model_info
+        self.variant_config = variant_config
+        self.loader = loader
+        self.compile_depth = compile_depth
+        self.op_by_op_backend = op_by_op_backend
+        self.assert_pcc = assert_pcc
+        self.assert_atol = assert_atol
+
+
 class IOType(Enum):
     INTER_DEVICE = 1
     USER = 2
@@ -1000,3 +1022,47 @@ def get_output_types_from_program(program):
                 _extract_tensor_metadata(node_arg, output_dtypes, output_shapes)
 
     return output_dtypes, output_shapes
+
+
+def construct_metadata_from_variants(model_loader_class, override_variants=None):
+    """
+    General utility to construct ModelMetadata objects from forge model variants.
+
+    Args:
+        model_loader_class: The ModelLoader CLASS (not instance)
+        override_variants: Dict mapping variant names to ModelMetadata objects with test-specific overrides
+
+    Returns:
+        tuple: (list of ModelMetadata objects, list of variant names)
+    """
+    if override_variants is None:
+        override_variants = {}
+
+    # Call class methods on the CLASS, not an instance
+    available_variants = model_loader_class.query_available_variants()
+    metadata_list = []
+
+    for variant_name, variant_config in available_variants.items():
+        if variant_name in override_variants:
+            # Get the override metadata and embed the forge model info
+            metadata = override_variants[variant_name]
+            metadata.variant_config = variant_config
+            # Create an INSTANCE of ModelLoader the class for this variant
+            metadata.loader = model_loader_class(variant=variant_name)
+            # Call class method to get model info
+            metadata.model_info = model_loader_class.get_model_info(
+                variant=variant_name
+            )
+            metadata_list.append(metadata)
+        else:
+            # Create default metadata with forge model info embedded
+            model_info = model_loader_class.get_model_info(variant=variant_name)
+            metadata = ModelMetadata(
+                variant_name=variant_name,
+                variant_config=variant_config,
+                model_info=model_info,
+                loader=model_loader_class(variant=variant_name),  # Create instance
+            )
+            metadata_list.append(metadata)
+
+    return metadata_list, list(available_variants.keys())

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -1040,7 +1040,29 @@ def construct_metadata_from_variants(model_loader_class, override_variants=None)
 
     # Call class methods on the CLASS, not an instance
     available_variants = model_loader_class.query_available_variants()
+
     metadata_list = []
+
+    # No available variants means only base variant exists
+    if not available_variants:
+        if "base" in override_variants:
+            # If base variant is overridden, return it
+            metadata = override_variants["base"]
+            # metadata.variant_config = None
+            metadata.loader = model_loader_class(variant=None)
+            metadata.model_info = model_loader_class.get_model_info(variant=None)
+            metadata_list.append(metadata)
+        else:
+            model_info = model_loader_class.get_model_info(variant=None)
+            metadata = ModelMetadata(
+                variant_name="base",
+                # variant_config=None,
+                model_info=model_info,
+                loader=model_loader_class(variant=None),  # Create instance
+            )
+            metadata_list.append(metadata)
+
+        return metadata_list, ["base"]
 
     for variant_name, variant_config in available_variants.items():
         if variant_name in override_variants:


### PR DESCRIPTION
### Ticket
Original/Related Issue: [Add TTNN IR compile depth specification as pytest parameterization instead of as env variable](https://github.com/tenstorrent/tt-torch/issues/755)

### Problem Description
This PR begins the modular refactoring of our tt-torch testing framework, building on the goals of #755. The previous large refactor (PR #855) became unmanageable due to its size and conflicts, especially with tt-forge-models integration. The original goal was to move compile depth control from environment variables to pytest parameters for better CI analysis in #755. This change sets up the refactoring of all our test files. 

### What's Changed
This PR applies a streamlined portion of the previous refactor, designed for compatibility with tt-forge-models from the outset. It's the foundational groundwork for future modular testing so only key general characteristics have been included.
Also, test_oft.py and test_albert_masket_lm.py are the two test files that have been refactored first with these changes.
Key changes:
- Introduced ModelMetadata Class: For better model information encapsulation and test parametrization.
- Improved Test Parametrization: Test files (e.g., compile_e2e) now directly use ModelMetadata for configuration, replacing env variables.
- tt-forge-models Compatibility: the ModelMetadata class embeds Front End agnostic information from tt-forge-models to make the refactor work.

Note: Features like CLI filters which were in PR #855 are excluded to keep this PR focused. They will be addressed in subsequent refactor PRs. This PR marks is the beginning of an incremental refactor.

### Next Steps
Apply these refactoring patterns to more test files in follow-up PRs and make CI updates too.

### Checklist
[ ] Ensure CI passes.
[ ] Validate parametrization (e.g., compile depth) behaves as expected.