### PR TITLE
Add nightly fixes for misc models based on july 17 nightly

### DIFF
--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -45,7 +45,7 @@ def test_bloom(record_property, mode, op_by_op):
         loader=loader,
         model_info=model_info,
         relative_atol=0.01,
-        assert_pcc=True,
+        assert_pcc=False,  # Bloom PCC regression tracked in https://github.com/tenstorrent/tt-torch/issues/1071
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -48,6 +48,7 @@ def test_codegen(record_property, mode, op_by_op):
         record_property_handle=record_property,
         run_generate=False,
         assert_atol=False,
+        required_pcc=0.97,
     )
 
     results = tester.test_model()

--- a/tests/models/mlpmixer/test_mlpmixer_n300.py
+++ b/tests/models/mlpmixer/test_mlpmixer_n300.py
@@ -39,6 +39,9 @@ class ThisTester(ModelTester):
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
+@pytest.mark.skip(
+    reason="MLPMixer DRAM crash - Out of Memory: Not enough space to allocate 2147483648 B DRAM buffer across 12 banks, where each bank needs to store 178958336 B. Tracked in https://github.com/tenstorrent/tt-torch/issues/1055"
+)
 def test_mlpmixer(record_property, mode, op_by_op):
     if mode == "train":
         pytest.skip()

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -30,6 +30,10 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "data_parallel_mode", [False, True], ids=["single_device", "data_parallel"]
 )
+@pytest.mark.xfail(
+    reason="MusicGen model sees RuntimeError: dimensionality of sizes (0) must match dimensionality of strides (1), follow up in issue https://github.com/tenstorrent/tt-torch/issues/1073",
+    strict=True,
+)
 def test_musicgen_small(record_property, mode, op_by_op, data_parallel_mode):
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -48,7 +48,7 @@ def test_opt(record_property, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         relative_atol=0.015,
-        assert_pcc=True,
+        assert_pcc=False,  # PCC regression in OPT model observed around July 17, follow up in https://github.com/tenstorrent/tt-torch/issues/1072
         assert_atol=False,
     )
     tester.test_model(assert_eval_token_mismatch=False)

--- a/tests/models/phi/test_phi_1_1p5_2.py
+++ b/tests/models/phi/test_phi_1_1p5_2.py
@@ -59,6 +59,9 @@ def test_phi(record_property, model_name, mode, op_by_op):
         compiler_config=cc,
         record_property_handle=record_property,
         model_group=model_group,
+        required_pcc=0.93
+        if model_name == "microsoft/phi-1.5"
+        else 0.95,  # PCC drop observed around Jul 17, follow up in https://github.com/tenstorrent/tt-torch/issues/1070
         run_generate=False,
         assert_atol=False,
     )

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -4,12 +4,12 @@
 # Reference: https://huggingface.co/timm
 # PyTorch Image Models (timm) is a collection of image models, layers, utilities, optimizers, schedulers, data-loaders / augmentations, and reference training / validation scripts that aim to pull together a wide variety of SOTA models with ability to reproduce ImageNet training results.
 
-from urllib.request import urlopen
 from PIL import Image
 import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.tools.utils import get_file
 
 dependencies = ["timm==1.0.9"]
 
@@ -26,10 +26,11 @@ class ThisTester(ModelTester):
         import timm
 
         img = Image.open(
-            urlopen(
+            get_file(
                 "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
             )
         )
+
         # get model specific transforms (normalization, resize)
         data_config = timm.data.resolve_model_data_config(self.framework_model)
         transforms = timm.data.create_transform(**data_config, is_training=False)

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -127,15 +127,6 @@ def test_torchvision_image_classification(
 
     model_group = "red" if model_name == "swin_v2_s" else "generality"
 
-    # Out of Memory: Not enough space to allocate 336691200 B DRAM buffer across 12 banks, where each bank needs to store 28057600 B
-    if model_name == "vit_h_14" and cc.compile_depth == CompileDepth.EXECUTE:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Out of Memory: Not enough space to allocate in DRAM error - https://github.com/tenstorrent/tt-torch/issues/793",
-                strict=True,
-            )
-        )
-
     tester = ThisTester(
         model_info,
         mode,

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -62,6 +62,7 @@ class ThisTester(ModelTester):
             pretrained=True,
             autoshape=False,
             device="cpu",
+            trust_repo=True,
         )
 
         # Remove the downloaded pretrained weight file.


### PR DESCRIPTION
### Ticket
This PR addresses miscellaneous July 17 nightly failures in full model tests.

### Problem description
- Musicgen hits a pytorch runtime exception -> xfailed #1073
- OPT sees a large PCC drop to 0.8 -> disable checking #1072 
- PHI 1, 1.5, 2 models see a minor pcc drop to .93-0.95 -> reduce threshold #1070 
- BLOOM model sees a large PCC drop to 0.66 -> disable checking #1071 
- EfficientNet models don't use the get_file API and are rate limited -> use get_file API
- YoloV5 fails due to untrusted weights demo. Port fix from @ssaliceTT #1045 
- MLPMixer N300 hits OOM causing test group crash -> skip test #1055 

### Checklist
- [x] New/Existing tests provide coverage for changes
