### PR TITLE
Add libgl to 'Getting Started from Source' documentation 

### DIFF
--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -125,7 +125,8 @@ sudo apt-get install -y \
     patchelf \
     libyaml-cpp-dev \
     libboost-all-dev \
-    lcov
+    lcov \
+    libgl
 ```
 
 Install OpenMPI:


### PR DESCRIPTION
### Ticket
None

### Problem description
`libgl` is necessary for YOLOv5 and it is included in Dockerfile. It is missing from `Getting Started from Source` documentation. Saber was having problems with this. 

### What's changed
Add libgl to `Getting Started from Source`

### Checklist
- [X] New/Existing tests provide coverage for changes
