### PR TITLE
Update to latest tt-forge-models for yolov3 s3 bucket fix

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -121,7 +121,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "3c6a286193f2773b13024d4952aaa66f28ab6e52")
+    set(TT_FORGE_MODELS_VERSION "9930bf88aef75a9679be7643b25592ac556b3a3a")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-models/issues/46

### Problem description
 - Weights file for yolov3 fetched from URL, not accessible on CiV2

### What's changed
- Pull in latest tt-forge-models which contains fix for yolov3 weight in s3 bucket instead of URL
- Update also includes yolov4 model update to use pretrained weights

### Checklist
- [x] Both tests covered by onPR
