### PR TITLE
Defer PCC/ATOL assertions for model tests until after tags reported

### DIFF
--- a/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
+++ b/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
@@ -79,7 +79,7 @@ def test_falcon_pipeline_parallel(record_property, model_name, mode, op_by_op):
     compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
     out = compiled_model(**test_input)
     golden = model(**test_input)
-    pccs, atols, _, _ = verify_against_golden(
+    pccs, atols, _, _, _ = verify_against_golden(
         tuple([golden.logits]),
         tuple([out.logits]),
         assert_pcc=assert_pcc,

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -89,7 +89,7 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
     out = compiled_model(**test_input)
     golden = model(**test_input)
-    pccs, atols, _, _ = verify_against_golden(
+    pccs, atols, _, _, _ = verify_against_golden(
         tuple([golden.logits]),
         tuple([out.logits]),
         assert_pcc,

--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -716,7 +716,7 @@ def test_verify_against_golden_low_atol_high_pcc(assert_pcc, assert_atol):
 
     golden_tensors = (torch.tensor([1.0, 2.0, 3.0]),)
     calculated_tensors = (torch.tensor([1.0, 2.0, 3.0]),)
-    pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+    pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
         golden_tensors,
         calculated_tensors,
         assert_pcc=assert_pcc,
@@ -743,7 +743,7 @@ def test_verify_against_golden_high_atol_high_pcc(assert_pcc, assert_atol):
         # Assert that an AssertionError is raised if we are asserting ATOL
         # when comparing tensors with a true high ATOL
         with pytest.raises(AssertionError) as e:
-            pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+            pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
                 golden_tensors,
                 calculated_tensors,
                 assert_pcc=assert_pcc,
@@ -751,7 +751,7 @@ def test_verify_against_golden_high_atol_high_pcc(assert_pcc, assert_atol):
                 required_atol=0.1,
             )
     else:
-        pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+        pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
             golden_tensors,
             calculated_tensors,
             assert_pcc=assert_pcc,
@@ -785,7 +785,7 @@ def test_verify_against_golden_low_atol_low_pcc(assert_pcc, assert_atol):
         # Assert that an AssertionError is raised if we are asserting PCC
         # when comparing tensors with a true low PCC
         with pytest.raises(AssertionError) as e:
-            pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+            pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
                 golden_tensors,
                 calculated_tensors,
                 assert_pcc=assert_pcc,
@@ -794,7 +794,7 @@ def test_verify_against_golden_low_atol_low_pcc(assert_pcc, assert_atol):
                 required_atol=0.25,
             )
     else:
-        pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+        pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
             golden_tensors,
             calculated_tensors,
             assert_pcc=assert_pcc,
@@ -823,7 +823,7 @@ def test_verify_against_golden_high_atol_low_pcc(assert_pcc, assert_atol):
         # In this case, both ATOL and PCC are truly bad, so asserting on either
         # should cause an AssertionError to be raised
         with pytest.raises(AssertionError) as e:
-            pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+            pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
                 golden_tensors,
                 calculated_tensors,
                 assert_pcc=assert_pcc,
@@ -832,7 +832,7 @@ def test_verify_against_golden_high_atol_low_pcc(assert_pcc, assert_atol):
                 required_atol=0.1,
             )
     else:
-        pccs, atols, passed_pcc, passed_atol = verify_against_golden(
+        pccs, atols, passed_pcc, passed_atol, _ = verify_against_golden(
             golden_tensors,
             calculated_tensors,
             assert_pcc=assert_pcc,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -501,7 +501,7 @@ class ModelTester:
             err_parts = []
             if self.assert_pcc and not passed_pcc:
                 err_parts.append(
-                    f"PCC check failed. Required: {self.required_pcc}, Got: {min(pccs) if pccs else 'N/A'}"
+                    f"PCC check failed. Required: {self.required_pcc}, Got lowest pcc {min(pccs) if pccs else 'N/A'}"
                 )
             if self.assert_atol and not passed_atol:
                 atol_threshold = (
@@ -510,7 +510,7 @@ class ModelTester:
                     else self.relative_atol
                 )
                 err_parts.append(
-                    f"ATOL check failed. Required: {atol_threshold}, Got: {max(atols) if atols else 'N/A'}"
+                    f"ATOL check failed. Required: {atol_threshold}, Got highest atol {max(atols) if atols else 'N/A'}"
                 )
             self.verification_failure_msg = "; ".join(err_parts)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -217,6 +217,9 @@ class ModelTester:
                 ) = DeviceManager.acquire_available_devices()
 
         self.record_tag_cache = {}  # Holds for tags to be written out at finalize()
+        self.verification_failure_msg = (
+            None  # Store failure message for deferred assertion
+        )
 
         self.record_tag_cache["backend"] = self.backend
         self.record_property("model_name", model_name + model_name_suffix)
@@ -441,7 +444,7 @@ class ModelTester:
         results = self.get_results_train(model, inputs, outputs)
         return results
 
-    def verify_outputs(self, golden, outputs):
+    def verify_outputs(self, golden, outputs, defer_assertions=False):
 
         # Only do golden check if running EXECUTE. Limited value comparing in other situations.
         if self.compiler_config.compile_depth != CompileDepth.EXECUTE:
@@ -474,17 +477,43 @@ class ModelTester:
             golden_tensors = self._extract_outputs(golden)
             output_tensors = self._extract_outputs(outputs)
 
+        # When defer_assertions=True, disable assertions in verify_against_golden
+        assert_pcc = self.assert_pcc if not defer_assertions else False
+        assert_atol = self.assert_atol if not defer_assertions else False
+
         pccs, atols, passed_pcc, passed_atol = verify_against_golden(
             golden_tensors,
             output_tensors,
-            self.assert_pcc,
-            self.assert_atol,
+            assert_pcc,
+            assert_atol,
             self.required_pcc,
             self.required_atol,
             self.relative_atol,
         )
         self.record_tag_cache["pccs"] = pccs
         self.record_tag_cache["atols"] = atols
+
+        # Store verification failure for deferred assertion
+        if defer_assertions and (
+            (self.assert_pcc and not passed_pcc)
+            or (self.assert_atol and not passed_atol)
+        ):
+            err_parts = []
+            if self.assert_pcc and not passed_pcc:
+                err_parts.append(
+                    f"PCC check failed. Required: {self.required_pcc}, Got: {min(pccs) if pccs else 'N/A'}"
+                )
+            if self.assert_atol and not passed_atol:
+                atol_threshold = (
+                    self.required_atol
+                    if self.required_atol is not None
+                    else self.relative_atol
+                )
+                err_parts.append(
+                    f"ATOL check failed. Required: {atol_threshold}, Got: {max(atols) if atols else 'N/A'}"
+                )
+            self.verification_failure_msg = "; ".join(err_parts)
+
         if passed_pcc and passed_atol:
             self.record_property("achieved_compile_depth", "PASSED")
 
@@ -522,7 +551,11 @@ class ModelTester:
         return self._test_model_eval_base(on_device, assert_eval_token_mismatch)
 
     def _verify_full_execution_output(
-        self, device_output, golden_output, assert_eval_token_mismatch
+        self,
+        device_output,
+        golden_output,
+        assert_eval_token_mismatch,
+        defer_assertions=False,
     ):
         """
         This function verifies a single device's output tensors against the golden tensors
@@ -536,12 +569,18 @@ class ModelTester:
             decoded_golden = self.tokenizer.batch_decode(
                 golden_output, skip_special_tokens=True
             )
-            if assert_eval_token_mismatch:
+            if assert_eval_token_mismatch and not defer_assertions:
                 assert (
                     decoded_outputs == decoded_golden
                 ), f'Output mismatch: calculated: "{decoded_outputs} vs golden: "{decoded_golden}"'
+            elif (
+                defer_assertions
+                and assert_eval_token_mismatch
+                and decoded_outputs != decoded_golden
+            ):
+                self.verification_failure_msg = f'Token output mismatch: calculated: "{decoded_outputs}" vs golden: "{decoded_golden}"'
         else:
-            self.verify_outputs(golden_output, device_output)
+            self.verify_outputs(golden_output, device_output, defer_assertions)
 
     @torch.inference_mode()
     def _test_model_eval_data_parallel(self, assert_eval_token_mismatch):
@@ -573,7 +612,7 @@ class ModelTester:
         try:
             for outputs in final_outputs:
                 self._verify_full_execution_output(
-                    outputs, golden, assert_eval_token_mismatch
+                    outputs, golden, assert_eval_token_mismatch, defer_assertions=True
                 )
         finally:
             if self.parent_device is not None:
@@ -597,7 +636,9 @@ class ModelTester:
         if self.compiler_config._enable_intermediate_verification:
             self.verify_intermediates_after_execution()
 
-        self._verify_full_execution_output(outputs, golden, assert_eval_token_mismatch)
+        self._verify_full_execution_output(
+            outputs, golden, assert_eval_token_mismatch, defer_assertions=True
+        )
         return outputs
 
     @torch.inference_mode()
@@ -705,6 +746,11 @@ class ModelTester:
             self.required_pcc,
         )
         self.record_property("tags", self.record_tag_cache)
+
+        # Assert any deferred verification failures after all reporting is complete
+        # This allows pytest to write junitxml during teardown even if the test fails
+        if self.verification_failure_msg:
+            assert False, self.verification_failure_msg
 
     def verify_intermediates_after_execution(self):
         # Prepare CSV output

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -919,7 +919,7 @@ class RuntimeIntermediate:
 
         # Get PCCs from raw tensors, which may not work due to TTNN reshaping (eg. channels last. Ignore as tensor shape mismatch assertionErrors for now.)
         try:
-            (self.pcc, self.atol, _, _) = verify_against_golden(
+            (self.pcc, self.atol, _, _, _) = verify_against_golden(
                 self.golden,
                 final_decomposed_output,
                 assert_pcc=False,
@@ -941,7 +941,7 @@ class RuntimeIntermediate:
             if isinstance(final_decomposed_output[0], torch.Tensor):
                 flat_intermediate = (torch.flatten(final_decomposed_output[0]),)
 
-            (self.flattened_pcc, self.flattened_atol, _, _) = verify_against_golden(
+            (self.flattened_pcc, self.flattened_atol, _, _, _) = verify_against_golden(
                 flat_golden,
                 flat_intermediate,
                 assert_pcc=False,

--- a/tt_torch/tools/verify.py
+++ b/tt_torch/tools/verify.py
@@ -171,8 +171,12 @@ def verify_against_golden(
                 msg = msg + f"{check_mark}\n"
             msg = msg + f"{check_mark}\n"
         else:
+            if atol_ != SKIPPED_NON_TENSOR_ITEM:
+                msg = (
+                    msg
+                    + f"  ATOL: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} "
+                )
             msg = msg + f"{red_x if assert_atol else atol_warning}\n"
-
             err_msg = (
                 err_msg
                 + f"ATOL of output {i}: {atol_:0,.4f}, threshold: {atol_threshold}{f' (calculated using relative_atol: {relative_atol})' if relative_atol is not None else ''} {red_x if assert_atol else atol_warning}\n"
@@ -193,7 +197,8 @@ def verify_against_golden(
             assert False, err_msg
     if not disable_print:
         print(msg)
-    return pccs, atols, passed_pcc, passed_atol
+
+    return pccs, atols, passed_pcc, passed_atol, atol_thresholds
 
 
 def _verify_torch_module(


### PR DESCRIPTION
### Ticket
Tests that assert on and then fail ATOL or PCC checks will not show up in database reports. This causes them to be absent from a nightly report, rather than showing up as explicitly failed, which is bad for observability.

### Problem description
ATOL and PCC data (along with much metadata in the rest of `tags`) is not flushed to the XML file in tester.finalize() if the assert_atol/pcc assert triggers, because the AssertionError short circuits execution and tester.finalize() cannot be afterwards, which will mess up test cleanup (e.g. device closure) and not report.

### What's changed
Defer ATOL and PCC assertions for tests using the ModelTester to after tester.finalize() is called, allowing tags to be gracefully flushed to XML before the assertion takes over control flow.

This also allows us to xfail on PCC and ATOL, so tests can notify us when they start passing due to uplift fixes.

### Checklist
- [x] Checked that a dummy testcase with failing ATOL/PCC assertions does produce a report that is ingested and queryable. Models that failed ATOL/PCC now show up, rather than being absent from the database entirely.
