### PR TITLE
Support dumping of flatbuffer binary into json file

### DIFF
--- a/tt_torch/dynamo/backend.py
+++ b/tt_torch/dynamo/backend.py
@@ -150,6 +150,19 @@ def dump_module(module, name, compiler_config):
             f.write("\n")
 
 
+def dump_binary_json(binary, compiler_config):
+    if compiler_config.dump_binary_json:
+        assert (
+            compiler_config.output_json_dir
+        ), "Cannot dump binary json, no output directory provided"
+        output_dir = compiler_config.output_json_dir
+        sanitized_model_name = sanitize_filename(compiler_config.model_name)
+        filepath = os.path.join(output_dir, f"{sanitized_model_name}.json")
+        my_json = tt_mlir.bytestream_to_json(binary)
+        with open(filepath, "a") as f:
+            f.write(my_json)
+
+
 def _shlo_backend(
     mcg,
     example_inputs,
@@ -253,6 +266,7 @@ def shlo_to_flatbuffer(
         compiler_config.enable_optimizer,
     )
     dump_module(module=ttnn, name="TTNN", compiler_config=compiler_config)
+    dump_binary_json(binary, compiler_config)
 
     return binary
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Vladan requested generating flatbuffer binary in json format.

### What's changed
Added support to dump flatbuffer binary in a json file.
Considerations:
- test needs to be running full model (NOT op-by-op)
- Right now, generation needs to happen locally. These json files are big so we need to strategize on if/ how to add to CI
- Example usage:
```
TT_TORCH_SAVE_BINARY_JSON=1 pytest -s tests/models/resnet/test_resnet.py::test_resnet[single_device-full-eval]
```

### Checklist
- [X] New/Existing tests provide coverage for changes
