### PR TITLE
Add an option in CompilerConfig to override arg_type_map

### DIFF
--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -693,10 +693,12 @@ class XLAExecutor:
             inputs[self.user_input_indices[idx]] = args[idx]
 
         output = self.program.graph_module(*inputs)
-        if self.arg_type_map_str is None:
-            self.generate_arg_type_map_str(output)
-        if os.environ.get("ARG_TYPE_MAP_OVERRIDE") != self.arg_type_map_str:
-            os.environ["ARG_TYPE_MAP_OVERRIDE"] = self.arg_type_map_str
+
+        if self.compiler_config.arg_type_map_override:
+            if self.arg_type_map_str is None:
+                self.generate_arg_type_map_str(output)
+            if os.environ.get("ARG_TYPE_MAP_OVERRIDE") != self.arg_type_map_str:
+                os.environ["ARG_TYPE_MAP_OVERRIDE"] = self.arg_type_map_str
 
         xm.mark_step()
         if self.compiler_config.push_outputs_to_cpu:

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -333,6 +333,7 @@ class CompilerConfig:
         self.automatic_parallelization = False
         self.mesh_shape = [1, 1]
         self.push_outputs_to_cpu = True
+        self.arg_type_map_override = False
 
     @property
     def model_name(self):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-torch/issues/1089

### Problem description
Provide context for the problem.

### What's changed
Add an option in CompilerConfig to override arg_type_map

### Checklist
- [ ] New/Existing tests provide coverage for changes
