### PR TITLE
Transformation for random number generation

### DIFF
--- a/tests/experimental/test_torch_xla_transformations.py
+++ b/tests/experimental/test_torch_xla_transformations.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from tt_torch.tools.verify import verify_against_golden
+import torch
+import torch_xla
+
+import pytest
+
+
+def test_bernoulli_transformation():
+    input_x = torch.full((1, 16), 0.5, dtype=torch.float32)
+
+    class Bernoulli(torch.nn.Module):
+        def forward(self, x):
+            return torch.bernoulli(x)
+
+    model = Bernoulli()
+    torch.manual_seed(33)
+    golden = model(input_x)
+
+    device = torch_xla.device()
+    model = torch.compile(model, backend="tt-experimental")
+    input_x = input_x.to(device)
+
+    torch.manual_seed(33)
+    output = model(input_x)
+    output = output.to("cpu")
+
+    verify_against_golden(
+        (golden,),
+        (output,),
+        assert_pcc=True,
+        assert_atol=True,
+        required_pcc=0.99,
+        required_atol=0.00,
+    )

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -8,6 +8,9 @@ import operator
 from .xla_decompositions import (
     CUSTOM_DECOMPOSITION_TABLE,
 )
+from .xla_transformations import (
+    ReplaceRandWithConstant,
+)
 import os
 import tempfile
 import multiprocessing as mp
@@ -590,6 +593,8 @@ def xla_pass_pipeline(gm, example_inputs, compiler_config):
         .run_decompositions(decompositions)
         .module()
     )
+
+    compiled_graph = ReplaceRandWithConstant(compiled_graph).transform()
 
     compiled_graph = bypass_dtype_promotion(compiled_graph, compiler_config)
     run_shape_prop(compiled_graph, example_inputs)

--- a/tt_torch/dynamo/experimental/xla_transformations.py
+++ b/tt_torch/dynamo/experimental/xla_transformations.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.fx
+from torch.fx.passes.infra.pass_base import PassBase
+
+# Transform: Replace aten.rand.default with a constant random tensor
+class ReplaceRandWithConstant(torch.fx.Transformer):
+    def call_function(self, target, args, kwargs):
+        # TODO: Remove this transformation when TTNN api add support for random
+        # number generation.
+        if target == torch.ops.aten.rand.default:
+            size = args[0]
+            dtype = kwargs.get("dtype", torch.float32)
+            device = kwargs.get("device", "cpu")
+            layout = kwargs.get("layout", None)
+            pin_memory = kwargs.get("pin_memory", False)
+            # Generate fixed random tensor on cpu
+            with torch.no_grad():
+                const_tensor = torch.rand(
+                    size,
+                    dtype=dtype,
+                    device="cpu",
+                    layout=layout,
+                    pin_memory=pin_memory,
+                )
+            return const_tensor.to("xla")
+        return super().call_function(target, args, kwargs)

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -19,6 +19,9 @@ from tt_torch.tools.utils import (
 from .decompositions import (
     CUSTOM_DECOMPOSITION_TABLE,
 )
+from .transformations import (
+    ReplaceRandWithConstant,
+)
 
 
 def run_shape_prop(gm, example_inputs):
@@ -585,6 +588,8 @@ def run_pass_pipeline_for_single_gm(
         .run_decompositions(decompositions)
         .module()
     )
+
+    gm_device = ReplaceRandWithConstant(gm_device).transform()
     gm_device = bypass_dtype_promotion(gm_device, compiler_config)
     # shape prop also propagates dtypes, need to run to figure out which casts are redundant
     run_shape_prop(gm_device, example_inputs)

--- a/tt_torch/dynamo/transformations.py
+++ b/tt_torch/dynamo/transformations.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import torch.fx
+from torch.fx.passes.infra.pass_base import PassBase
+
+# Transform: Replace aten.rand.default with a constant random tensor
+class ReplaceRandWithConstant(torch.fx.Transformer):
+    def call_function(self, target, args, kwargs):
+        if target == torch.ops.aten.rand.default:
+            size = args[0]
+            dtype = kwargs.get("dtype", torch.float32)
+            device = kwargs.get("device", "cpu")
+            layout = kwargs.get("layout", None)
+            pin_memory = kwargs.get("pin_memory", False)
+            # Generate fixed random tensor on cpu
+            with torch.no_grad():
+                const_tensor = torch.rand(
+                    size,
+                    dtype=dtype,
+                    device="cpu",
+                    layout=layout,
+                    pin_memory=pin_memory,
+                )
+            return const_tensor.to(device)
+        return super().call_function(target, args, kwargs)


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
TTNN API does not support random number generation.

### What's changed
Add a transformation to convert torch.ops.aten.rand.default op to
randomly generated constant tensor.

### Checklist
- [X] New/Existing tests provide coverage for changes
