### PR TITLE
Add workflow data collection for experimental nightly tests

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -9,22 +9,54 @@ on:
       - "Nightly Tests"
       - "Run Model Tests"
       - "Run Tests"
+      - "Nightly Experimental Tests"
     types:
       - completed
-
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Run ID to collect data for'
+        required: true
+        default: '0'
+      run_attempt:
+        description: 'Run attempt to collect data for'
+        required: true
+        default: '1'
 jobs:
   produce-cicd-data:
     runs-on: ubuntu-latest
     env:
         GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Collect CI/CD data
+      - name: Debug manual dispatch inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "=== Manual Dispatch Debug Info ==="
+          echo "Event name: ${{ github.event_name }}"
+          echo "Run ID input: ${{ github.event.inputs.run_id }}"
+          echo "Run attempt input: ${{ github.event.inputs.run_attempt }}"
+          echo "================================="
+
+      - name: Collect CI/CD data (from workflow_run)
         uses: tenstorrent/tt-github-actions/.github/actions/collect_data@main
         if: ${{ github.event_name == 'workflow_run' }}
         with:
           repository: ${{ github.repository }}
           run_id: ${{ github.event.workflow_run.id }}
           run_attempt: ${{ github.event.workflow_run.run_attempt }}
+          sftp_host: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
+          sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
+          sftp_optest_host: ${{ secrets.SFTP_OP_TEST_WRITER_HOSTNAME }}
+          sftp_optest_user: ${{ secrets.SFTP_OP_TEST_WRITER_USERNAME }}
+          ssh-private-key: ${{ secrets.SFTP_CICD_WRITER_KEY }}
+
+      - name: Collect CI/CD data (from manual dispatch)
+        uses: tenstorrent/tt-github-actions/.github/actions/collect_data@main
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          repository: ${{ github.repository }}
+          run_id: ${{ github.event.inputs.run_id }}
+          run_attempt: ${{ github.event.inputs.run_attempt }}
           sftp_host: ${{ secrets.SFTP_CICD_WRITER_HOSTNAME }}
           sftp_user: ${{ secrets.SFTP_CICD_WRITER_USERNAME }}
           sftp_optest_host: ${{ secrets.SFTP_OP_TEST_WRITER_HOSTNAME }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Nightly experimental test data isn't picked up and shunted into database

### What's changed
Add ability to pick up nightly experimental test data automatically through collect-data job, and add a manual trigger to collect-data job for retroactive data collection.

### Checklist
- [x] New/Existing tests provide coverage for changes
