### PR TITLE
Uplift tt-xla to 10061a261faf8008c781c3282bee9ba58bdeab52

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,7 +6,7 @@
 # underlying tt-mlir version we will have tt-xla use
 set(TT_MLIR_VERSION "bcc6c92b437f1ce7a31fdee5a760397ff4889ead")
 # tt-xla version to use
-set(TTXLA_VERSION "7e554cec849f37e7326beab1d7ba9880b2a4581b")
+set(TTXLA_VERSION "10061a261faf8008c781c3282bee9ba58bdeab52")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)


### PR DESCRIPTION
Uplifts these changes from tt-xla:
```
10061a2 Muhammad Asif Manzoor 2025-07-23 Enable ttmlir runtime debugging (#826)
a982da1 Jackson Nie 2025-07-23 Add op model build option to tt-mlir (#892)
192cfac Logeshwaran Elanchelian 2025-07-23 remove xfail marker from test_mnist_cnn_dropout (#889)
5d9ad4a Uros Pantelic 2025-07-23 Llama3.1 8 b paralel (#779)
b59cbb1 Andrej Jakovljevic 2025-07-23 Uplift third_party/tt-mlir to bcc6c92b437f1ce7a31fdee5a760397ff4889ead 2025-07-23 (#888)
4f2758c Nebojsa Sumrak 2025-07-22 Run Performance benchmarks from tt-xla (#868)
55ce5a4 Andrej Jakovljevic 2025-07-22 Uplift third_party/tt-mlir to 71d693a4074e06324d93e86957db0bf5fcdade47 2025-07-22 (#872)
4c37cea Vladimir Vukoman 2025-07-21 Set new uplift commit author (#870)
```