### PR TITLE
Update tensor creation process

### DIFF
--- a/tests/torch/test_basic.py
+++ b/tests/torch/test_basic.py
@@ -285,6 +285,22 @@ def test_div_zero():
     verify_module(Basic(), inputs=[input1, input2])
 
 
+# ConcatOp returns non-empty tensor as output (without performing actual operation).
+# However, the stablehlo graph contains both function arguments (empty and non-empty tensor).
+def test_empty():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.cat([x, y], dim=-1)
+
+    # Empty tensor
+    input1 = torch.randn((1, 2, 2, 0), dtype=torch.float32)
+    input2 = torch.randn((1, 2, 2, 2), dtype=torch.float32)
+    verify_module(Basic(), inputs=[input1, input2])
+
+
 def test_exp():
     class Basic(nn.Module):
         def __init__(self):


### PR DESCRIPTION
### Ticket
closes https://github.com/tenstorrent/tt-torch/issues/1115

### Problem description
`tt::runtime::createBorrowedHostTensor` is used to create tensor which can only be used for non empty tensors. This cause runtime failure if a graph contains empty tensor.

### What's changed
Use `tt::runtime::createOwnedHostTensor` to create empty tensors.

### Checklist
- [X] New/Existing tests provide coverage for changes
