### PR TITLE
Add --forked to full-model-execute ymls and shuffle high memory phi-2 to high-memory group

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -177,12 +177,13 @@ jobs:
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-inception_v4.tf_in1k]
                   tests/models/vovnet/test_vovnet_onnx.py::test_vovnet_onnx[full-eval]
                   tests/models/seamless_m4t/test_seamless_m4t.py::test_seamless_m4t[full-eval]
+                  tests/models/bert/test_bert.py::test_bert[large-full-eval]
             "
           },
           {
             # Approximately 5 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_7_bert_qrtn", tests: "
-                  tests/models/bert/test_bert.py::test_bert[large-full-eval]
+            wh-runner: high-memory-wormhole, bh-runner: p150, name: "eval_7_high_mem", tests: "
+                  tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
             "
           },
           # Approximately 180 minutes.
@@ -204,7 +205,6 @@ jobs:
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b7-eval]
                 tests/models/codegen/test_codegen.py::test_codegen[full-eval]
                 tests/models/codegen/test_codegen_generate.py::test_codegen_generate[full-eval]
-                tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Base-eval]
                 tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-3B-Instruct-eval]
                 tests/models/t5/test_t5.py::test_t5[full-t5-large-eval]
@@ -394,7 +394,7 @@ jobs:
       run: |
         source env/activate
 
-        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --forked --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -220,7 +220,7 @@ jobs:
       run: |
         source env/activate
 
-        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --forked --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ mdutils
 pre-commit
 pytest
 pytest-cov
+pytest-xdist
+pytest-forked
 tabulate
 openpyxl
 seaborn


### PR DESCRIPTION
### Ticket
None

### Problem description
 - Tests that use more than 32GB or 48GB memory can be killed with signal 137 which takes down entire pytest group resulting in nothing reported to superset database.
 - We didn't have common `high-memory` tag that could return n150 or n300 high machines for use by tests

### What's changed
- Added deps (pytest-xdist, pytest-forked) to use pytest --forked arg which gives per-test processes so when tests killed due to OOM, it only affects a single test and not entire group.
- Move high memory offender phi-2 to it's own group, move previously quarantined bert test back to common group
- On github settings, tagged all high-memory-n* machines with `high-memory-wormhole` now and use it here to try and make phi-2 safer in future runs,

### Checklist
- [x] Tested locally and on branch
