### PR TITLE
Update 5 models from tt-forge-models

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -80,7 +80,7 @@ jobs:
           },
           {
             wh-runner: wormhole_b0, bh-runner: p150, name: "eval_4", tests: "
-                  tests/models/llama/test_llama_3b.py::test_llama_3b[full-meta-llama/Llama-3.2-3B-eval]
+                  tests/models/llama/test_llama_3b.py::test_llama_3b[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_x_400mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_x_800mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_x_1_6gf]

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -74,7 +74,7 @@ jobs:
           },
           {
             runs-on: wormhole_b0, name: "llama", tests: "
-              tests/models/llama/test_llama_3b.py::test_llama_3b[op_by_op_torch-meta-llama/Llama-3.2-3B-eval]
+              tests/models/llama/test_llama_3b.py::test_llama_3b[op_by_op_torch-eval]
               tests/models/llama/test_llama_7b.py::test_llama_7b[op_by_op_torch-eval]
               "
           },

--- a/tests/experimental/models/llama/test_llama_3b.py
+++ b/tests/experimental/models/llama/test_llama_3b.py
@@ -11,47 +11,36 @@ import torch_xla.core.xla_model as xm
 from tt_torch.tools.utils import (
     calculate_pcc,
 )
+from third_party.tt_forge_models.llama.causal_lm.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = AutoModelForCausalLM.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
-        )
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
-        )
-        self.tokenizer.pad_token = self.tokenizer.eos_token
-        return model
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        self.test_input = "This is a sample text from "
-        inputs = self.tokenizer.encode_plus(
-            self.test_input,
-            return_tensors="pt",
-            max_length=32,
-            padding="max_length",
-            truncation=True,
-        )
-        return inputs
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
-@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.TORCH, None],
     ids=["op_by_op_torch", "full"],
 )
-def test_llama_3b(record_property, model_name, op_by_op):
+def test_llama_3b(record_property, op_by_op):
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     cc.enable_consteval = True
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         "eval",
+        loader=loader,
         compiler_config=cc,
         assert_atol=False,
         assert_pcc=True,
@@ -65,21 +54,10 @@ def test_llama_3b(record_property, model_name, op_by_op):
 
 
 def test_llama_3b_eager():
-    model = AutoModelForCausalLM.from_pretrained(
-        "meta-llama/Llama-3.2-3B", torch_dtype=torch.bfloat16
-    ).eval()
-    tokenizer = AutoTokenizer.from_pretrained(
-        "meta-llama/Llama-3.2-3B", torch_dtype=torch.bfloat16
-    )
-    tokenizer.pad_token = tokenizer.eos_token
-    test_input = "This is a sample text from "
-    inputs = tokenizer.encode_plus(
-        test_input,
-        return_tensors="pt",
-        max_length=32,
-        padding="max_length",
-        truncation=True,
-    )
+    loader = ModelLoader(variant=None)
+    model = loader.load_model(dtype_override=torch.bfloat16).eval()
+    inputs = loader.load_inputs(dtype_override=torch.bfloat16)
+
     cpu_outputs = model(**inputs).logits
 
     device = xm.xla_device()

--- a/tests/experimental/models/mistral/test_mistral.py
+++ b/tests/experimental/models/mistral/test_mistral.py
@@ -9,54 +9,39 @@ from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 import torch_xla.core.xla_model as xm
 
 from tt_torch.tools.utils import calculate_pcc
+from third_party.tt_forge_models.mistral.pytorch import ModelLoader, ModelVariant
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, padding_side="left", torch_dtype=torch.bfloat16
-        )
-        m = AutoModelForCausalLM.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
-        )
-        return m
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        # Set up sample input
-        self.test_input = "How often does the letter r occur in Mistral?"
-        inputs = self.tokenizer.encode_plus(self.test_input, return_tensors="pt")
-        return inputs
+        return self.loader.load_inputs()
 
 
-model_info_list = [
-    ("ministral3b", "ministral/Ministral-3b-instruct"),
-]
-
-
-@pytest.mark.parametrize(
-    "model_info",
-    model_info_list,
-    ids=[model_info[0] for model_info in model_info_list],
-)
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.TORCH, None],
     ids=["op_by_op_torch", "full"],
 )
-def test_mistral(record_property, model_info, op_by_op):
-    __, model_name = model_info
-    model_group = "red"
-
+def test_mistral(record_property, op_by_op):
     cc = CompilerConfig()
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
     cc.enable_consteval = True
 
+    loader = ModelLoader(variant=ModelVariant.MINISTRAL_3B)
+    model_info = loader.get_model_info(variant=ModelVariant.MINISTRAL_3B)
+    model_name = model_info.name
+    model_group = model_info.group.value
+
     # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/689
     tester = ThisTester(
         model_name,
         "eval",
+        loader=loader,
         compiler_config=cc,
         record_property_handle=record_property,
         assert_atol=False,
@@ -70,17 +55,9 @@ def test_mistral(record_property, model_info, op_by_op):
 
 
 def test_mistral3b_eager():
-    tokenizer = AutoTokenizer.from_pretrained(
-        "ministral/Ministral-3b-instruct",
-        padding_side="left",
-        torch_dtype=torch.bfloat16,
-    )
-    model = AutoModelForCausalLM.from_pretrained(
-        "ministral/Ministral-3b-instruct", torch_dtype=torch.bfloat16
-    ).eval()
-
-    test_input = "How often does the letter r occur in Mistral?"
-    inputs = tokenizer.encode_plus(test_input, return_tensors="pt")
+    loader = ModelLoader(variant=ModelVariant.MINISTRAL_3B)
+    model = loader.load_model(dtype_override=torch.bfloat16).eval()
+    inputs = loader.load_inputs()
 
     cpu_outputs = model(**inputs).logits
 

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -5,43 +5,27 @@ import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig
+from third_party.tt_forge_models.llama.causal_lm.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = AutoModelForCausalLM.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
-        )
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model_name, torch_dtype=torch.bfloat16
-        )
-        self.tokenizer.pad_token = self.tokenizer.eos_token
-        return model
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        self.test_input = "This is a sample text from "
-        inputs = self.tokenizer.encode_plus(
-            self.test_input,
-            return_tensors="pt",
-            max_length=32,
-            padding="max_length",
-            truncation=True,
-        )
-        return inputs
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
 
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
 )
-@pytest.mark.parametrize("model_name", ["meta-llama/Llama-3.2-3B"])
 @pytest.mark.parametrize(
     "op_by_op",
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
-def test_llama_3b(record_property, model_name, mode, op_by_op):
+def test_llama_3b(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
@@ -51,9 +35,13 @@ def test_llama_3b(record_property, model_name, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
         compiler_config=cc,
         assert_atol=False,
         assert_pcc=True,

--- a/tests/models/mlpmixer/test_mlpmixer_n300.py
+++ b/tests/models/mlpmixer/test_mlpmixer_n300.py
@@ -2,32 +2,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
-from mlp_mixer_pytorch import MLPMixer
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.mlp_mixer.lucidrains.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        """
-        https://github.com/lucidrains/mlp-mixer-pytorch
-        """
-        model = MLPMixer(
-            image_size=256,
-            channels=3,
-            patch_size=16,
-            dim=512,
-            depth=12,
-            num_classes=1000,
-        )
-        model = model.to(torch.bfloat16)
-        return model
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        img = torch.randn(32, 3, 256, 256)
-        img = img.to(torch.bfloat16)
-        return img
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=32)
 
 
 @pytest.mark.parametrize(
@@ -52,15 +38,18 @@ def test_mlpmixer(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_debug = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
         assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -3,32 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512
 
-from transformers import SegformerImageProcessor, SegformerForSemanticSegmentation
-from PIL import Image
 import pytest
 from tests.utils import ModelTester
 import torch
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
-from third_party.tt_forge_models.tools.utils import get_file
+from third_party.tt_forge_models.segformer.semantic_segmentation.pytorch import (
+    ModelLoader,
+)
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        self.processor = SegformerImageProcessor.from_pretrained(
-            "nvidia/segformer-b0-finetuned-ade-512-512"
-        )
-        model = SegformerForSemanticSegmentation.from_pretrained(
-            "nvidia/segformer-b0-finetuned-ade-512-512"
-        )
-        model = model.to(torch.bfloat16)
-        return model
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(str(image_file))
-        inputs = self.processor(images=image, return_tensors="pt")
-        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
-        return inputs
+        return self.loader.load_inputs(dtype_override=torch.bfloat16)
 
     def set_inputs_train(self, inputs):
         inputs["pixel_values"] = inputs["pixel_values"].requires_grad_(True)
@@ -56,7 +45,6 @@ class ThisTester(ModelTester):
 def test_segformer(record_property, mode, op_by_op, data_parallel_mode):
     if mode == "train":
         pytest.skip()
-    model_name = "SegFormer"
 
     cc = CompilerConfig()
     cc.enable_consteval = True
@@ -68,9 +56,13 @@ def test_segformer(record_property, mode, op_by_op, data_parallel_mode):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name,
+        model_info.name,
         mode,
+        loader=loader,
         relative_atol=0.01,
         compiler_config=cc,
         # TODO - Enable checking - https://github.com/tenstorrent/tt-torch/issues/527

--- a/tests/models/unet/test_unet_n300.py
+++ b/tests/models/unet/test_unet_n300.py
@@ -3,44 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Reference: https://pytorch.org/hub/mateuszbuda_brain-segmentation-pytorch_unet/
 
-import numpy as np
-from PIL import Image
-from torchvision import transforms
-import requests
 import torch
 import pytest
 from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.unet.torch_hub.pytorch import ModelLoader
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        torch.hub._validate_not_a_forked_repo = lambda a, b, c: True
-        model = torch.hub.load(
-            "mateuszbuda/brain-segmentation-pytorch",
-            "unet",
-            in_channels=3,
-            out_channels=1,
-            init_features=32,
-            pretrained=True,
-        )
-        model = model.to(torch.bfloat16)
-        return model
+        return self.loader.load_model(dtype_override=torch.bfloat16)
 
     def _load_inputs(self):
-        url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
-        input_image = Image.open(requests.get(url, stream=True).raw)
-        m, s = np.mean(input_image, axis=(0, 1)), np.std(input_image, axis=(0, 1))
-        preprocess = transforms.Compose(
-            [
-                transforms.ToTensor(),
-                transforms.Normalize(mean=m, std=s),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = torch.stack([input_tensor] * 4)
-        input_batch = input_batch.to(torch.bfloat16)
-        return input_batch
+        return self.loader.load_inputs(dtype_override=torch.bfloat16, batch_size=4)
 
 
 @pytest.mark.parametrize(
@@ -62,14 +37,20 @@ def test_unet(record_property, mode, op_by_op):
     cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
-    cc.dump_debug = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
     tester = ThisTester(
-        model_name, mode, compiler_config=cc, record_property_handle=record_property
+        model_info.name,
+        mode,
+        loader=loader,
+        compiler_config=cc,
+        record_property_handle=record_property,
     )
     results = tester.test_model()
     if mode == "eval":

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -134,7 +134,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "gengelage/issue-920-v6")
+    set(TT_FORGE_MODELS_VERSION "3e11880246c1b926a61116a00c0a46aebf25fd8f")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -134,7 +134,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "fec874acaf2e2ced4a1f6912b817fb71622960b9")
+    set(TT_FORGE_MODELS_VERSION "gengelage/issue-920-v6")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
#920 

### Problem description
Move model implementation to tt-forge-models repo

### What's changed
Updated loading functions to import from tt-forge-models for the following model tests:
- llama3b
- llama3b eager (experimental folder)
- mistral eager (experimental folder)
- mlp_mixer
- roberta
- segformer
- unet

### Checklist
- [x] New/Existing tests provide coverage for changes
