### PR TITLE
Update mlir path in SHA override verification step

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -81,7 +81,7 @@ jobs:
       continue-on-error: true
       shell: bash
       run: |
-          cd third_party/tt-mlir/src/tt-mlir
+          cd third_party/tt-xla/src/tt-xla/third_party/tt-mlir/src/tt-mlir
           branch_name=$(git rev-parse --abbrev-ref HEAD)
           commit_sha=$(git rev-parse HEAD)
           commit_title=$(git log -1 --pretty=%s)
@@ -89,7 +89,7 @@ jobs:
           echo "Commit SHA: $commit_sha"
           echo "Commit title: $commit_title"
           echo "::notice::Using tt-mlir: $branch_name, commit: $commit_sha, title: $commit_title"
-          cd ../../../..
+          cd -
 
 
     - name: Copy wheel and env directories


### PR DESCRIPTION
### Ticket
None

### Problem description
When On PR is called with a custom mlir version, this step seems to be silently failing [example CI run](https://github.com/tenstorrent/tt-torch/actions/runs/16654414657/job/47135677314#step:10:14)

### What's changed
Updated path

### Checklist
- [x] New/Existing tests provide coverage for changes
  - Tested with override CI [[link]](https://github.com/tenstorrent/tt-torch/actions/runs/16656979261/job/47144789177#step:10:16)
