### PR TITLE
Make pytest --forked set only on some groups via new pytest-args variable in yml

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -44,7 +44,7 @@ jobs:
         build: [
           {
             # Approximately 70 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_1", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_1", pytest-args: "", tests: "
                   tests/models/musicgen_small/test_musicgen_small.py::test_musicgen_small[single_device-full-eval]
                   tests/models/bert/test_bert_turkish.py::test_bert_turkish[single_device-full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-vgg19]
@@ -85,7 +85,7 @@ jobs:
             "
           },
           {
-            wh-runner: n300, name: "eval_1_data_parallel", tests: "
+            wh-runner: n300, name: "eval_1_data_parallel", pytest-args: "", tests: "
                   tests/models/bert/test_bert_turkish.py::test_bert_turkish[data_parallel-full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[data_parallel-full-eval-vgg19]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[data_parallel-full-eval-vgg19_bn]
@@ -120,7 +120,7 @@ jobs:
           },
           {
             # Approximately 95 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_2", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_2", pytest-args: "", tests: "
                   tests/models/bloom/test_bloom.py::test_bloom[full-eval]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-hrnet_w18.ms_aug_in1k]
                   tests/models/timm/test_timm_image_classification.py::test_timm_image_classification[single_device-full-eval-ghostnet_100.in1k]
@@ -149,7 +149,7 @@ jobs:
           },
           {
             # Approximately 65 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_3", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_3", pytest-args: "", tests: "
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-1.5-eval]
                   tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-1B-Base-eval]
                   tests/models/falcon/test_falcon3.py::test_falcon[full-tiiuae/Falcon3-1B-Instruct-eval]
@@ -157,7 +157,7 @@ jobs:
           },
           {
             # Approximately 70 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_5", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_5", pytest-args: "", tests: "
                   tests/models/Qwen/test_qwen2_casual_lm.py::test_qwen2_casual_lm[full-eval]
                   tests/models/opt/test_opt.py::test_opt[full-eval]
                   tests/models/t5/test_t5.py::test_t5[full-t5-small-eval]
@@ -167,7 +167,7 @@ jobs:
           },
           {
             # Approximately 55 minutes.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_6", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_6", pytest-args: "", tests: "
                   tests/models/stable_diffusion/test_stable_diffusion_unet.py::test_stable_diffusion_unet[full-eval]
                   tests/models/stable_diffusion/test_stable_diffusion_transformer.py::test_stable_diffusion_transformer[full-SD3.5-medium-transformer-eval]
                   tests/models/unet/test_unet.py::test_unet[full-eval]
@@ -181,20 +181,15 @@ jobs:
             "
           },
           {
-            # Approximately 5 minutes.
-            wh-runner: high-memory-wormhole, bh-runner: p150, name: "eval_7_high_mem", tests: "
+           # Approximately 180 minutes.
+            wh-runner: high-memory-wormhole, bh-runner: p150, name: "eval_7_high_mem", pytest-args: "--forked", tests: "
                   tests/models/phi/test_phi_1_1p5_2.py::test_phi[full-microsoft/phi-2-eval]
-            "
-          },
-          # Approximately 180 minutes.
-          {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_8", tests: "
                   tests/models/mamba/test_mamba.py::test_mamba[full-mamba-790m-hf-eval]
             "
           },
           # Approximately 70 minutes.
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_9", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_9", pytest-args: "", tests: "
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b0-eval]
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b1-eval]
                 tests/models/EfficientNet/test_EfficientNet.py::test_EfficientNet[full-efficientnet-b2-eval]
@@ -214,7 +209,7 @@ jobs:
           },
           {
             # These are WIP model_group=red models, marked w/ pytest.skip with reasons, run here for reporting.
-            wh-runner: wormhole_b0, bh-runner: p150, name: "skip_tests_red_models", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "skip_tests_red_models", pytest-args: "", tests: "
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-lstm-eval]
                 tests/models/bi_lstm_crf/test_bi_lstm_crf.py::test_bi_lstm_crf[full-gru-eval]
                 tests/models/oft/test_oft.py::test_oft[full-eval]
@@ -249,7 +244,7 @@ jobs:
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780
           {
-            wh-runner: n300, name: "eval_10_batch_parallel", tests: "
+            wh-runner: n300, name: "eval_10_batch_parallel", pytest-args: "", tests: "
                 tests/models/stable_diffusion/test_stable_diffusion_unet_n300.py::test_stable_diffusion_unet[full-eval]
                 tests/models/unet/test_unet_n300.py::test_unet[full-eval]
                 tests/models/unet_brain/test_unet_brain_n300.py::test_unet_brain[full-eval]
@@ -300,7 +295,7 @@ jobs:
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780
           {
-            wh-runner: n300, name: "eval_11_batch_parallel", tests: "
+            wh-runner: n300, name: "eval_11_batch_parallel", pytest-args: "", tests: "
                 tests/models/timm/test_timm_image_classification_n300.py::test_timm_image_classification[full-eval-dla34.in1k]
                 tests/models/timm/test_timm_image_classification_n300.py::test_timm_image_classification[full-eval-ghostnet_100.in1k]
                 tests/models/timm/test_timm_image_classification_n300.py::test_timm_image_classification[full-eval-hrnet_w18.ms_aug_in1k]
@@ -394,7 +389,7 @@ jobs:
       run: |
         source env/activate
 
-        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --forked --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest ${{ matrix.build.pytest-args }} --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -43,7 +43,7 @@ jobs:
         runner: [wormhole, blackhole]
         build: [
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_1", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_1", pytest-args: "", tests: "
                   tests/models/distilbert/test_distilbert.py::test_distilbert[full-distilbert-base-uncased-eval]
                   tests/models/mlpmixer/test_mlpmixer.py::test_mlpmixer[full-eval]
                   tests/models/yolov3/test_yolov3.py::test_yolov3[full-eval]
@@ -53,7 +53,7 @@ jobs:
             "
           },
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_2", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_2", pytest-args: "", tests: "
                   tests/models/mnist/test_mnist.py::test_mnist_train[single_device-full-eval]
                   tests/models/MobileNetV2/test_MobileNetV2.py::test_MobileNetV2[full-eval]
                   tests/models/openpose/test_openpose_v2.py::test_openpose_v2[full-eval]
@@ -67,7 +67,7 @@ jobs:
             "
           },
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_3", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_3", pytest-args: "", tests: "
                   tests/models/albert/test_albert_masked_lm.py::test_albert_masked_lm[single_device-full-albert-xxlarge-v2-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_y_400mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_y_800mf]
@@ -79,7 +79,7 @@ jobs:
             "
           },
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_4", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_4", pytest-args: "", tests: "
                   tests/models/llama/test_llama_3b.py::test_llama_3b[full-eval]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_x_400mf]
                   tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-regnet_x_800mf]
@@ -92,7 +92,7 @@ jobs:
             "
           },
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_5", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "eval_5", pytest-args: "", tests: "
                 tests/models/perceiver_io/test_perceiver_io.py::test_perceiver_io[full-eval]
                 tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-mobilenet_v2]
                 tests/models/torchvision/test_torchvision_image_classification.py::test_torchvision_image_classification[single_device-full-eval-mobilenet_v3_small]
@@ -111,7 +111,7 @@ jobs:
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780
           {
-            wh-runner: n300, name: "eval_6", tests: "
+            wh-runner: n300, name: "eval_6", pytest-args: "", tests: "
                 tests/torch/test_basic_async.py
                 tests/torch/test_basic_multichip.py
                 tests/models/mnist/test_mnist.py::test_mnist_train[data_parallel-full-eval]
@@ -129,7 +129,7 @@ jobs:
             "
           },
           {
-            wh-runner: high-memory-n300, name: "eval_6_highmem_quarantine", tests: "
+            wh-runner: high-memory-n300, name: "eval_6_highmem_quarantine", pytest-args: "--forked", tests: "
               tests/models/llama/test_llama_7b_pipeline_parallel.py::test_llama_7b_pipeline_parallel[huggyllama/llama-7b-eval]
               tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-7B-Base-eval]
               tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py::test_falcon_pipeline_parallel[full-tiiuae/Falcon3-10B-Base-eval]
@@ -137,7 +137,7 @@ jobs:
             "
           },
           {
-            wh-runner: wormhole_b0, bh-runner: p150, name: "tt-xla-eager", tests: "
+            wh-runner: wormhole_b0, bh-runner: p150, name: "tt-xla-eager", pytest-args: "", tests: "
               tests/experimental/test_torch_xla_basic.py
               tests/experimental/models/Qwen/test_qwen2_causal_lm.py::test_qwen2_causal_lm_eager
               tests/experimental/models/llama/test_llama_3b.py::test_llama_3b_eager
@@ -220,7 +220,7 @@ jobs:
       run: |
         source env/activate
 
-        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest --forked --durations=0 -v -rf ${{matrix.build.tests}} \
+        TT_TORCH_SAVE_MLIR=STABLEHLO,TTIR,TTNN pytest ${{ matrix.build.pytest-args }} --durations=0 -v -rf ${{matrix.build.tests}} \
            --junit-xml=${{ steps.strings.outputs.test_report_path_models }} \
            --cov=tt_torch --cov-report term --cov-report xml:coverage.xml --cov-append | tee pytest.log
 


### PR DESCRIPTION
### Ticket
None

### Problem description
- The pytest --forked flag was slowing down when running lots of pytests in single process like `tests/experimental/test_torch_xla_basic.py`(locally see 10x slowdown) and it was really only needed for risky/crashy tests anyways

### What's changed
- provide mechanism for it to be easily added to groups via pytest-args and add it to a couple places in push/nightly ymls
- Shrink number of test groups by combining two groups in nightly

### Checklist
- [x] Testing on branch https://github.com/tenstorrent/tt-torch/actions/runs/16666049006
