### PR TITLE
Change all device references in CI to /dev/tenstorrent

### DIFF
--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -48,7 +48,7 @@ jobs:
     name: "Test ${{matrix.build.runs-on}}-${{ matrix.build.c }}-${{ matrix.build.commit }}"
     container:
       image: "ghcr.io/tenstorrent/tt-torch/tt-torch-ci-ubuntu-22-04:${{ needs.inspect.outputs.docker-tag }}"
-      options: --device /dev/tenstorrent/0
+      options: --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/generate-benchmark-matrix.yml
+++ b/.github/workflows/generate-benchmark-matrix.yml
@@ -35,7 +35,7 @@ jobs:
 
     container:
       image: ${{ needs.docker-build.outputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0
+      options: --user root --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/generate-benchmark-report.yml
+++ b/.github/workflows/generate-benchmark-report.yml
@@ -23,7 +23,7 @@ jobs:
 
     container:
       image: ${{ needs.docker-build.outputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0
+      options: --user root --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/generate-model-report.yml
+++ b/.github/workflows/generate-model-report.yml
@@ -33,7 +33,7 @@ jobs:
 
     container:
       image: ${{ needs.docker-build.outputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0
+      options: --user root --device /dev/tenstorrent
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-depth-benchmark-tests.yml
+++ b/.github/workflows/run-depth-benchmark-tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-e2e-compile-tests.yml
+++ b/.github/workflows/run-e2e-compile-tests.yml
@@ -69,7 +69,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -320,7 +320,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-multidevice-tests.yml
+++ b/.github/workflows/run-multidevice-tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: llmbox, name: "run", container-options: "--device /dev/tenstorrent/0 --device /dev/tenstorrent/1 --device /dev/tenstorrent/2 --device /dev/tenstorrent/3"},
+          {runs-on: llmbox, name: "run", container-options: "--device /dev/tenstorrent"},
         ]
 
     name: tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})

--- a/.github/workflows/run-op-by-op-model-tests-weekly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-weekly.yml
@@ -278,7 +278,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          {runs-on: wormhole_b0, name: "run", container-options: "--device /dev/tenstorrent/0"},
+          {runs-on: wormhole_b0, name: "run", container-options: "--device /dev/tenstorrent"},
         ]
     name: tests (${{ matrix.build.runs-on }}, ${{ matrix.build.name }})
     runs-on:

--- a/.github/workflows/run-tools-tests.yml
+++ b/.github/workflows/run-tools-tests.yml
@@ -35,7 +35,7 @@ jobs:
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=2gb
+      options: --user root --device /dev/tenstorrent --shm-size=2gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/run-tt-forge-models-tests.yml
+++ b/.github/workflows/run-tt-forge-models-tests.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.runner == 'wormhole' && matrix.build.wh-runner || matrix.runner == 'blackhole' && matrix.build.bh-runner || 'wormhole_b0'}}
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=2gb
+      options: --user root --device /dev/tenstorrent --shm-size=2gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G


### PR DESCRIPTION
### Ticket
None

### Problem Description
Loudbox runners are now tagged as `wormhole_b0` meaning tests can arbitrarily be picked up on multidevice runners. Existing device-in-container mounting will lead to an illegal configuration with only a subset of pcie devices mounted in container and all subsequent tests to fail.

### What's changed
Remove references to specific single-device mounting to YAML containers and mount everything to /dev/tenstorrent as suggested in our docs. This does not impact tests that require a set amount of devices because they manually acquire devices during test initialization rather than greedily acquiring all devices available on the system.

### Checklist
- [x] New/Existing tests provide coverage for changes
