### PR TITLE
skip bi_lstm_crf test when running op_by_op for GRU variant

### DIFF
--- a/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
+++ b/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import torch
 import pytest
 
 from bi_lstm_crf import BiRnnCrf
@@ -43,6 +42,10 @@ def test_bi_lstm_crf(record_property, variant, variant_config, mode, op_by_op):
     cc.enable_consteval = True
     cc.consteval_parameters = True
     if op_by_op:
+        if variant.value == "gru":
+            pytest.skip(
+                "Op-by-op not supported for GRU variant, tracking issue: https://github.com/tenstorrent/tt-torch/issues/1153"
+            )
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO

--- a/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
+++ b/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from bi_lstm_crf import BiRnnCrf
 from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.bi_rnn_crf.pytorch import ModelLoader


### PR DESCRIPTION
### Problem description
BiLSTM models using pack_padded_sequence/pad_packed_sequence fail to compile with our torch-xla [fork](https://github.com/tenstorrent/pytorch-xla) due to a fake tensor bug in PyTorch's _pad_packed_sequence decomposition. In torch-xla==2.7.0 there was no tracing or compiling of these ops causing it not to fail. 
More details in the issue tracking this failure #1153 

### What's changed
- added a skip for `test_bi_lstm_crf[op_by_op_torch-gru-eval]`

### Checklist
- [x] New/Existing tests provide coverage for changes
