### PR TITLE
Pin torchcodec to 0.5.0 for Whisper, remove tt-forge-models-tests.yml dummy cron, show python deps in full model tests

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -209,6 +209,13 @@ jobs:
         mv install/wheels/* ${{ steps.strings.outputs.dist-dir }}
         pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
 
+    - name: Show actual installed python dependencies
+      if: ${{ env.RUN_TEST != 'skip' }}
+      shell: bash
+      run: |
+        source env/activate
+        pip freeze
+
     - name: Run Full Model Execution Tests
       if: ${{ env.RUN_TEST != 'skip' }}
       env:

--- a/.github/workflows/tt-forge-models-tests.yml
+++ b/.github/workflows/tt-forge-models-tests.yml
@@ -38,10 +38,6 @@ on:
         type: string
         default: '["wormhole","blackhole"]'
 
-  schedule:
-    # Feb31 impossible date so job appears on Actions UI
-    - cron: '0 0 31 2 *'
-
 permissions:
   packages: write
   checks: write

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,4 @@ opencv-contrib-python
 gliner
 ultralytics
 efficientnet_pytorch
-torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg.
+torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg. 0.6.0 fails with NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,4 @@ opencv-contrib-python
 gliner
 ultralytics
 efficientnet_pytorch
-torchcodec # required for whisper test. Requires system dep ffmpeg.
+torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg.


### PR DESCRIPTION
### Ticket
None

### Problem description
Misc CI fixes from Aug 8

### What's changed
- Torchcodec upgraded to 0.6.0 inducing new failure in test_whisper NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend. Pin to 0.5.0
- Remove dummy cron job from tt-forge-models-tests.yml which didn't work
- Add step to show python deps in full model tests

### Checklist
- [x] Quick onPush test to check that full model tests still work