### PR TITLE
Typo in `_get_custom_decopositions` 

### DIFF
--- a/tt_torch/dynamo/decompositions.py
+++ b/tt_torch/dynamo/decompositions.py
@@ -326,7 +326,7 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
     ]
 
 
-def _get_custom_decopositions() -> DecompositionTable:
+def _get_custom_decompositions() -> DecompositionTable:
     aten = torch.ops.aten
     return {
         aten.upsample_nearest1d.vec: upsample_nearest_vec,
@@ -342,4 +342,4 @@ def _get_custom_decopositions() -> DecompositionTable:
 
 
 CUSTOM_DECOMPOSITION_TABLE = get_decompositions(_get_default_decomposition_ops())
-CUSTOM_DECOMPOSITION_TABLE.update(_get_custom_decopositions())
+CUSTOM_DECOMPOSITION_TABLE.update(_get_custom_decompositions())

--- a/tt_torch/dynamo/experimental/xla_decompositions.py
+++ b/tt_torch/dynamo/experimental/xla_decompositions.py
@@ -412,7 +412,7 @@ def _get_default_decomposition_ops() -> DecompositionOpsList:
     ]
 
 
-def _get_custom_decopositions() -> DecompositionTable:
+def _get_custom_decompositions() -> DecompositionTable:
     aten = torch.ops.aten
     return {
         aten.upsample_nearest1d.vec: upsample_nearest_vec,
@@ -438,4 +438,4 @@ def _get_custom_decopositions() -> DecompositionTable:
 
 
 CUSTOM_DECOMPOSITION_TABLE = get_decompositions(_get_default_decomposition_ops())
-CUSTOM_DECOMPOSITION_TABLE.update(_get_custom_decopositions())
+CUSTOM_DECOMPOSITION_TABLE.update(_get_custom_decompositions())


### PR DESCRIPTION
### Ticket
None

### Problem description
Should be *decompositions* not *decopositions* 

### What's changed
Changed typo, skipped on pr tests

### Checklist
- [X] New/Existing tests provide coverage for changes
