### PR TITLE
Uplift third_party/tt-mlir to 402adb4cc01f10e51f445cdbad4363c0feb32751 2025-08-13

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # underlying tt-mlir version we will have tt-xla use
-set(TT_MLIR_VERSION "d59983fcf90f50448e5698af7febfdb9fe65d7c4")
+set(TT_MLIR_VERSION "402adb4cc01f10e51f445cdbad4363c0feb32751")
 # tt-xla version to use
 set(TTXLA_VERSION "e11a4e14fab86fa8695957ac1df663572b80c19c")
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,7 +6,7 @@
 # underlying tt-mlir version we will have tt-xla use
 set(TT_MLIR_VERSION "402adb4cc01f10e51f445cdbad4363c0feb32751")
 # tt-xla version to use
-set(TTXLA_VERSION "e11a4e14fab86fa8695957ac1df663572b80c19c")
+set(TTXLA_VERSION "4e980da06f76b9c19da8c19d3fbb2984751eff6e")
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -394,7 +394,9 @@ std::vector<at::Tensor> run_end_to_end(std::vector<at::Tensor> &inputs,
 
   tt::runtime::Binary binary = create_binary_from_bytestream(byte_stream);
 
-  tt::runtime::Device device = tt::runtime::openMeshDevice({1, 1});
+  tt::runtime::MeshDeviceOptions options;
+  options.meshShape = {1, 1};
+  tt::runtime::Device device = tt::runtime::openMeshDevice(options);
 
   const int program_idx = 0;
 
@@ -450,9 +452,10 @@ PYBIND11_MODULE(tt_mlir, m) {
                                            : py::none();
           },
           [](tt::runtime::MeshDeviceOptions &o, py::handle value) {
-            o.meshShape = py::none().is(value)
-                              ? std::nullopt
-                              : std::make_optional(value.cast<std::vector<uint32_t>>());
+            o.meshShape =
+                py::none().is(value)
+                    ? std::nullopt
+                    : std::make_optional(value.cast<std::vector<uint32_t>>());
           })
       .def_property(
           "l1_small_size",

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -444,6 +444,17 @@ PYBIND11_MODULE(tt_mlir, m) {
       .def_readwrite("enable_program_cache",
                      &tt::runtime::MeshDeviceOptions::enableProgramCache)
       .def_property(
+          "mesh_shape",
+          [](const tt::runtime::MeshDeviceOptions &o) {
+            return o.meshShape.has_value() ? py::cast(o.meshShape.value())
+                                           : py::none();
+          },
+          [](tt::runtime::MeshDeviceOptions &o, py::handle value) {
+            o.meshShape = py::none().is(value)
+                              ? std::nullopt
+                              : std::make_optional(value.cast<std::vector<uint32_t>>());
+          })
+      .def_property(
           "l1_small_size",
           [](const tt::runtime::MeshDeviceOptions &o) {
             return o.l1SmallSize.has_value() ? py::cast(o.l1SmallSize.value())
@@ -480,8 +491,7 @@ PYBIND11_MODULE(tt_mlir, m) {
         "Run shardy automatic data parallelization pass on stableHLO");
   m.def("compile_stable_hlo_to_ttir", &compile_stable_hlo_to_ttir,
         "A function that compiles stableHLO to TTIR");
-  m.def("open_mesh_device", &tt::runtime::openMeshDevice, py::arg("mesh_shape"),
-        py::arg("options"),
+  m.def("open_mesh_device", &tt::runtime::openMeshDevice, py::arg("options"),
         "Open a mesh of devices for execution using the new API and create "
         "system description");
   m.def("close_mesh_device", &tt::runtime::closeMeshDevice,

--- a/tt_torch/dynamo/executor.py
+++ b/tt_torch/dynamo/executor.py
@@ -269,9 +269,10 @@ class Executor:
             return self.devices[device_idx]
         # Return a default parent mesh
         mesh_options = tt_mlir.MeshDeviceOptions()
+        mesh_options.mesh_shape = self.compiler_config.mesh_shape
         if len(self.compiler_config.mesh_shape) == 32:
             mesh_options.dispatch_core_type = tt_mlir.DispatchCoreType.WORKER
-        device = tt_mlir.open_mesh_device(self.compiler_config.mesh_shape, mesh_options)
+        device = tt_mlir.open_mesh_device(mesh_options)
         self.devices[device_idx] = device
         self.owned_device_indices.append(device_idx)
         return device

--- a/tt_torch/tools/device_manager.py
+++ b/tt_torch/tools/device_manager.py
@@ -16,6 +16,7 @@ class DeviceManager:
 
     @staticmethod
     def _get_parent_mesh_options(
+        mesh_shape=None,
         device_ids=None,
         num_hw_cqs=None,
         enable_program_cache=None,
@@ -23,6 +24,8 @@ class DeviceManager:
         dispatch_core_type=None,
     ) -> tt_mlir.MeshDeviceOptions:
         options = tt_mlir.MeshDeviceOptions()
+        if mesh_shape is not None:
+            options.mesh_shape = mesh_shape
         if device_ids is not None:
             options.device_ids = device_ids
         if num_hw_cqs is not None:
@@ -45,7 +48,7 @@ class DeviceManager:
     @classmethod
     def create_parent_mesh_device(
         cls,
-        mesh_shape,
+        mesh_shape=None,
         device_ids=None,
         num_hw_cqs=None,
         enable_program_cache=None,
@@ -63,13 +66,14 @@ class DeviceManager:
             mesh_shape[0] * mesh_shape[1] <= num_available
         ), "Mesh shape exceeds available devices."
         options = cls._get_parent_mesh_options(
+            mesh_shape,
             device_ids,
             num_hw_cqs,
             enable_program_cache,
             l1_small_size,
             dispatch_core_type,
         )
-        parent_mesh = tt_mlir.open_mesh_device(mesh_shape=mesh_shape, options=options)
+        parent_mesh = tt_mlir.open_mesh_device(options=options)
         cls._devices[parent_mesh] = set()
         cls._parent_shapes[parent_mesh] = mesh_shape
         return parent_mesh


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir to the 402adb4cc01f10e51f445cdbad4363c0feb32751

Bisect note: tt-mlir change 9a5ab756c7c50fdd8c1d5749842add4206b446d8 removes the meshShape arg to openMeshDevice.