### PR TITLE
Use tt-mlir from tt-xla by default, and uplift tt-xla only

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -25,8 +25,8 @@ checkout_tt_xla() {
 }
 
 MLIR_DOCKER_TAG=$(
-    # Read tt-mlir version from third_party/tt-xla/src/tt-xla/third_party/CMakeLists.txt
-    # clone tt-mlir version to tmp/third_party/tt-mlir
+    # Read tt-mlir version from tt-xla's third_party/CMakeLists.txt
+    # Clone tt-mlir version to tmp/third_party/tt-mlir
     # Get the MLIR docker tag
 
     # Note - third_party/tt-xla is cloned at the commit specified by the TT_XLA_VERSION in third_party/CMakeLists.txt
@@ -44,7 +44,7 @@ MLIR_DOCKER_TAG=$(
         : # TT_MLIR_VERSION is directly set in third_party/CMakeLists.txt due to override or source modification
     else
         # Extract TT_MLIR_VERSION from tt-xla's CMakeLists.txt
-        TT_XLA_VERSION=$(grep -oP 'set\(TTXLA_VERSION "\K[^"]+' third_party/CMakeLists.txt || echo "")
+        TT_XLA_VERSION=$(grep -oP 'set\(TT_XLA_VERSION "\K[^"]+' third_party/CMakeLists.txt || echo "")
 
         if [ -z "$TT_XLA_VERSION" ]; then
             exit 1

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -38,21 +38,6 @@ jobs:
         run: |
             # Update the CMakeLists.txt file with the new SHA
             sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${{ inputs.mlir_override }}\")/" third_party/CMakeLists.txt
-      # The TT_MLIR_VERSION is "" by default and retrieved from tt-xla
-      - name: Clone tt-xla repository and find out the mlir version from tt-xla
-        if: ${{ inputs.mlir_override == '' }}
-        shell: bash
-        run: |
-          # Extract the TTXLA_VERSION from CMakeLists.txt
-          TTXLA_VERSION=$(grep -oP 'set\(TTXLA_VERSION "\K[^"]+' third_party/CMakeLists.txt)
-          echo "Using TTXLA_VERSION: $TTXLA_VERSION"
-
-          # Clone the tt-xla repository
-          mkdir -p third_party/tt-xla/src
-          git clone https://github.com/tenstorrent/tt-xla.git third_party/tt-xla/src/tt-xla
-
-          # Checkout the specific commit
-          git -C third_party/tt-xla/src/tt-xla checkout $TTXLA_VERSION
       - name: Check if Docker image already exists
         id: check
         shell: bash

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docker-image: ${{ steps.check.outputs.docker-image }}
+
     steps:
       - uses: actions/checkout@v4
       - name: Override tt-mlir SHA mlir_override is set
@@ -37,6 +38,21 @@ jobs:
         run: |
             # Update the CMakeLists.txt file with the new SHA
             sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${{ inputs.mlir_override }}\")/" third_party/CMakeLists.txt
+      # The TT_MLIR_VERSION is "" by default and retrieved from tt-xla
+      - name: Clone tt-xla repository and find out the mlir version from tt-xla
+        if: ${{ inputs.mlir_override == '' }}
+        shell: bash
+        run: |
+          # Extract the TTXLA_VERSION from CMakeLists.txt
+          TTXLA_VERSION=$(grep -oP 'set\(TTXLA_VERSION "\K[^"]+' third_party/CMakeLists.txt)
+          echo "Using TTXLA_VERSION: $TTXLA_VERSION"
+
+          # Clone the tt-xla repository
+          mkdir -p third_party/tt-xla/src
+          git clone https://github.com/tenstorrent/tt-xla.git third_party/tt-xla/src/tt-xla
+
+          # Checkout the specific commit
+          git -C third_party/tt-xla/src/tt-xla checkout $TTXLA_VERSION
       - name: Check if Docker image already exists
         id: check
         shell: bash

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -48,6 +48,9 @@ jobs:
           git clone https://github.com/tenstorrent/tt-xla.git tt-xla
           cd tt-xla
           # Fetch commit history between $COMMIT_SHA and LATEST_SHA
+          if [ -z ${{env.CURRENT_COMMIT_SHA}} ]; then
+            exit 1
+          fi
           git log --oneline ${{ env.CURRENT_COMMIT_SHA}}..${{ env.LATEST_SHA }} >>../commit_list.txt
           cd ..
           cat commit_list.txt

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -13,8 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SUBMODULE_PATH: third_party/tt-mlir
-      MLIR_VERSION: origin/main
+      SUBMODULE_PATH: third_party/tt-xla
 
     steps:
 
@@ -26,28 +25,28 @@ jobs:
       - name: Set env variable
         run: |
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-          echo "CURRENT_COMMIT_SHA=$(grep -oP 'set\(TT_MLIR_VERSION "\K[^"]+' third_party/CMakeLists.txt)" >> $GITHUB_ENV
+          echo "CURRENT_COMMIT_SHA=$(grep -oP 'set\(TT_XLA_VERSION "\K[^"]+' third_party/CMakeLists.txt)" >> $GITHUB_ENV
 
-      - name: Update tt-mlir reference
+      - name: Update tt-xla reference
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
             # Fetch the latest SHA using GitHub CLI
-            LATEST_SHA=$(gh api repos/tenstorrent/tt-mlir/commits/main --jq '.sha')
+            LATEST_SHA=$(gh api repos/tenstorrent/tt-xla/commits/main --jq '.sha')
             echo "LATEST_SHA=${LATEST_SHA}" >> $GITHUB_ENV
             echo "SUBMODULE_VERSION=${LATEST_SHA}" >> $GITHUB_ENV
             # Update the CMakeLists.txt file with the new SHA
-            sed -i "s/set(TT_MLIR_VERSION \".*\")/set(TT_MLIR_VERSION \"${LATEST_SHA}\")/" third_party/CMakeLists.txt
+            sed -i "s/set(TT_XLA_VERSION \".*\")/set(TT_XLA_VERSION \"${LATEST_SHA}\")/" third_party/CMakeLists.txt
 
-      - name: Fetch commit history from tt-mlir repository
+      - name: Fetch commit history from tt-xla repository
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          # Clone the tt-mlir repository
+          # Clone the tt-xla repository
           cd ${{ runner.temp }}
-          echo "### List of tt-mlir commits since previous uplift:" > commit_list.txt
-          git clone https://github.com/tenstorrent/tt-mlir.git tt-mlir
-          cd tt-mlir
+          echo "### List of tt-xla commits since previous uplift:" > commit_list.txt
+          git clone https://github.com/tenstorrent/tt-xla.git tt-xla
+          cd tt-xla
           # Fetch commit history between $COMMIT_SHA and LATEST_SHA
           git log --oneline ${{ env.CURRENT_COMMIT_SHA}}..${{ env.LATEST_SHA }} >>../commit_list.txt
           cd ..

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TTXLA_VERSION "3c34c7b8ef9b336e4cd6b84ad59bcc26317e9b88")
 
 # Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
 set(TT_MLIR_VERSION "")
-if(DEFINED TT_MLIR_VERSION AND NOT TT_MLIR_VERSION STREQUAL "")
+if(NOT TT_MLIR_VERSION STREQUAL "")
     set(USE_CUSTOM_TT_MLIR_VERSION ON)
     message(STATUS "Overriding TT_MLIR_VERSION in tt-xla build: ${TT_MLIR_VERSION}")
     list(APPEND TT_XLA_MLIR_OVERRIDE_ARGS

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -22,7 +22,39 @@ endif()
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
     project(ttmlir-toolchain LANGUAGES CXX C)
+
+    # Extract TT_MLIR_VERSION from tt-xla repository only if not already set
+    if(TT_MLIR_VERSION STREQUAL "")
+        # Step 1: Download tt-xla's CMakeLists.txt from GitHub
+        set(TTXLA_CMAKE_URL "https://raw.githubusercontent.com/tenstorrent/tt-xla/${TTXLA_VERSION}/third_party/CMakeLists.txt")
+        execute_process(
+            COMMAND curl -s ${TTXLA_CMAKE_URL}
+            OUTPUT_VARIABLE TTXLA_CMAKE_CONTENT
+            ERROR_QUIET
+        )
+
+        # Step 2: Extract TT_MLIR_VERSION that tt-xla is using
+        execute_process(
+            COMMAND bash -c "echo '${TTXLA_CMAKE_CONTENT}' | sed -n 's/.*set(TT_MLIR_VERSION \"\\(.*\\)\").*/\\1/p'"
+            OUTPUT_VARIABLE TT_XLA_FALLBACK_TT_MLIR_VERSION
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+
+        # Use the fallback tt-mlir version from tt-xla to build the toolchain
+        if(TT_XLA_FALLBACK_TT_MLIR_VERSION STREQUAL "")
+            message(FATAL_ERROR "Could not extract TT_MLIR_VERSION from tt-xla")
+        else()
+            set(TT_MLIR_VERSION ${TT_XLA_FALLBACK_TT_MLIR_VERSION})
+            message(STATUS "Extracted TT_MLIR_VERSION from tt-xla: ${TT_MLIR_VERSION}")
+        endif()
+    else()
+        message(STATUS "Using provided override TT_MLIR_VERSION: ${TT_MLIR_VERSION}")
+    endif()
+
     if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir/src/tt-mlir)
+        # Create the directory structure if it doesn't exist
+        file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir/src)
         execute_process(
             COMMAND git clone --recursive https://github.com/tenstorrent/tt-mlir.git ${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir/src/tt-mlir
         )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # tt-xla version to use
-set(TTXLA_VERSION "3c34c7b8ef9b336e4cd6b84ad59bcc26317e9b88")
+set(TT_XLA_VERSION "3c34c7b8ef9b336e4cd6b84ad59bcc26317e9b88")
 
 # Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
 set(TT_MLIR_VERSION "")
@@ -26,7 +26,7 @@ if (BUILD_TOOLCHAIN)
     # Extract TT_MLIR_VERSION from tt-xla repository only if not already set
     if(TT_MLIR_VERSION STREQUAL "")
         # Step 1: Download tt-xla's CMakeLists.txt from GitHub
-        set(TTXLA_CMAKE_URL "https://raw.githubusercontent.com/tenstorrent/tt-xla/${TTXLA_VERSION}/third_party/CMakeLists.txt")
+        set(TTXLA_CMAKE_URL "https://raw.githubusercontent.com/tenstorrent/tt-xla/${TT_XLA_VERSION}/third_party/CMakeLists.txt")
         execute_process(
             COMMAND curl -s ${TTXLA_CMAKE_URL}
             OUTPUT_VARIABLE TTXLA_CMAKE_CONTENT
@@ -114,7 +114,7 @@ else()
             -DTTMLIR_ENABLE_PERF_TRACE=${TT_RUNTIME_ENABLE_PERF_TRACE}
             ${TT_XLA_MLIR_OVERRIDE_ARGS}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-xla.git
-        GIT_TAG ${TTXLA_VERSION}
+        GIT_TAG ${TT_XLA_VERSION}
         GIT_PROGRESS ON
         BUILD_BYPRODUCTS
             ${TTXLA_PJRT_DYLIB}

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -3,10 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# underlying tt-mlir version we will have tt-xla use
-set(TT_MLIR_VERSION "b03d526f953d654ef167faf534a20fd2b357ba76")
 # tt-xla version to use
 set(TTXLA_VERSION "3c34c7b8ef9b336e4cd6b84ad59bcc26317e9b88")
+
+# Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
+set(TT_MLIR_VERSION "")
+if(DEFINED TT_MLIR_VERSION AND NOT TT_MLIR_VERSION STREQUAL "")
+    set(USE_CUSTOM_TT_MLIR_VERSION ON)
+    message(STATUS "Overriding TT_MLIR_VERSION in tt-xla build: ${TT_MLIR_VERSION}")
+    list(APPEND TT_XLA_MLIR_OVERRIDE_ARGS
+        -DUSE_CUSTOM_TT_MLIR_VERSION=ON
+        -DTT_MLIR_VERSION=${TT_MLIR_VERSION}
+    )
+else()
+    message(STATUS "Not overriding TT_MLIR_VERSION and using TT_XLA default tt-mlir version")
+endif()
 
 if (BUILD_TOOLCHAIN)
     cmake_minimum_required(VERSION 3.20)
@@ -66,11 +77,10 @@ else()
             -DCMAKE_C_COMPILER=clang-17
             -DCMAKE_CXX_COMPILER=clang++-17
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-            -DUSE_CUSTOM_TT_MLIR_VERSION=ON
-            -DTT_MLIR_VERSION=${TT_MLIR_VERSION}
             -DTT_RUNTIME_DEBUG=${TT_RUNTIME_DEBUG}
             -DCMAKE_INSTALL_PREFIX=${TTXLA_INSTALL_PREFIX}
             -DTTMLIR_ENABLE_PERF_TRACE=${TT_RUNTIME_ENABLE_PERF_TRACE}
+            ${TT_XLA_MLIR_OVERRIDE_ARGS}
         GIT_REPOSITORY https://github.com/tenstorrent/tt-xla.git
         GIT_TAG ${TTXLA_VERSION}
         GIT_PROGRESS ON


### PR DESCRIPTION
### Ticket
#1173 

### Problem description
With switch to tt-xla backend, tt-torch no longer includes tt-mlir as a direct dependency. As such, we should use the tt-mlir version from tt-xla by default and only uplift tt-xla, rather than uplifting the two separately.

### What's changed
- Change nightly uplift job to uplift tt-xla only, and not tt-mlir
- Set TT_MLIR_VERSION in third_party/CMakeLists to an empty string, and only override TT_MLIR_VERSION in tt-xla build if set to nonempty string
- Update other points in repo dependent on reading TT_MLIR_VERSION to use tt-xla's TT_MLIR_VERSION
  - Where a TT_MLIR_VERSION is needed but not provided (docker build, get docker tag, toolchain build), there is additional logic to checkout tt-xla at the specified top level TTXLA_VERSION, read its TT_MLIR_VERSION as a fallback and use that.

### Checklist
- [x] tt-torch still builds
- [x] Other references in CI scripts to TT_MLIR_VERSION are fixed
- [x] workflow dispatch tt_mlir_version still works
- [x] manual trigger of uplift still works 
- [x] toolchain build still works  
