### PR TITLE
Switch tt-forge-models run-tests.yml job to run single test and set HF_TOKEN etc

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -96,10 +96,14 @@ jobs:
         pytest -vv tests/runner/test_models.py --validate-test-config
 
     - name: Run tt-forge-models runner tests
+      env:
+        HF_HOME: ${{ env.DOCKER_CACHE_ROOT }}/huggingface
+        TORCH_HOME: ${{ env.DOCKER_CACHE_ROOT }}/torch
+        HF_TOKEN: ${{ secrets.HF_TOKEN }}
       shell: bash
       run: |
         source env/activate
-        pytest -vv tests/runner/test_models.py -m expected_passing -k mobilenet
+        pytest -vv tests/runner/test_models.py -m expected_passing -k "mobilenetv2/pytorch-mobilenet_v2-full-eval"
 
     - name: Verify CI model test matrices
       shell: bash


### PR DESCRIPTION
### Ticket
None

### Problem description
- Recent tt-forge-models uplift brought many passing mobilenet variants and run-tests.yml used -k mobilenet which now triggered 13 tests instead of 2 and hit rate limit error due to no HF_TOKEN though passed on cached rerun.

### What's changed
- Switch to just run 1 mobilenet test explicitly which is enough here
- Set HF_TOKEN and other env-vars for this job

### Checklist
- [x] onPR
