### PR TITLE
Bring up Detr3d pytorch model

### DIFF
--- a/.github/workflows/run-full-model-execution-tests-nightly.yml
+++ b/.github/workflows/run-full-model-execution-tests-nightly.yml
@@ -242,6 +242,7 @@ jobs:
                 tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-hpe-hg3x-eval]
                 tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-3d_bb-ddd_3dop-eval]
                 tests/models/centernet/test_centernet_onnx.py::test_centernet_onnx[full-centernet-3d_bb-ddd_sub-eval]
+                tests/models/detr3d/test_detr3d.py::test_detr3d[full-eval]
             "
           },
           # This test group needs to be moved. This will be done once multichip tests are refactored: #780

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -195,6 +195,12 @@ jobs:
               tests/models/flux/test_flux.py::test_flux[op_by_op_torch-dev-eval]
             "
           },
+          {
+            runs-on: wormhole_b0, name: "detr3d", tests: "
+              tests/models/detr3d/test_detr3d.py::test_detr3d[op_by_op_torch-eval]
+              tests/models/detr3d/test_detr3d.py::test_detr3d[op_by_op_stablehlo-eval]
+            "
+          },
         ]
     runs-on:
       - ${{ matrix.build.sh-run && format('tt-ubuntu-2204-{0}-stable', matrix.build.runs-on) ||  matrix.build.runs-on }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,7 @@ ase==3.24.0 # For hippynn
 hippynn==0.0.3
 pycocotools
 FlagEmbedding
+addict
+yapf
+opencv-python-headless
+scikit-image

--- a/tests/models/detr3d/test_detr3d.py
+++ b/tests/models/detr3d/test_detr3d.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from tests.utils import ModelTester, skip_full_eval_test
+from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
+from third_party.tt_forge_models.detr3d.pytorch.loader import ModelLoader
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        return self.loader.load_model(variant_name=model_path)
+
+    def _load_inputs(self):
+        model_dict = dict(model_info_list)
+        model_path = model_dict[self.model_name]
+        return self.loader.load_inputs(variant_name=model_path)
+
+
+model_info_list = [
+    ("detr3d", "resnet101"),
+]
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+@pytest.mark.parametrize(
+    "model_info",
+    model_info_list,
+    ids=[model_info[0] for model_info in model_info_list],
+)
+@pytest.mark.parametrize(
+    "op_by_op",
+    # [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
+    # ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
+    [None],
+    ids=["full"],
+)
+def test_detr3d(record_property, model_info, mode, op_by_op):
+    model_name, _ = model_info
+
+    cc = CompilerConfig()
+    cc.enable_consteval = True
+    cc.consteval_parameters = True
+    if op_by_op:
+        cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
+        if op_by_op == OpByOpBackend.STABLEHLO:
+            cc.op_by_op_backend = OpByOpBackend.STABLEHLO
+
+    # TODO - update this test once centernet ModelLoader is updated to properly support variants
+    # for now it contains a few hacks.
+    loader = ModelLoader(variant=None)
+    model_info = loader.get_model_info(variant=None)
+
+    skip_full_eval_test(
+        record_property,
+        cc,
+        model_info.name,
+        bringup_status="FAILED_RUNTIME",
+        reason="Out of Memory: Not enough space to allocate 285081600 B L1 buffer across 64 banks, where each bank needs to store 4454400 B",
+        model_group=model_info.group,
+    )
+
+    # TODO Enable PCC/ATOL/Checking - https://github.com/tenstorrent/tt-torch/issues/976
+    tester = ThisTester(
+        model_name,
+        mode,
+        loader=loader,
+        assert_pcc=False,
+        assert_atol=False,
+        compiler_config=cc,
+        record_property_handle=record_property,
+        model_group=model_info.group,
+    )
+
+    results = tester.test_model()
+
+    if mode == "eval":
+        # Results
+        print(results)
+
+    tester.finalize()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -176,7 +176,7 @@ else()
     install(DIRECTORY ${TORCH_MLIR_INSTALL_PREFIX}/python_packages/torch_mlir/torch_mlir DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 
     # tt-forge-models - Python-only project, no need to build.
-    set(TT_FORGE_MODELS_VERSION "c8a3cb8ee57189fa59e693cae7c4b3ab72b4ede1")
+    set(TT_FORGE_MODELS_VERSION "52d9bc66e38a8bdb611bba3d75ce93a34f812574")
     ExternalProject_Add(
         tt_forge_models
         SOURCE_DIR ${TTTORCH_SOURCE_DIR}/third_party/tt_forge_models


### PR DESCRIPTION
### Ticket
[351](https://github.com/tenstorrent/tt-torch/issues/351)

### Problem description

- Added the PyTorch implementation of the DETR3D model.

- The original implementation relied on external libraries such as mmcv, mmdet, and mmdet3d.

- Removed these dependencies by refactoring key functions, including config, DictAction, build_model, load_checkpoint, and set_random_seed.

- Replaced the use of build_dataset by directly passing randomly generated input tensors during testing.

- Substituted mmcv.load_checkpoint with model.load_state_dict() for loading model weights.
- Replaced dcnv2(modulated_conv_forward) (which relies on MMCV) with torchvision.ops.deform_conv2d to eliminate the MMCV dependency.

### What's changed

- Added a new test file test_detr3d.py that implements PYTORCH testing for the DETR3D model

- Attached are the logs showing that both OpByOpBackend.STABLEHLO and OpByOpBackend.TORCH are passing.
[detr3d_OpByOpBackend.STABLEHLO.log](https://github.com/user-attachments/files/21930550/detr3d_OpByOpBackend.STABLEHLO.log)
[detr3d_OpByOpBackend.TORCH.log](https://github.com/user-attachments/files/21930552/detr3d_OpByOpBackend.TORCH.log)


### Checklist
- [ ] New/Existing tests provide coverage for changes
