### PR TITLE
Revert "Uplift third_party/tt-mlir to a3ea3703fb0db66c76a92173d4ba1af94ca27f67 2025-08-21"

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -133,6 +133,7 @@ jobs:
       - pre-commit
       - spdx
       - docker-build
+      - check-files
       - build
       - test
       - full-model-test

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -23,7 +23,7 @@ on:
         description: 'Use shared runners'
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   build:

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # underlying tt-mlir version we will have tt-xla use
-set(TT_MLIR_VERSION "a3ea3703fb0db66c76a92173d4ba1af94ca27f67")
+set(TT_MLIR_VERSION "84b226f2298c285b31fb0792f2cc4685e0065876")
 # tt-xla version to use
 set(TTXLA_VERSION "3c34c7b8ef9b336e4cd6b84ad59bcc26317e9b88")
 


### PR DESCRIPTION
Reverts tenstorrent/tt-torch#1180 which was accidentally automerged due to a bug in check-all-green which will permit merging under invalid circumstances. 

A Github outage on Aug 21 4UTC caused a specific job on `ubuntu-latest` to fail, skip all dependent tests, mark the changeset as mergable from the perspective of check-all-green.  
