### PR TITLE
Add global sharding registry to allow mark_sharding() to work through torch.compile path

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -114,6 +114,7 @@ jobs:
             wh-runner: n300, name: "eval_6", pytest-args: "", tests: "
                 tests/torch/test_basic_async.py
                 tests/torch/test_basic_multichip.py
+                tests/torch/test_basic_sharding.py
                 tests/models/mnist/test_mnist.py::test_mnist_train[data_parallel-full-eval]
                 tests/models/resnet50/test_resnet50.py::test_resnet[data_parallel-full-eval]
                 tests/models/resnet/test_resnet.py::test_resnet[data_parallel-full-eval]

--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -114,7 +114,6 @@ jobs:
             wh-runner: n300, name: "eval_6", pytest-args: "", tests: "
                 tests/torch/test_basic_async.py
                 tests/torch/test_basic_multichip.py
-                tests/torch/test_basic_sharding.py
                 tests/models/mnist/test_mnist.py::test_mnist_train[data_parallel-full-eval]
                 tests/models/resnet50/test_resnet50.py::test_resnet[data_parallel-full-eval]
                 tests/models/resnet/test_resnet.py::test_resnet[data_parallel-full-eval]
@@ -127,6 +126,12 @@ jobs:
                 tests/models/vit/test_vit_n300.py::test_vit[full-large-eval]
                 tests/models/segformer/test_segformer_n300.py::test_segformer[full-eval]
                 tests/models/hardnet/test_hardnet_n300.py::test_hardnet[full-eval]
+            "
+          },
+          {
+            # It is not safe to run XLA SPMD tests with other tests using torch/xla
+            wh-runner: n300, name: "eval_6_spmd", pytest-args: "", tests: "
+                tests/torch/test_basic_sharding.py
             "
           },
           {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,7 @@ def use_xla_environment():
     # Sets the mesh shape used by the auto parallel pass
     os.environ["MESH_SHAPE"] = f"1,{num_devices}"
 
-    os.environ["TT_TORCH_USE_EXPERIMENTAL_BACKEND"] = "1"
+    os.environ["TT_TORCH_FORCE_EXPERIMENTAL_BACKEND"] = "1"
     # Initialize SPMD
     xr.use_spmd()
 
@@ -64,7 +64,7 @@ def use_xla_environment():
     os.environ.pop("ENABLE_AUTO_PARALLEL", None)
     os.environ.pop("CONVERT_SHLO_TO_SHARDY", None)
     os.environ.pop("MESH_SHAPE", None)
-    os.environ.pop("TT_TORCH_USE_EXPERIMENTAL_BACKEND", None)
+    os.environ.pop("TT_TORCH_FORCE_EXPERIMENTAL_BACKEND", None)
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ import xml.etree.ElementTree as ET
 import socket
 import os
 import tt_mlir
-import torch_xla.runtime as xr
-import torch_xla
 import tt_torch.dynamo.sharding_utils as sharding_utils
 
 global junitxml_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,19 +40,21 @@ def manage_dependencies(request):
 
 
 @pytest.fixture(scope="function")
-def use_xla_environment():
+def use_xla_spmd_environment():
     """
     Setup XLA environment for tensor parallelism.
     SPMD and nonSPMD tests are not to be mixed in the same pytest process/test group.
     """
 
     env_vars_to_restore = {
-        "TT_TORCH_FORCE_EXPERIMENTAL_BACKEND": os.environ.get("TT_TORCH_FORCE_EXPERIMENTAL_BACKEND", None)
+        "TT_TORCH_FORCE_EXPERIMENTAL_BACKEND": os.environ.get(
+            "TT_TORCH_FORCE_EXPERIMENTAL_BACKEND", None
+        )
     }
 
     # Needed to set TT_TORCH_FORCE_EXPERIMENTAL_BACKEND to reuse verify_torch_module
     os.environ["TT_TORCH_FORCE_EXPERIMENTAL_BACKEND"] = "1"
-    sharding_utils.setup_xla_environment()
+    sharding_utils.setup_xla_spmd_environment()
 
     yield
 

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import tt_torch.dynamo.sharding_utils as ts
+import torch
+import torch.nn as nn
+import torch_xla
+import torch_xla.core.xla_model as xm
+from tt_torch.dynamo.backend import CompilerConfig, BackendOptions
+from tt_torch.tools.verify import verify_module
+
+import os
+import torch_xla.runtime as xr
+import torch_xla.distributed.spmd as xs
+from torch_xla.distributed.spmd import Mesh
+import numpy as np
+import torch_xla
+
+
+class FooModule(nn.Module):
+    def __init__(self):
+        super(FooModule, self).__init__()
+        # Define x1 as a weight parameter
+        self.x1 = nn.Parameter(torch.ones((32, 32)))
+
+    def forward(self, x2):
+        x2 *= 2
+        y1 = self.x1 @ x2
+        return y1, x2
+
+
+def setup_xla_environment():
+    """Setup XLA environment for tensor parallelism."""
+    print("Setting up XLA environment...")
+    num_devices = xr.global_runtime_device_count()
+
+    # Enables the auto parallel pass in tt-mlir
+    os.environ["ENABLE_AUTO_PARALLEL"] = "TRUE"
+    # Converts the StableHLO emitted by torch-xla to the Shardy dialect
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    # Sets the mesh shape used by the auto parallel pass
+    os.environ["MESH_SHAPE"] = f"1,{num_devices}"
+
+    os.environ["TT_TORCH_USE_EXPERIMENTAL_BACKEND"] = "1"
+    # Initialize SPMD
+    xr.use_spmd()
+
+    torch_xla.sync(True, True)
+    print("XLA environment configured.")
+
+
+def create_device_mesh() -> Mesh:
+    """
+    Create device mesh for tensor parallelism.
+
+    Args:
+        num_devices: Total number of devices
+        mesh_shape: Shape of the device mesh (batch_dim, model_dim)
+
+    Returns:
+        Mesh object for SPMD operations
+    """
+    num_devices = xr.global_runtime_device_count()
+    mesh_shape = (1, num_devices)
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, ("batch", "model"))
+    print(f"Created device mesh: {mesh_shape} with {num_devices} devices")
+    return mesh
+
+
+def test_linear():
+    class Basic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.sharded_weight = nn.Parameter(torch.randn(32, 64))
+
+        def forward(self, x):
+            return x @ self.sharded_weight
+
+    setup_xla_environment()
+    cc = CompilerConfig()
+    cc.mesh = create_device_mesh()
+    test_class = Basic()
+    weight_shard_spec = (None, "model")  # Shard along the model dimension
+    ts.mark_sharding(test_class.sharded_weight, weight_shard_spec)
+
+    # This also verifies that the PCC between the ondevice sharded matmul  and CPU unsharded matmul is the same
+    verify_module(test_class, input_shapes=[(32, 32)], compiler_config=cc)
+
+    assert ts.get_sharding(test_class.sharded_weight) == weight_shard_spec

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -4,7 +4,7 @@
 import tt_torch.dynamo.sharding_utils as ts
 import torch
 import torch.nn as nn
-from tt_torch.dynamo.backend import CompilerConfig, BackendOptions
+from tt_torch.dynamo.backend import CompilerConfig
 from tt_torch.tools.verify import verify_module
 
 import pytest

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -18,10 +18,6 @@ def create_device_mesh() -> Mesh:
     """
     Create device mesh for tensor parallelism.
 
-    Args:
-        num_devices: Total number of devices
-        mesh_shape: Shape of the device mesh (batch_dim, model_dim)
-
     Returns:
         Mesh object for SPMD operations
     """

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -44,7 +44,8 @@ def test_linear_param_sharded():
             return x @ self.sharded_weight
 
     cc = CompilerConfig()
-    cc.mesh = create_device_mesh()
+    cc.xla_mesh = create_device_mesh()
+
     test_class = Basic()
     weight_shard_spec = (None, "model")
     ts.mark_sharding(test_class.sharded_weight, weight_shard_spec)

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -4,49 +4,14 @@
 import tt_torch.dynamo.sharding_utils as ts
 import torch
 import torch.nn as nn
-import torch_xla
-import torch_xla.core.xla_model as xm
 from tt_torch.dynamo.backend import CompilerConfig, BackendOptions
 from tt_torch.tools.verify import verify_module
 
-import os
+import pytest
 import torch_xla.runtime as xr
-import torch_xla.distributed.spmd as xs
 from torch_xla.distributed.spmd import Mesh
 import numpy as np
-import torch_xla
-
-
-class FooModule(nn.Module):
-    def __init__(self):
-        super(FooModule, self).__init__()
-        # Define x1 as a weight parameter
-        self.x1 = nn.Parameter(torch.ones((32, 32)))
-
-    def forward(self, x2):
-        x2 *= 2
-        y1 = self.x1 @ x2
-        return y1, x2
-
-
-def setup_xla_environment():
-    """Setup XLA environment for tensor parallelism."""
-    print("Setting up XLA environment...")
-    num_devices = xr.global_runtime_device_count()
-
-    # Enables the auto parallel pass in tt-mlir
-    os.environ["ENABLE_AUTO_PARALLEL"] = "TRUE"
-    # Converts the StableHLO emitted by torch-xla to the Shardy dialect
-    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-    # Sets the mesh shape used by the auto parallel pass
-    os.environ["MESH_SHAPE"] = f"1,{num_devices}"
-
-    os.environ["TT_TORCH_USE_EXPERIMENTAL_BACKEND"] = "1"
-    # Initialize SPMD
-    xr.use_spmd()
-
-    torch_xla.sync(True, True)
-    print("XLA environment configured.")
+import weakref
 
 
 def create_device_mesh() -> Mesh:
@@ -68,23 +33,35 @@ def create_device_mesh() -> Mesh:
     return mesh
 
 
-def test_linear():
+@pytest.mark.usefixtures("use_xla_environment")
+def test_linear_param_sharded():
     class Basic(nn.Module):
         def __init__(self):
             super().__init__()
-            self.sharded_weight = nn.Parameter(torch.randn(32, 64))
+            self.sharded_weight = nn.Parameter(torch.randn(32, 128))
 
         def forward(self, x):
             return x @ self.sharded_weight
 
-    setup_xla_environment()
     cc = CompilerConfig()
     cc.mesh = create_device_mesh()
     test_class = Basic()
-    weight_shard_spec = (None, "model")  # Shard along the model dimension
+    weight_shard_spec = (None, "model")
     ts.mark_sharding(test_class.sharded_weight, weight_shard_spec)
 
-    # This also verifies that the PCC between the ondevice sharded matmul  and CPU unsharded matmul is the same
+    # Check that sharding annotation worked
+    assert ts.get_sharding(test_class.sharded_weight) == weight_shard_spec
+
+    weak_ref = weakref.ref(test_class.sharded_weight)
+
+    # Check that the PCC between the ondevice sharded matmul and CPU unsharded matmul is the same
     verify_module(test_class, input_shapes=[(32, 32)], compiler_config=cc)
 
-    assert ts.get_sharding(test_class.sharded_weight) == weight_shard_spec
+    # Check that cache doesn't hold onto the weight tensor
+    del test_class
+    import gc
+
+    gc.collect()
+    assert (
+        weak_ref() is None
+    ), "Reference to sharded weight torch.Tensor is still held after deleting the module"

--- a/tests/torch/test_basic_sharding.py
+++ b/tests/torch/test_basic_sharding.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import tt_torch.dynamo.sharding_utils as ts
+import tt_torch.dynamo.sharding_utils as sharding_utils
 import torch
 import torch.nn as nn
 from tt_torch.dynamo.backend import CompilerConfig
@@ -44,10 +44,10 @@ def test_linear_param_sharded():
 
     test_class = Basic()
     weight_shard_spec = (None, "model")
-    ts.mark_sharding(test_class.sharded_weight, weight_shard_spec)
+    sharding_utils.mark_sharding(test_class.sharded_weight, weight_shard_spec)
 
     # Check that sharding annotation worked
-    assert ts.get_sharding(test_class.sharded_weight) == weight_shard_spec
+    assert sharding_utils.get_sharding(test_class.sharded_weight) == weight_shard_spec
 
     weak_ref = weakref.ref(test_class.sharded_weight)
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
             chmod -R +x ${TTXLA_INSTALL_PREFIX}
         CMAKE_GENERATOR Ninja
         CMAKE_ARGS
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_C_COMPILER=clang-17
             -DCMAKE_CXX_COMPILER=clang++-17
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -105,7 +105,7 @@ else()
             chmod -R +x ${TTXLA_INSTALL_PREFIX}
         CMAKE_GENERATOR Ninja
         CMAKE_ARGS
-            -DCMAKE_BUILD_TYPE=Debug
+            -DCMAKE_BUILD_TYPE=Release
             -DCMAKE_C_COMPILER=clang-17
             -DCMAKE_CXX_COMPILER=clang++-17
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -639,8 +639,8 @@ class XLAExecutor:
                 self.user_input_indices.append(idx)
             else:
                 source_tensor = self.program.state_dict[input_spec.target]
+                shard_spec = ts.get_sharding(source_tensor)
                 device_tensor = source_tensor.to("xla")
-                shard_spec = ts.get_sharding(device_tensor)
                 if shard_spec is not None:
                     xs.mark_sharding(
                         device_tensor, self.compiler_config.xla_mesh, shard_spec

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -643,7 +643,7 @@ class XLAExecutor:
                 shard_spec = ts.get_sharding(device_tensor)
                 if shard_spec is not None:
                     xs.mark_sharding(
-                        device_tensor, self.compiler_config.mesh, shard_spec
+                        device_tensor, self.compiler_config.xla_mesh, shard_spec
                     )
                 self.inputs.append(device_tensor)
 
@@ -654,7 +654,7 @@ class XLAExecutor:
                 device_inputs = inputs.to(device)
                 if shard_spec is not None:
                     xs.mark_sharding(
-                        device_inputs, self.compiler_config.mesh, shard_spec
+                        device_inputs, self.compiler_config.xla_mesh, shard_spec
                     )
                 return device_inputs
             else:

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -40,7 +40,7 @@ from tt_torch.tools.utils import (
 import torch_xla
 import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
-import tt_torch.dynamo.sharding_utils as ts
+import tt_torch.dynamo.sharding_utils as sharding_utils
 
 from ..executor import get_inputs_size, gb_to_bytes
 
@@ -639,7 +639,7 @@ class XLAExecutor:
                 self.user_input_indices.append(idx)
             else:
                 source_tensor = self.program.state_dict[input_spec.target]
-                shard_spec = ts.get_sharding(source_tensor)
+                shard_spec = sharding_utils.get_sharding(source_tensor)
                 device_tensor = source_tensor.to("xla")
                 if shard_spec is not None:
                     xs.mark_sharding(
@@ -650,7 +650,7 @@ class XLAExecutor:
     def push_tensors_to_device(self, inputs, device):
         if hasattr(inputs, "to"):
             if device not in [inputs.device, inputs.device.type]:
-                shard_spec = ts.get_sharding(inputs)
+                shard_spec = sharding_utils.get_sharding(inputs)
                 device_inputs = inputs.to(device)
                 if shard_spec is not None:
                     xs.mark_sharding(

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -642,6 +642,9 @@ class XLAExecutor:
                 shard_spec = sharding_utils.get_sharding(source_tensor)
                 device_tensor = source_tensor.to("xla")
                 if shard_spec is not None:
+                    assert (
+                        self.compiler_config.xla_mesh
+                    ), "compiler_config.xla_mesh must be set to mark_sharding on tensors"
                     xs.mark_sharding(
                         device_tensor, self.compiler_config.xla_mesh, shard_spec
                     )
@@ -653,6 +656,9 @@ class XLAExecutor:
                 shard_spec = sharding_utils.get_sharding(inputs)
                 device_inputs = inputs.to(device)
                 if shard_spec is not None:
+                    assert (
+                        self.compiler_config.xla_mesh
+                    ), "compiler_config.xla_mesh must be set to mark_sharding on tensors"
                     xs.mark_sharding(
                         device_inputs, self.compiler_config.xla_mesh, shard_spec
                     )

--- a/tt_torch/dynamo/sharding_utils.py
+++ b/tt_torch/dynamo/sharding_utils.py
@@ -1,27 +1,32 @@
-from typing import Dict, Tuple, Optional
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import Tuple, Optional
 import torch
-import os
 
 # Type aliases
 ShardSpec = Tuple[Optional[str], ...]
-ShardMap = Dict[torch.Tensor, ShardSpec]
+ShardMap = dict[torch.Tensor, ShardSpec]
 
 
 class ShardingRegistry:
     def __init__(self):
-        self.shard_map:ShardMap = {}
-    
-    def mark_sharding(self, tensor:torch.Tensor, shard_spec: ShardSpec) -> None:
+        self.shard_map: ShardMap = {}
+
+    def mark_sharding(self, tensor: torch.Tensor, shard_spec: ShardSpec) -> None:
         self.shard_map[tensor] = shard_spec
-    
-    def get_sharding(self, tensor:torch.Tensor) -> Optional[ShardSpec]:
+
+    def get_sharding(self, tensor: torch.Tensor) -> Optional[ShardSpec]:
         return self.shard_map.get(tensor)
 
+
 _sharding_registry = ShardingRegistry()
+
 
 def mark_sharding(tensor: torch.Tensor, shard_spec: ShardSpec) -> None:
     """Mark sharding for a tensor."""
     _sharding_registry.mark_sharding(tensor, shard_spec)
+
 
 def get_sharding(tensor: torch.Tensor) -> Optional[ShardSpec]:
     """Get sharding spec for a tensor."""

--- a/tt_torch/dynamo/sharding_utils.py
+++ b/tt_torch/dynamo/sharding_utils.py
@@ -23,6 +23,9 @@ class ShardingRegistry:
 
     def mark_sharding(self, tensor: torch.Tensor, shard_spec: ShardSpec) -> None:
         key = _tensor_key(tensor)
+        assert (
+            key not in self.shard_map
+        ), f"Source tensor with shape {tensor.shape} is already marked for sharding with shard_spec {self.shard_map[key]}"
         self.shard_map[key] = shard_spec
 
     def get_sharding(self, tensor: torch.Tensor) -> Optional[ShardSpec]:
@@ -48,7 +51,7 @@ def get_shard_map_size() -> int:
     return len(_sharding_registry.shard_map)
 
 
-def setup_xla_environment():
+def setup_xla_spmd_environment():
     """
     Configure XLA environment for SPMD.
 

--- a/tt_torch/dynamo/sharding_utils.py
+++ b/tt_torch/dynamo/sharding_utils.py
@@ -1,0 +1,33 @@
+from typing import Dict, Tuple, Optional
+import torch
+import os
+
+# Type aliases
+ShardSpec = Tuple[Optional[str], ...]
+ShardMap = Dict[torch.Tensor, ShardSpec]
+
+
+class ShardingRegistry:
+    def __init__(self):
+        self.shard_map:ShardMap = {}
+    
+    def mark_sharding(self, tensor:torch.Tensor, shard_spec: ShardSpec) -> None:
+        self.shard_map[tensor] = shard_spec
+    
+    def get_sharding(self, tensor:torch.Tensor) -> Optional[ShardSpec]:
+        return self.shard_map.get(tensor)
+
+_sharding_registry = ShardingRegistry()
+
+def mark_sharding(tensor: torch.Tensor, shard_spec: ShardSpec) -> None:
+    """Mark sharding for a tensor."""
+    _sharding_registry.mark_sharding(tensor, shard_spec)
+
+def get_sharding(tensor: torch.Tensor) -> Optional[ShardSpec]:
+    """Get sharding spec for a tensor."""
+    return _sharding_registry.get_sharding(tensor)
+
+
+def get_shard_map_size() -> int:
+    """Get the number of tensors in the shard map."""
+    return len(_sharding_registry.shard_map)

--- a/tt_torch/dynamo/sharding_utils.py
+++ b/tt_torch/dynamo/sharding_utils.py
@@ -1,23 +1,30 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Dict
 import torch
 
 # Type aliases
 ShardSpec = Tuple[Optional[str], ...]
-ShardMap = dict[torch.Tensor, ShardSpec]
+TensorKey = Tuple[int, Tuple[int, ...], torch.dtype, str]  # (id, shape, dtype, device)
+
+
+def _tensor_key(tensor: torch.Tensor) -> TensorKey:
+    """Generate a stable key for a tensor based on id, shape, dtype, and device"""
+    return (id(tensor), tuple(tensor.shape), tensor.dtype, str(tensor.device))
 
 
 class ShardingRegistry:
     def __init__(self):
-        self.shard_map: ShardMap = {}
+        self.shard_map: Dict[TensorKey, ShardSpec] = {}
 
     def mark_sharding(self, tensor: torch.Tensor, shard_spec: ShardSpec) -> None:
-        self.shard_map[tensor] = shard_spec
+        key = _tensor_key(tensor)
+        self.shard_map[key] = shard_spec
 
     def get_sharding(self, tensor: torch.Tensor) -> Optional[ShardSpec]:
-        return self.shard_map.get(tensor)
+        key = _tensor_key(tensor)
+        return self.shard_map.get(key)
 
 
 _sharding_registry = ShardingRegistry()

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -336,6 +336,7 @@ class CompilerConfig:
         self.mesh_shape = [1, 1]
         self.push_outputs_to_cpu = True
         self.arg_type_map_override = False
+        self.xla_mesh = None
 
     @property
     def model_name(self):


### PR DESCRIPTION
### Ticket
Dependency of https://github.com/tenstorrent/tt-xla/issues/1001

### Problem description
It is not currently possible to mark sharding for tensors in models using the torch.compile flow. This is because we can only mark_sharding on XLA tensors that have been moved onto device, but we move them onto device in the XLAbackend where the user cannot access them.

### What's changed
- Create deferred shard marking path using a global sharding registry:
  - Users mark sharding by ts.mark_sharding() on raw torch.Tensors to save them in a global dict. The API for this mirrors the existing torch-xla API
  - In the executor, extract the user shard marking by pulling it out of the dict
  - Use weak references in the global sharding registry to avoid preventing the original torch tensors from being GC'd
- Create initial pytest for sharding
- Create test fixture to setup and teardown torch-xla SPMD env variables 

### Checklist
- [x] New/Existing tests provide coverage for changes
