### PR TITLE
Various nightly fixes/improvements (BH tests enable, enable PCC, remove xfail, high-memory machines)

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -56,7 +56,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      runners: '["wormhole"]'
+      runners: '["wormhole", "blackhole"]'
       tests-filter: "expected_passing"
       num-splits: 8
   download-report:

--- a/.github/workflows/run-op-by-op-model-tests-nightly.yml
+++ b/.github/workflows/run-op-by-op-model-tests-nightly.yml
@@ -158,7 +158,7 @@ jobs:
           },
           {
             # only testing 4k variant as they're identical aside from token size
-            runs-on: wormhole_b0, name: "phi3", tests: "
+            runs-on: high-memory-wormhole, name: "phi3", tests: "
               tests/models/phi/test_phi_3.py::test_phi_3[op_by_op_torch-mini_4k_instruct-eval]
             "
           },
@@ -180,7 +180,7 @@ jobs:
             "
           },
           {
-            runs-on: wormhole_b0, name: "phi4", tests: "
+            runs-on: high-memory-wormhole, name: "phi4", tests: "
               tests/models/phi/test_phi_4.py::test_phi_4[op_by_op_torch-eval]
             "
           },

--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -43,9 +43,6 @@ def test_qwen2_casual_lm(record_property, mode, op_by_op):
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO: Remove this once PCC ATOL is fixed on blackhole runners - https://github.com/tenstorrent/tt-torch/issues/1003
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
-
     variant = ModelVariant.QWEN_2_5_1_5B
     loader = ModelLoader(variant=variant)
     model_info = loader.get_model_info(variant=variant)
@@ -57,10 +54,10 @@ def test_qwen2_casual_lm(record_property, mode, op_by_op):
         model_info=model_info,
         compiler_config=cc,
         record_property_handle=record_property,
-        assert_pcc=assert_pcc,
+        assert_pcc=True,
         assert_atol=False,
         run_generate=False,
-        required_pcc=0.85,
+        required_pcc=0.93,
     )
 
     results = tester.test_model()

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -79,15 +79,6 @@ def test_timm_image_classification(
     if mode == "train":
         pytest.skip()
 
-    # Follow up in https://github.com/tenstorrent/tt-torch/issues/1142
-    if model_name in ["ese_vovnet19b_dw.ra_in1k"]:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Error code: 13 - loc(\"reduce-window.282\"): error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28)",
-                strict=True,
-            )
-        )
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -120,10 +120,8 @@ def test_torchvision_image_classification(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO Enable checking (vit_h_14) - https://github.com/tenstorrent/tt-torch/issues/491
-    # TODO Enable checking (densenet161) - https://github.com/tenstorrent/tt-torch/issues/1142
     model_name = model_info[0]
-    assert_pcc = False if model_name in ["vit_h_14", "densenet161"] else True
+    assert_pcc = True
     assert_atol = False
 
     model_group = "red" if model_name == "swin_v2_s" else "generality"

--- a/tests/models/torchvision/test_torchvision_image_classification_n300.py
+++ b/tests/models/torchvision/test_torchvision_image_classification_n300.py
@@ -118,10 +118,8 @@ def test_torchvision_image_classification(
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
 
-    # TODO Enable checking (vit_h_14) - https://github.com/tenstorrent/tt-torch/issues/491
-    # TODO Enable checking (densenet161) - https://github.com/tenstorrent/tt-torch/issues/1142
     model_name = model_info[0]
-    assert_pcc = False if model_name in ["vit_h_14", "densenet161"] else True
+    assert_pcc = True
     assert_atol = False
 
     # FIXME fails with tt-experimental - https://github.com/tenstorrent/tt-torch/issues/1105

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -66,19 +66,9 @@ def test_torchvision_object_detection(
 ):
     model_name, _ = model_info
 
-    # Follow up in https://github.com/tenstorrent/tt-torch/issues/1142
-    if model_name in ["ssd300_vgg16"]:
-        request.node.add_marker(
-            pytest.mark.xfail(
-                reason="Error code: 13 - loc(\"reduce-window.244\"): error: 'ttir.max_pool2d' op output tensor height and width dimension (38, 38) do not match the expected dimensions (37, 38)",
-                strict=True,
-            )
-        )
-
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True
-
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -58,12 +58,11 @@ def test_yolos(record_property, mode, op_by_op, data_parallel_mode):
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
             cc.op_by_op_backend = OpByOpBackend.STABLEHLO
-    assert_pcc = tt_mlir.get_arch() != tt_mlir.Arch.BLACKHOLE
     tester = ThisTester(
         model_name,
         mode,
         required_pcc=0.98,
-        assert_pcc=assert_pcc,
+        assert_pcc=True,
         assert_atol=False,
         compiler_config=cc,
         record_property_handle=record_property,

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -189,8 +189,6 @@ test_config = {
     },
     "densenet/pytorch-densenet161-full-eval": {
         "status": ModelStatus.EXPECTED_PASSING,
-        # PCC Drop to 0.41146078113061335 Aug5: Issue https://github.com/tenstorrent/tt-torch/issues/1142
-        "assert_pcc": False,
     },
     "densenet/pytorch-densenet169-full-eval": {
         "status": ModelStatus.EXPECTED_PASSING,

--- a/tests/runner/test_config.py
+++ b/tests/runner/test_config.py
@@ -22,21 +22,15 @@ test_config = {
     },
     "vovnet/pytorch-vovnet27s-full-eval": {
         "assert_pcc": False,
-        # Aug5: Issue https://github.com/tenstorrent/tt-torch/issues/1142
-        "status": ModelStatus.KNOWN_FAILURE_XFAIL,
-        "xfail_reason": "loc(\"reduce-window.234\"): error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28)",
+        "status": ModelStatus.EXPECTED_PASSING,
     },
     "vovnet/pytorch-vovnet39-full-eval": {
         "assert_pcc": False,
-        # Aug5: Issue https://github.com/tenstorrent/tt-torch/issues/1142
-        "status": ModelStatus.KNOWN_FAILURE_XFAIL,
-        "xfail_reason": "loc(\"reduce-window.234\"): error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28)",
+        "status": ModelStatus.EXPECTED_PASSING,
     },
     "vovnet/pytorch-vovnet57-full-eval": {
         "assert_pcc": False,
-        # Aug5: Issue https://github.com/tenstorrent/tt-torch/issues/1142
-        "status": ModelStatus.KNOWN_FAILURE_XFAIL,
-        "xfail_reason": "loc(\"reduce-window.234\"): error: 'ttir.max_pool2d' op output tensor height and width dimension (28, 28) do not match the expected dimensions (27, 28)",
+        "status": ModelStatus.EXPECTED_PASSING,
     },
     "hardnet/pytorch-full-eval": {
         "required_pcc": 0.98,


### PR DESCRIPTION
### Ticket
#1003

### Problem description
- A few improvements can be made in nightly now after recent fixes and more machines available

### What's changed
- Run tt-forge-models expected passing tests against blackhole too (was disabled recently due to lack of machines)
- Remove xfail on few tests recently solved for #1142 (vovnet, densenet) 
- Enable PCC check on vit_h_14 for #491 now passing
- Enable PCC check on YOLOS and test_qwen2_casual_lm for BH and raise threshold (#1003)
- Move phi3/phi4 op-by-op to high-memory-wormhole machine to try and avoid OOM for past months

### Checklist
- [x] Visually check superset for test changes. For testing BH on tt-forge-models ran CI here, passed in 90 mins : https://github.com/tenstorrent/tt-torch/actions/runs/17157618434
