### PR TITLE
[wip] Remove references to consteval parameters

### DIFF
--- a/demos/llama3.2_generate_demo.py
+++ b/demos/llama3.2_generate_demo.py
@@ -45,7 +45,6 @@ def main():
     clear_dynamo_cache()
     cc = CompilerConfig()
     cc.enable_consteval = False
-    cc.consteval_parameters = False
 
     options = BackendOptions()
     options.compiler_config = cc

--- a/demos/resnet/resnet50_data_parallel_async.py
+++ b/demos/resnet/resnet50_data_parallel_async.py
@@ -33,7 +33,6 @@ def download_image(url):
 def main():
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     num_devices = DeviceManager.get_num_available_devices()
     parent, devices = DeviceManager.acquire_available_devices()

--- a/demos/resnet/resnet50_data_parallel_demo.py
+++ b/demos/resnet/resnet50_data_parallel_demo.py
@@ -77,7 +77,6 @@ def main(use_simplified_manager):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     num_devices = DeviceManager.get_num_available_devices()
     if use_simplified_manager:

--- a/demos/resnet/resnet50_demo.py
+++ b/demos/resnet/resnet50_demo.py
@@ -22,7 +22,6 @@ def main(run_interactive):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     options = BackendOptions()
     options.compiler_config = cc

--- a/demos/resnet/resnet50_single_vs_multi_device_compare.py
+++ b/demos/resnet/resnet50_single_vs_multi_device_compare.py
@@ -126,7 +126,6 @@ if __name__ == "__main__":
     # Compile for single device
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     single_options = BackendOptions()
     single_options.compiler_config = cc

--- a/demos/stable_diffusion/sd_demo.py
+++ b/demos/stable_diffusion/sd_demo.py
@@ -22,7 +22,6 @@ def main(run_interactive):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     options = BackendOptions()
     options.compiler_config = cc

--- a/docs/src/adding_models.md
+++ b/docs/src/adding_models.md
@@ -196,7 +196,6 @@ def <test_name>(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/docs/src/controlling.md
+++ b/docs/src/controlling.md
@@ -8,7 +8,6 @@ You can use the following environment variables to override default behavior:
 | TT_TORCH_VERIFY_OP_BY_OP | Sets whether to verify the output of each compiled op against pytorch when running with compile depth `EXECUTE_OP_BY_OP`. | False |
 | TT_TORCH_VERIFY_INTERMEDIATES | Sets whether to verify runtime intermediates during execution. | False |
 | TT_TORCH_CONSTEVAL | Enables evaluation of constant expressions (consteval) in the Torch FX graph prior to compilation. | False |
-| TT_TORCH_CONSTEVAL_PARAMETERS | Extends consteval to include parameters (e.g., model weights) as well as embedded constants. | False |
 | TT_TORCH_INLINE_PARAMETERS | Inlines parameters in the MLIR module (and thus flatbuffer executable) rather than requiring them as inputs. NOTE: The maximum size of a flatbuffer is 2GB so this will cause compilation to fail for sufficiently large models | False |
 | TT_TORCH_IR_LOG_LEVEL | Enables printing MLIR from Torch to TTNN. It supports two modes; `INFO` and `DEBUG`. `INFO` prints MLIR for all conversions steps (Torch, StableHLO, TTIR and TTNN MLIR graphs). `DEBUG` prints intermediate MLIR for all passes (IR dump before and after each pass) additionally. Be warned, `DEBUG` IR printing forces single core compile, so it is much slower. | Disable |
 

--- a/docs/src/controlling.md
+++ b/docs/src/controlling.md
@@ -34,7 +34,6 @@ model = MyModel()
 
 cc = CompilerConfig()
 cc.enable_consteval = True
-cc.consteval_parameters = True # This will enable constant folding on the parameters in addition to any constants
 
 options = BackendOptions()
 options.compiler_config = cc

--- a/tests/experimental/models/resnet50/test_resnet50.py
+++ b/tests/experimental/models/resnet50/test_resnet50.py
@@ -50,7 +50,6 @@ def test_resnet(record_property, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
 
@@ -135,7 +134,6 @@ def test_resnet_perf():
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.push_outputs_to_cpu = False
     options = BackendOptions(compiler_config=cc)
     # Push model and input to device

--- a/tests/models/EfficientNet/test_EfficientNet.py
+++ b/tests/models/EfficientNet/test_EfficientNet.py
@@ -63,7 +63,6 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/EfficientNet/test_EfficientNet_n300.py
+++ b/tests/models/EfficientNet/test_EfficientNet_n300.py
@@ -63,7 +63,6 @@ def test_EfficientNet(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -43,7 +43,6 @@ def test_MobileNetV2(record_property, mode, op_by_op):
     model_name = "MobileNetV2"
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/MobileNetV2/test_MobileNetV2_n300.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2_n300.py
@@ -43,7 +43,6 @@ def test_MobileNetV2(record_property, mode, op_by_op):
     model_name = "MobileNetV2"
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/Qwen/test_qwen2_casual_lm.py
+++ b/tests/models/Qwen/test_qwen2_casual_lm.py
@@ -37,7 +37,6 @@ def test_qwen2_casual_lm(record_property, mode, op_by_op):
         pytest.skip()
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/Qwen/test_qwen2_token_classification.py
+++ b/tests/models/Qwen/test_qwen2_token_classification.py
@@ -35,7 +35,6 @@ def test_qwen2_token_classification(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/RMBG/test_RMBG.py
+++ b/tests/models/RMBG/test_RMBG.py
@@ -38,7 +38,6 @@ def test_RMBG(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -61,7 +61,6 @@ def test_albert_masked_lm(
 ):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -40,7 +40,6 @@ def test_albert_question_answering(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -45,7 +45,6 @@ def test_albert_sequence_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -47,7 +47,6 @@ def test_albert_token_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/autoencoder_conv/test_autoencoder_conv.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv.py
@@ -60,7 +60,6 @@ def test_autoencoder_conv(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -85,7 +85,6 @@ def test_autoencoder_conv_v2(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -33,7 +33,6 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
         pytest.skip()
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear_n300.py
@@ -33,7 +33,6 @@ def test_autoencoder_linear(record_property, mode, op_by_op):
         pytest.skip()
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -56,7 +56,6 @@ def test_beit_image_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/beit/test_beit_image_classification_n300.py
+++ b/tests/models/beit/test_beit_image_classification_n300.py
@@ -53,7 +53,6 @@ def test_beit_image_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -43,7 +43,6 @@ def test_bert(record_property, mode, op_by_op, variant, variant_config):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/bert/test_bert_turkish.py
+++ b/tests/models/bert/test_bert_turkish.py
@@ -45,7 +45,6 @@ def test_bert_turkish(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
+++ b/tests/models/bi_lstm_crf/test_bi_lstm_crf.py
@@ -39,7 +39,6 @@ def test_bi_lstm_crf(record_property, variant, variant_config, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if variant.value == "gru":
             pytest.skip(

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -30,7 +30,6 @@ class ThisTester(ModelTester):
 def test_bloom(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/centernet/test_centernet_onnx.py
+++ b/tests/models/centernet/test_centernet_onnx.py
@@ -51,7 +51,6 @@ def test_centernet_onnx(record_property, model_info, mode, op_by_op):
     model_name, _ = model_info
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op is not None:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -52,7 +52,6 @@ def test_clip(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -32,7 +32,6 @@ class ThisTester(ModelTester):
 def test_codegen(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/codegen/test_codegen_generate.py
+++ b/tests/models/codegen/test_codegen_generate.py
@@ -32,7 +32,6 @@ class ThisTester(ModelTester):
 def test_codegen_generate(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/d_fine/test_d_fine.py
+++ b/tests/models/d_fine/test_d_fine.py
@@ -41,7 +41,6 @@ def test_d_fine(record_property, variant, variant_config, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/deepseek/test_deepseek.py
+++ b/tests/models/deepseek/test_deepseek.py
@@ -30,7 +30,6 @@ class ThisTester(ModelTester):
 def test_deepseek(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -52,7 +52,6 @@ def test_deit(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/deit/test_deit_n300.py
+++ b/tests/models/deit/test_deit_n300.py
@@ -52,7 +52,6 @@ def test_deit(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -37,7 +37,6 @@ class ThisTester(ModelTester):
 def test_detr(record_property, mode, op_by_op, data_parallel_mode):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/detr/test_detr_onnx.py
+++ b/tests/models/detr/test_detr_onnx.py
@@ -67,7 +67,6 @@ def test_detr_onnx(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op is not None:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -37,7 +37,6 @@ def test_distilbert(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:
@@ -78,7 +77,6 @@ def test_distilbert_multiloop(record_property, model_name, mode, op_by_op, num_l
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.cache_preprocessed_constants = True
 
     tester = ThisTester(

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -35,7 +35,6 @@ class ThisTester(ModelTester):
 def test_dpr(record_property, mode, op_by_op, data_parallel_mode):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -41,7 +41,6 @@ def test_falcon(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/falcon/test_falcon3.py
+++ b/tests/models/falcon/test_falcon3.py
@@ -53,7 +53,6 @@ def test_falcon(record_property, model_name, mode, op_by_op):
     model_group = "red"
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
+++ b/tests/models/falcon/test_falcon3_7b_10b_pipeline_parallel.py
@@ -74,7 +74,6 @@ def test_falcon_pipeline_parallel(record_property, model_name, mode, op_by_op):
     options.compiler_config = cc
     cc.device_map = device_map
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     options.devices = [device1, device2]
     compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
     out = compiled_model(**test_input)

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -30,7 +30,6 @@ class ThisTester(ModelTester):
 def test_flan_t5(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/flux/test_flux.py
+++ b/tests/models/flux/test_flux.py
@@ -40,7 +40,6 @@ print("Available variants: ", [str(k) for k in available_variants.keys()])
 def test_flux(record_property, variant, variant_config, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/gliner/test_gliner.py
+++ b/tests/models/gliner/test_gliner.py
@@ -28,7 +28,6 @@ class ThisTester(ModelTester):
 def test_gliner(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -32,7 +32,6 @@ class ThisTester(ModelTester):
 def test_glpn_kitti(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -43,7 +43,6 @@ def test_gpt2(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -30,7 +30,6 @@ class ThisTester(ModelTester):
 def test_gpt_neo(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -39,7 +39,6 @@ def test_hardnet(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/hardnet/test_hardnet_n300.py
+++ b/tests/models/hardnet/test_hardnet_n300.py
@@ -36,7 +36,6 @@ def test_hardnet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/llama/test_llama3_generative.py
+++ b/tests/models/llama/test_llama3_generative.py
@@ -63,7 +63,6 @@ def test_llama3_generate(record_property, mode, op_by_op):
     # Consteval disabled due to 4D Causal Attention Mask evaluation getting constant folded in torchfx
     # due to incorrect tracing of static cache and malformed output missing static cache tensors
     cc.enable_consteval = False
-    cc.consteval_parameters = False
 
     options = BackendOptions()
     options.compiler_config = cc

--- a/tests/models/llama/test_llama_3b.py
+++ b/tests/models/llama/test_llama_3b.py
@@ -28,7 +28,6 @@ class ThisTester(ModelTester):
 def test_llama_3b(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/llama/test_llama_7b_generative_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_generative_pipeline_parallel.py
@@ -61,7 +61,6 @@ def test_llama_7b_generative_pipeline_parallel():
     clear_dynamo_cache()
     cc = CompilerConfig()
     cc.enable_consteval = False
-    cc.consteval_parameters = False
 
     model_name = "huggyllama/llama-7b"
 

--- a/tests/models/llama/test_llama_7b_pipeline_parallel.py
+++ b/tests/models/llama/test_llama_7b_pipeline_parallel.py
@@ -84,7 +84,6 @@ def test_llama_7b_pipeline_parallel(record_property, model_name, mode):
     options.compiler_config = cc
     cc.device_map = device_map
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     options.devices = [device1, device2]
     compiled_model = torch.compile(model, backend="tt", dynamic=False, options=options)
     out = compiled_model(**test_input)

--- a/tests/models/mgp-str-base/test_mgp_str_base.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base.py
@@ -39,7 +39,6 @@ def test_mgp_str_base(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.dump_info = True
     if op_by_op:
         if data_parallel_mode:

--- a/tests/models/mgp-str-base/test_mgp_str_base_n300.py
+++ b/tests/models/mgp-str-base/test_mgp_str_base_n300.py
@@ -37,7 +37,6 @@ def test_mgp_str_base(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/mistral/test_mistral.py
+++ b/tests/models/mistral/test_mistral.py
@@ -44,7 +44,6 @@ def test_mistral(record_property, variant, variant_config, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -33,7 +33,6 @@ def test_mlpmixer(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/mlpmixer/test_mlpmixer_n300.py
+++ b/tests/models/mlpmixer/test_mlpmixer_n300.py
@@ -35,7 +35,6 @@ def test_mlpmixer(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     if op_by_op:

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -35,7 +35,6 @@ def test_mnist_train(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/mnist/test_mnist_n300.py
+++ b/tests/models/mnist/test_mnist_n300.py
@@ -33,7 +33,6 @@ def test_mnist_train(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     if op_by_op:

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -51,7 +51,6 @@ def test_mobilenet_ssd(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op:
         if data_parallel_mode:

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -33,7 +33,6 @@ class ThisTester(ModelTester):
 def test_musicgen_small(record_property, mode, op_by_op, data_parallel_mode):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/oft/test_oft.py
+++ b/tests/models/oft/test_oft.py
@@ -30,7 +30,6 @@ def test_oft(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -44,7 +44,6 @@ def test_openpose(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -35,7 +35,6 @@ def test_openpose_v2(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -38,7 +38,6 @@ def test_opt(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -47,7 +47,6 @@ def test_perceiver_io(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/phi/test_phi_1_1p5_2.py
+++ b/tests/models/phi/test_phi_1_1p5_2.py
@@ -49,7 +49,6 @@ def test_phi(record_property, model_name, mode, op_by_op):
     model_group = "red"
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/phi/test_phi_3.py
+++ b/tests/models/phi/test_phi_3.py
@@ -49,7 +49,6 @@ def test_phi_3(record_property, variant, variant_config, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/phi/test_phi_3p5_moe.py
+++ b/tests/models/phi/test_phi_3p5_moe.py
@@ -36,7 +36,6 @@ def test_phi_3p5_moe(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # consteval_parameters is disabled because it results in a memory related crash
 
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -39,7 +39,6 @@ def test_resnet(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -52,7 +52,6 @@ def test_resnet(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/resnet50/test_resnet50_llmbox.py
+++ b/tests/models/resnet50/test_resnet50_llmbox.py
@@ -49,7 +49,6 @@ def test_resnet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 8]
 

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -34,7 +34,6 @@ def test_roberta(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/seamless_m4t/test_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_seamless_m4t.py
@@ -36,7 +36,6 @@ def test_seamless_m4t(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -48,7 +48,6 @@ def test_segformer(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/segformer/test_segformer_n300.py
+++ b/tests/models/segformer/test_segformer_n300.py
@@ -45,7 +45,6 @@ def test_segformer(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -48,7 +48,6 @@ def test_segment_anything(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -48,7 +48,6 @@ def test_speecht5_tts(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -35,7 +35,6 @@ def test_squeeze_bert(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/stable_diffusion/test_stable_diffusion_1_4.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_1_4.py
@@ -34,7 +34,6 @@ def test_stable_diffusion_1_4(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/stable_diffusion/test_stable_diffusion_3_5.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_3_5.py
@@ -51,7 +51,6 @@ def test_stable_diffusion_3_5(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_transformer.py
@@ -98,7 +98,6 @@ def test_stable_diffusion_transformer(record_property, model_info, mode, op_by_o
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    # consteval_parameters is disabled because it results in a memory related crash
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/stable_diffusion/test_stable_diffusion_transformer_block.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_transformer_block.py
@@ -59,7 +59,6 @@ def test_stable_diffusion_transformer_block(record_property, model_info, mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     tester = ThisTester(
         model_name,

--- a/tests/models/stable_diffusion/test_stable_diffusion_unet.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_unet.py
@@ -32,7 +32,6 @@ def test_stable_diffusion_unet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/stable_diffusion/test_stable_diffusion_unet_n300.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_unet_n300.py
@@ -74,7 +74,6 @@ def test_stable_diffusion_unet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -37,7 +37,6 @@ def test_t5(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -81,7 +81,6 @@ def test_timm_image_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/timm/test_timm_image_classification_n300.py
+++ b/tests/models/timm/test_timm_image_classification_n300.py
@@ -73,7 +73,6 @@ def test_timm_image_classification(record_property, model_name, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -112,7 +112,6 @@ def test_torchvision_image_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode == "data_parallel":
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/torchvision/test_torchvision_image_classification_n300.py
+++ b/tests/models/torchvision/test_torchvision_image_classification_n300.py
@@ -109,7 +109,6 @@ def test_torchvision_image_classification(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -68,7 +68,6 @@ def test_torchvision_object_detection(
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -33,7 +33,6 @@ def test_unet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/unet/test_unet_n300.py
+++ b/tests/models/unet/test_unet_n300.py
@@ -34,7 +34,6 @@ def test_unet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     if op_by_op:

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -69,7 +69,6 @@ def test_unet_brain(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/unet_brain/test_unet_brain_n300.py
+++ b/tests/models/unet_brain/test_unet_brain_n300.py
@@ -69,7 +69,6 @@ def test_unet_brain(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -39,7 +39,6 @@ def test_unet_carvana(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/unet_carvana/test_unet_carvana_n300.py
+++ b/tests/models/unet_carvana/test_unet_carvana_n300.py
@@ -39,7 +39,6 @@ def test_unet_carvana(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/vgg19_unet/test_vgg19_unet.py
+++ b/tests/models/vgg19_unet/test_vgg19_unet.py
@@ -32,7 +32,6 @@ def test_vgg19_unet(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -36,7 +36,6 @@ def test_vilt(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/vit/test_vit.py
+++ b/tests/models/vit/test_vit.py
@@ -41,7 +41,6 @@ def test_vit(record_property, mode, variant, variant_config, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/vit/test_vit_n300.py
+++ b/tests/models/vit/test_vit_n300.py
@@ -42,7 +42,6 @@ def test_vit(record_property, mode, variant, variant_config, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/vit/test_vit_onnx.py
+++ b/tests/models/vit/test_vit_onnx.py
@@ -60,7 +60,6 @@ def test_vit_onnx(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         cc.op_by_op_backend = OpByOpBackend.STABLEHLO

--- a/tests/models/vovnet/test_vovnet_onnx.py
+++ b/tests/models/vovnet/test_vovnet_onnx.py
@@ -60,7 +60,6 @@ def test_vovnet_onnx(record_property, mode, op_by_op):
     model_group = "red"
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
 
     if op_by_op is not None:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -52,7 +52,6 @@ def test_whisper(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -40,7 +40,6 @@ print("Available variants: ", [str(k) for k in available_variants.keys()])
 def test_xglm(record_property, mode, variant, variant_config, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -51,7 +51,6 @@ def test_yolos(record_property, mode, op_by_op, data_parallel_mode):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         if data_parallel_mode:
             pytest.skip("Op-by-op not supported in data parallel mode")

--- a/tests/models/yolos/test_yolos_n300.py
+++ b/tests/models/yolos/test_yolos_n300.py
@@ -47,7 +47,6 @@ def test_yolos(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -46,7 +46,6 @@ def test_yolov10(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -30,7 +30,6 @@ def test_yolov3(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/yolov3/test_yolov3_n300.py
+++ b/tests/models/yolov3/test_yolov3_n300.py
@@ -30,7 +30,6 @@ def test_yolov3(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
     cc.dump_debug = True

--- a/tests/models/yolov4/test_yolov4.py
+++ b/tests/models/yolov4/test_yolov4.py
@@ -30,7 +30,6 @@ class ThisTester(ModelTester):
 def test_yolov4(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/models/yolov4/test_yolov4_n300.py
+++ b/tests/models/yolov4/test_yolov4_n300.py
@@ -42,7 +42,6 @@ class ThisTester(ModelTester):
 def test_yolov4(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.automatic_parallelization = True
     cc.mesh_shape = [1, 2]
 

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -119,7 +119,6 @@ def test_yolov5(record_property, mode, op_by_op):
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     if op_by_op:
         cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
         if op_by_op == OpByOpBackend.STABLEHLO:

--- a/tests/runner/test_models.py
+++ b/tests/runner/test_models.py
@@ -54,7 +54,6 @@ def test_all_models(test_entry, mode, op_by_op, record_property, test_metadata):
 
         cc = CompilerConfig()
         cc.enable_consteval = True
-        cc.consteval_parameters = True
         if op_by_op:
             cc.compile_depth = CompileDepth.EXECUTE_OP_BY_OP
             cc.op_by_op_backend = op_by_op

--- a/tests/torch/test_basic_multichip.py
+++ b/tests/torch/test_basic_multichip.py
@@ -26,7 +26,6 @@ def test_pipeline_parallel():
     cc = CompilerConfig()
     options.compiler_config = cc
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.device_map = {"l1": 0, "l2": 1}
     parent_device = DeviceManager.create_parent_mesh_device([1, 2])
     device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))
@@ -73,7 +72,6 @@ def test_pipeline_parallel_topological_sort():
     cc = CompilerConfig()
     options.compiler_config = cc
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     cc.device_map = {"l1": 0, "l2": 1, "l3": 1, "l4": 0}
     parent_device = DeviceManager.create_parent_mesh_device([1, 2])
     device1 = DeviceManager.create_sub_mesh_device(parent_device, (0, 0))

--- a/tests/torch/test_constant_fold.py
+++ b/tests/torch/test_constant_fold.py
@@ -28,7 +28,6 @@ def test_multiple_ops():
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     verify_module(
         ConstantFoldable(),
         input_shapes=[(256, 256)],
@@ -59,7 +58,6 @@ def test_interp():
     )
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     verify_module(Basic(), inputs=[small], compiler_config=cc)
 
 
@@ -85,7 +83,6 @@ def test_linear():
 
     cc = CompilerConfig()
     cc.enable_consteval = True
-    cc.consteval_parameters = True
     verify_module(
         Basic(), input_shapes=[(32, 32)], compiler_config=cc, required_atol=0.02
     )

--- a/tt_torch/dynamo/experimental/xla_backend.py
+++ b/tt_torch/dynamo/experimental/xla_backend.py
@@ -605,8 +605,6 @@ def xla_pass_pipeline(gm, example_inputs, compiler_config):
 
     if compiler_config.enable_consteval:
         compiled_graph = constant_fold(compiled_graph)
-    elif compiler_config.consteval_parameters:
-        raise Exception("consteval_parameters is enabled but enable_consteval is not")
 
     compiled_graph = bypass_redundant_getitem(compiled_graph)
     compiled_graph = rectify_buffer_inplace_copy(compiled_graph)

--- a/tt_torch/dynamo/passes.py
+++ b/tt_torch/dynamo/passes.py
@@ -592,8 +592,6 @@ def run_pass_pipeline_for_single_gm(
 
     if compiler_config.enable_consteval:
         gm_device = constant_fold(gm_device)
-    elif compiler_config.consteval_parameters:
-        raise Exception("consteval_parameters is enabled but enable_consteval is not")
 
     gm_device = bypass_redundant_getitem(gm_device)
     gm_device = rectify_buffer_inplace_copy(gm_device)

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -312,7 +312,6 @@ class CompilerConfig:
         self.op_by_op_backend = OpByOpBackend.TORCH
         self.enable_consteval = False
         self.enable_optimizer = False
-        self._consteval_parameters = False
         self._enable_intermediate_verification = False
         self.dump_debug = False
         self.dump_info = False
@@ -331,7 +330,6 @@ class CompilerConfig:
         self.valid_dialects = ["STABLEHLO", "TTIR", "TTNN"]
         self.device_map = {}
         self.apply_environment_overrides()
-        self.post_init()
         self.automatic_parallelization = False
         self.mesh_shape = [1, 1]
         self.push_outputs_to_cpu = True
@@ -406,14 +404,6 @@ class CompilerConfig:
         if self.runtime_intermediate_cache is None:
             self.runtime_intermediate_cache = {}
 
-    @property
-    def consteval_parameters(self):
-        return self._consteval_parameters
-
-    @consteval_parameters.setter
-    def consteval_parameters(self, value):
-        self._consteval_parameters = value
-        self.post_init()
 
     def apply_environment_overrides(self):
         compile_depth = os.environ.get("TT_TORCH_COMPILE_DEPTH")
@@ -434,9 +424,6 @@ class CompilerConfig:
         enable_optimizer = os.environ.get("TT_TORCH_OPTIMIZER")
         if enable_optimizer and int(enable_optimizer):
             self.enable_optimizer = True
-        consteval_parameters = os.environ.get("TT_TORCH_CONSTEVAL_PARAMETERS")
-        if consteval_parameters and int(consteval_parameters):
-            self.consteval_parameters = True
         inline_parameters = os.environ.get("TT_TORCH_INLINE_PARAMETERS")
         if inline_parameters and int(inline_parameters):
             self.inline_parameters = True
@@ -465,12 +452,6 @@ class CompilerConfig:
         dump_binary = os.environ.get("TT_TORCH_SAVE_BINARY")
         if dump_binary and int(dump_binary):
             self.dump_binary = True
-
-    def post_init(self):
-        if self.consteval_parameters:
-            torch._dynamo.config.inline_inbuilt_nn_modules = False
-        else:
-            torch._dynamo.config.inline_inbuilt_nn_modules = True
 
     def reset_unique_ops(self):
         self.unique_ops = {}
@@ -564,7 +545,6 @@ class CompilerConfig:
             "single_op_timeout": self.single_op_timeout,
             "enable_consteval": self.enable_consteval,
             "enable_optimizer": self.enable_optimizer,
-            "_consteval_parameters": self._consteval_parameters,
             "_enable_intermediate_verification": self._enable_intermediate_verification,
             "_verify_op_by_op": self._verify_op_by_op,
         }

--- a/tt_torch/tools/utils.py
+++ b/tt_torch/tools/utils.py
@@ -404,7 +404,6 @@ class CompilerConfig:
         if self.runtime_intermediate_cache is None:
             self.runtime_intermediate_cache = {}
 
-
     def apply_environment_overrides(self):
         compile_depth = os.environ.get("TT_TORCH_COMPILE_DEPTH")
         if compile_depth:


### PR DESCRIPTION
### Ticket
#1182 

### Problem description
When applying mark_sharding() on user tensors through the torch.compile flow, we are unable to correlate original user tensors with their potentially constant folded equivalents. 

Also, we aim to remove constant folding entirely from the frontend so it can be handled in MLIR.

### What's changed
Remove all references to consteval_parameters

### Checklist
- [ ] New/Existing tests provide coverage for changes
