### PR TITLE
Add Eager Tensor Parallel tests to CI

### DIFF
--- a/.github/workflows/run-full-model-execution-tests.yml
+++ b/.github/workflows/run-full-model-execution-tests.yml
@@ -132,6 +132,7 @@ jobs:
             # It is not safe to run XLA SPMD tests with other tests using torch/xla
             wh-runner: n300, name: "eval_6_spmd", pytest-args: "", tests: "
                 tests/torch/test_basic_sharding.py
+                tests/experimental/test_ccl_ops_n300.py
             "
           },
           {
@@ -151,13 +152,19 @@ jobs:
               tests/experimental/models/resnet50/test_resnet50.py::test_resnet_eager
             "
           },
+          {
+            wh-runner: llmbox, name: "tp_eager", pytest-args: "", tests: "
+                tests/experimental/test_ccl_ops_llmbox.py
+                tests/experimental/models/llama/test_llama_8b_tp_eager.py::test_llama_8b_eager[128-causal]
+            "
+          },
         ]
     runs-on: ${{ matrix.runner == 'wormhole' && matrix.build.wh-runner || matrix.runner == 'blackhole' && matrix.build.bh-runner  || 'wormhole_b0'}}
     name: "test exec ${{ matrix.runner == 'wormhole' && 'wh' || matrix.runner == 'blackhole' && 'bh' || 'unk' }} (${{ matrix.build.name }})"
 
     container:
       image: ${{ inputs.docker-image }}
-      options: --user root --device /dev/tenstorrent/0 --shm-size=4gb
+      options: --user root --device /dev/tenstorrent --shm-size=4gb
       volumes:
         - /dev/hugepages:/dev/hugepages
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/tests/experimental/models/llama/test_llama_8b_tp_eager.py
+++ b/tests/experimental/models/llama/test_llama_8b_tp_eager.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# This import is unused but needed to register the Tenstorrent PJRT device with XLA
 import tt_torch
 
 import torch

--- a/tests/experimental/models/llama/test_llama_8b_tp_eager.py
+++ b/tests/experimental/models/llama/test_llama_8b_tp_eager.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import tt_torch
+
+import torch
+import pytest
+from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaConfig, LlamaModel
+import torch_xla
+import torch_xla.runtime as xr
+import torch_xla.distributed.spmd as xs
+from torch_xla.distributed.spmd import Mesh
+from tests.utils import create_device_mesh, setup_xla_environment_for_tp
+
+from tt_torch.tools.utils import (
+    calculate_pcc,
+)
+
+
+def apply_tensor_parallel_sharding_base(
+    model: LlamaModel, mesh: Mesh, move_to_device: bool = True
+) -> None:
+    if move_to_device:
+        model = model.to(torch_xla.device())
+
+    # Apply sharding to each transformer layer
+    for layer in model.layers:
+        xs.mark_sharding(layer.mlp.up_proj.weight, mesh, ("model", "batch"))
+        xs.mark_sharding(layer.mlp.gate_proj.weight, mesh, ("model", "batch"))
+        xs.mark_sharding(layer.mlp.down_proj.weight, mesh, ("batch", "model"))
+
+        xs.mark_sharding(layer.self_attn.q_proj.weight, mesh, ("model", "batch"))
+        xs.mark_sharding(layer.self_attn.k_proj.weight, mesh, ("model", "batch"))
+        xs.mark_sharding(layer.self_attn.v_proj.weight, mesh, ("model", "batch"))
+        xs.mark_sharding(layer.self_attn.o_proj.weight, mesh, ("batch", "model"))
+
+
+def apply_tensor_parallel_sharding_causal(
+    model: AutoModelForCausalLM, mesh: Mesh
+) -> None:
+    model = model.to(torch_xla.device())
+    apply_tensor_parallel_sharding_base(model.model, mesh, move_to_device=False)
+    xs.mark_sharding(model.lm_head.weight, mesh, ("model", "batch"))
+
+
+@pytest.mark.parametrize(
+    "run_causal",
+    [True, False],
+    ids=["causal", "base"],
+)
+@pytest.mark.parametrize("sequence_length", [128, 256, 512], ids=["128", "256", "512"])
+def test_llama_8b_eager(run_causal, sequence_length):
+    torch.manual_seed(42)
+
+    setup_xla_environment_for_tp()
+    mesh = create_device_mesh((1, xr.global_runtime_device_count()), ("batch", "model"))
+
+    model_name = "meta-llama/Llama-3.1-8B"
+    config = LlamaConfig.from_pretrained(model_name)
+    if run_causal:
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name, config=config, torch_dtype=torch.bfloat16
+        ).eval()
+    else:
+        model = LlamaModel.from_pretrained(
+            model_name, config=config, torch_dtype=torch.bfloat16
+        )
+
+    batch_size = 1
+    inputs = torch.randint(
+        0, config.vocab_size, (batch_size, sequence_length), dtype=torch.int32
+    )
+    # Run model on CPU first
+    outputs = model(inputs)
+    if run_causal:
+        cpu_outputs = outputs.logits
+    else:
+        cpu_outputs = outputs.last_hidden_state
+
+    # Now run on devices
+    if run_causal:
+        apply_tensor_parallel_sharding_causal(model, mesh)
+    else:
+        apply_tensor_parallel_sharding_base(model, mesh)
+
+    inputs = inputs.to(torch_xla.device())
+    xs.mark_sharding(inputs, mesh, (None, None))  # Replicate inputs to all devices
+
+    outputs = model(inputs)
+    torch_xla.sync(True, True)  # Wait until all computations have finished
+    if run_causal:
+        tt_outputs = outputs.logits.to("cpu")
+    else:
+        tt_outputs = outputs.last_hidden_state.to("cpu")
+
+    pcc = calculate_pcc(tt_outputs, cpu_outputs)
+    print(f"PCC: {pcc}")
+    assert pcc >= 0.95

--- a/tests/experimental/models/llama/test_llama_8b_tp_eager.py
+++ b/tests/experimental/models/llama/test_llama_8b_tp_eager.py
@@ -5,12 +5,12 @@ import tt_torch
 
 import torch
 import pytest
-from transformers import AutoTokenizer, AutoModelForCausalLM, LlamaConfig, LlamaModel
+from transformers import AutoModelForCausalLM, LlamaConfig, LlamaModel
 import torch_xla
 import torch_xla.runtime as xr
 import torch_xla.distributed.spmd as xs
 from torch_xla.distributed.spmd import Mesh
-from tests.utils import create_device_mesh, setup_xla_environment_for_tp
+from tests.utils import create_device_mesh
 
 from tt_torch.tools.utils import (
     calculate_pcc,
@@ -49,10 +49,10 @@ def apply_tensor_parallel_sharding_causal(
     ids=["causal", "base"],
 )
 @pytest.mark.parametrize("sequence_length", [128, 256, 512], ids=["128", "256", "512"])
+@pytest.mark.usefixtures("use_xla_spmd_environment")
 def test_llama_8b_eager(run_causal, sequence_length):
     torch.manual_seed(42)
 
-    setup_xla_environment_for_tp()
     mesh = create_device_mesh((1, xr.global_runtime_device_count()), ("batch", "model"))
 
     model_name = "meta-llama/Llama-3.1-8B"

--- a/tests/experimental/test_ccl_ops_llmbox.py
+++ b/tests/experimental/test_ccl_ops_llmbox.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import tt_torch
+
+import torch
+import torch_xla
+import torch_xla.core.xla_model as xm
+import torch_xla.runtime as xr
+import torch_xla.distributed.spmd as xs
+import os
+import copy
+from tests.utils import create_device_mesh, setup_xla_environment_for_tp
+import pytest
+
+"""
+These tests are meant to be run on an LLMBox or T3K (8 devices).
+"""
+
+@pytest.mark.parametrize("shard_dim", [0, 1])
+def test_all_reduce(shard_dim):
+    """Test all_reduce operation with sharding on different dimensions.
+
+    Args:
+        shard_dim: Dimension to shard on (0 for batch, 1 for model)
+    """
+    os.environ["XLA_ALWAYS_ALLREDUCE"] = "1"
+    setup_xla_environment_for_tp()
+    mesh = create_device_mesh((2, 4), ("batch", "model"))
+
+    # Create tensor with values that make reduction easy to verify
+    t = torch.ones(256, 512)
+    t = t.to(torch_xla.device())
+
+    if shard_dim == 0:
+        # Shard on batch dimension (dim 0)
+        xs.mark_sharding(t, mesh, ("batch", None))
+        # For all_reduce on batch sharding: pair devices across batch rows
+        groups = [[0, 4], [1, 5], [2, 6], [3, 7]]
+    elif shard_dim == 1:
+        # Shard on model dimension (dim 1)
+        xs.mark_sharding(t, mesh, (None, "model"))
+        # For all_reduce on model sharding: two groups of 4 devices each
+        groups = [[0, 1, 2, 3], [4, 5, 6, 7]]
+
+    # Perform all_reduce sum operation
+    y = xm.all_reduce(xm.REDUCE_SUM, t, groups=groups)
+
+    torch_xla.sync()
+    y = y.to("cpu")
+    print(f"All-reduce shard dim: {shard_dim}, Y Shape: {y.shape}")
+    print(f"y: {y}")
+
+    # All_reduce sums values across the sharded dimension within each group
+    # The result tensor has reduced shape along the sharded dimension
+    if shard_dim == 0:
+        expected = torch.ones(256, 512) * 2.0
+    elif shard_dim == 1:
+        expected = torch.ones(256, 512) * 4.0
+
+    assert torch.allclose(y, expected, atol=0.001)
+
+
+@pytest.mark.parametrize("shard_dim", [0, 1])
+def test_all_gather(shard_dim):
+    """Test all_gather operation with sharding on different dimensions.
+
+    Args:
+        shard_dim: Dimension to shard on (0 for batch, 1 for model)
+    """
+    setup_xla_environment_for_tp()
+    mesh = create_device_mesh((2, 4), ("batch", "model"))
+
+    # Random inputs between 0 and 0.1
+    t = (torch.rand(8192, 784) - 0.0) * 0.1
+    golden = copy.deepcopy(t)
+    print("Golden shape: ", golden.shape)
+
+    t = t.to(torch_xla.device())
+
+    if shard_dim == 0:
+        # Shard on batch dimension (dim 0)
+        xs.mark_sharding(t, mesh, ("batch", None))
+        # Correct replica groups for batch sharding: pair devices across batch rows
+        groups = [[0, 4], [1, 5], [2, 6], [3, 7]]
+        gather_dim = 0
+    else:
+        # Shard on model dimension (dim 1)
+        xs.mark_sharding(t, mesh, (None, "model"))
+        # For model sharding: two groups of 4 devices each (one group per batch row)
+        groups = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        gather_dim = 1
+
+    y = xm.all_gather(t, gather_dim, groups=groups, pin_layout=False)
+
+    y = y.to("cpu")
+    print(f"All-gather shard dim: {shard_dim}, Y Shape: {y.shape}")
+    chunks = torch.chunk(y, len(groups[0]), dim=gather_dim)
+    for i in range(1, len(chunks)):
+        assert torch.allclose(chunks[i], chunks[0], atol=0.001)
+    assert torch.allclose(chunks[0], golden, atol=0.001)

--- a/tests/experimental/test_ccl_ops_llmbox.py
+++ b/tests/experimental/test_ccl_ops_llmbox.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# This import is unused but needed to register the Tenstorrent PJRT device with XLA
 import tt_torch
 
 import torch
@@ -37,7 +39,7 @@ def test_all_reduce(shard_dim):
         xs.mark_sharding(t, mesh, ("batch", None))
         # For all_reduce on batch sharding: pair devices across batch rows
         groups = [[0, 4], [1, 5], [2, 6], [3, 7]]
-    elif shard_dim == 1:
+    else:
         # Shard on model dimension (dim 1)
         xs.mark_sharding(t, mesh, (None, "model"))
         # For all_reduce on model sharding: two groups of 4 devices each
@@ -55,7 +57,7 @@ def test_all_reduce(shard_dim):
     # The result tensor has reduced shape along the sharded dimension
     if shard_dim == 0:
         expected = torch.ones(256, 512) * 2.0
-    elif shard_dim == 1:
+    else:
         expected = torch.ones(256, 512) * 4.0
 
     assert torch.allclose(y, expected, atol=0.001)

--- a/tests/experimental/test_ccl_ops_llmbox.py
+++ b/tests/experimental/test_ccl_ops_llmbox.py
@@ -9,14 +9,16 @@ import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import os
 import copy
-from tests.utils import create_device_mesh, setup_xla_environment_for_tp
+from tests.utils import create_device_mesh
 import pytest
 
 """
 These tests are meant to be run on an LLMBox or T3K (8 devices).
 """
 
+
 @pytest.mark.parametrize("shard_dim", [0, 1])
+@pytest.mark.usefixtures("use_xla_spmd_environment")
 def test_all_reduce(shard_dim):
     """Test all_reduce operation with sharding on different dimensions.
 
@@ -24,7 +26,6 @@ def test_all_reduce(shard_dim):
         shard_dim: Dimension to shard on (0 for batch, 1 for model)
     """
     os.environ["XLA_ALWAYS_ALLREDUCE"] = "1"
-    setup_xla_environment_for_tp()
     mesh = create_device_mesh((2, 4), ("batch", "model"))
 
     # Create tensor with values that make reduction easy to verify
@@ -61,13 +62,13 @@ def test_all_reduce(shard_dim):
 
 
 @pytest.mark.parametrize("shard_dim", [0, 1])
+@pytest.mark.usefixtures("use_xla_spmd_environment")
 def test_all_gather(shard_dim):
     """Test all_gather operation with sharding on different dimensions.
 
     Args:
         shard_dim: Dimension to shard on (0 for batch, 1 for model)
     """
-    setup_xla_environment_for_tp()
     mesh = create_device_mesh((2, 4), ("batch", "model"))
 
     # Random inputs between 0 and 0.1

--- a/tests/experimental/test_ccl_ops_n300.py
+++ b/tests/experimental/test_ccl_ops_n300.py
@@ -9,14 +9,16 @@ import torch_xla.core.xla_model as xm
 import torch_xla.distributed.spmd as xs
 import os
 import copy
-from tests.utils import create_device_mesh, setup_xla_environment_for_tp
+from tests.utils import create_device_mesh
 import pytest
 
 """
 These tests are meant to be run on an N300 (2 devices).
 """
 
+
 @pytest.mark.parametrize("shard_dim", [0, 1])
+@pytest.mark.usefixtures("use_xla_spmd_environment")
 def test_all_reduce(shard_dim):
     """Test all_reduce operation with sharding on different dimensions.
 
@@ -24,7 +26,6 @@ def test_all_reduce(shard_dim):
         shard_dim: Dimension to shard on (0 for batch, 1 for model)
     """
     os.environ["XLA_ALWAYS_ALLREDUCE"] = "1"
-    setup_xla_environment_for_tp()
 
     # Create tensor with values that make reduction easy to verify
     t = torch.ones(256, 512)
@@ -55,13 +56,13 @@ def test_all_reduce(shard_dim):
 
 
 @pytest.mark.parametrize("shard_dim", [0, 1])
+@pytest.mark.usefixtures("use_xla_spmd_environment")
 def test_all_gather(shard_dim):
     """Test all_gather operation with sharding on different dimensions.
 
     Args:
         shard_dim: Dimension to shard on (0 for batch, 1 for model)
     """
-    setup_xla_environment_for_tp()
 
     # Random inputs between 0 and 0.1
     t = (torch.rand(8192, 784) - 0.0) * 0.1

--- a/tests/experimental/test_ccl_ops_n300.py
+++ b/tests/experimental/test_ccl_ops_n300.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+
+# This import is unused but needed to register the Tenstorrent PJRT device with XLA
 import tt_torch
 
 import torch
@@ -36,7 +38,7 @@ def test_all_reduce(shard_dim):
         mesh = create_device_mesh((2, 1), ("batch", "model"))
         xs.mark_sharding(t, mesh, ("batch", None))
         groups = [[0, 1]]
-    elif shard_dim == 1:
+    else:
         # Shard on model dimension (dim 1)
         mesh = create_device_mesh((1, 2), ("batch", "model"))
         xs.mark_sharding(t, mesh, (None, "model"))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -32,6 +32,30 @@ import io
 import csv
 import tt_mlir
 
+# Torch-XLA imports
+import torch_xla.runtime as xr
+from torch_xla.distributed.spmd import Mesh
+
+
+def setup_xla_environment_for_tp():
+    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
+    os.environ["XLA_STABLEHLO_COMPILE"] = "1"
+    os.environ["PJRT_DEVICE"] = "TT"
+    xr.use_spmd()
+
+
+def create_device_mesh(mesh_shape, mesh_names):
+    assert len(mesh_shape) == len(
+        mesh_names
+    ), "Mesh shape and names must match in length"
+    num_devices = xr.global_runtime_device_count()
+    assert (
+        np.prod(mesh_shape) == num_devices
+    ), "Mesh shape must match the number of devices"
+    device_ids = np.array(range(num_devices))
+    mesh = Mesh(device_ids, mesh_shape, mesh_names)
+    return mesh
+
 
 def skip_full_eval_test(
     record_property,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,13 +37,6 @@ import torch_xla.runtime as xr
 from torch_xla.distributed.spmd import Mesh
 
 
-def setup_xla_environment_for_tp():
-    os.environ["CONVERT_SHLO_TO_SHARDY"] = "1"
-    os.environ["XLA_STABLEHLO_COMPILE"] = "1"
-    os.environ["PJRT_DEVICE"] = "TT"
-    xr.use_spmd()
-
-
 def create_device_mesh(mesh_shape, mesh_names):
     assert len(mesh_shape) == len(
         mesh_names


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/975

### Problem description
No TP tests are currently in CI (either here or in tt-xla)

### What's changed
Adding CCL Ops tests (for n300 and llmbox) and Llama 3.1 8B eager test (for llmbox)

### Checklist
- [x] New/Existing tests provide coverage for changes
