### PR TITLE
Downgrade gliner

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ kornia
 timm
 ml_dtypes
 opencv-contrib-python
-gliner
+gliner==0.2.21
 ultralytics
 efficientnet_pytorch
 torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg. 0.6.0 fails with NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend


### PR DESCRIPTION
### Ticket
None

### Problem description
Gliner new version 0.2.22 was released on August 26th. https://pypi.org/project/gliner/ It downgrades transformers version from 4.52 to 4.51 which results in some failures in the nightly runs.

### What's changed
Pinned gliner to 0.2.21. 
Opened an issue in gliner about this: https://github.com/urchade/GLiNER/issues/290 

### Checklist
- [X] New/Existing tests provide coverage for changes
