### PR TITLE
Uplift tt-xla/ python 3.11

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -12,8 +12,6 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-venv \
     python3-pip \
-    python3.11-dev \
-    python3.11-venv \
     git \
     git-lfs \
     libhwloc-dev \
@@ -39,6 +37,11 @@ RUN apt-get update && apt-get install -y \
     unzip \
     ffmpeg \
     protobuf-compiler
+
+# Install python 3.11
+RUN add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
 
 # Install python3.11 packages
 RUN python3.11 -m pip install \

--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     python3-venv \
     python3-pip \
-    python3.10-dev \
-    python3.10-venv \
+    python3.11-dev \
+    python3.11-venv \
     git \
     git-lfs \
     libhwloc-dev \
@@ -40,8 +40,8 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     protobuf-compiler
 
-# Install python3.10 packages
-RUN python3.10 -m pip install \
+# Install python3.11 packages
+RUN python3.11 -m pip install \
     setuptools==59.6.0 \
     wheel
 

--- a/.github/workflows/build-torch-xla-wheel.yml
+++ b/.github/workflows/build-torch-xla-wheel.yml
@@ -32,13 +32,13 @@ jobs:
           curl https://pyenv.run | bash
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
-          pyenv install 3.10.12
-          pyenv global 3.10.12
-          ln -sf $HOME/.pyenv/versions/3.10.12/bin/python3.10 /usr/local/bin/python3.10
+          pyenv install 3.11
+          pyenv global 3.11
+          ln -sf $HOME/.pyenv/versions/3.11.13/bin/python3.11 /usr/local/bin/python3.11
 
-          # Install essential packages for Python 3.10
-          python3.10 -m pip install --upgrade pip
-          python3.10 -m pip install pyyaml setuptools wheel numpy typing_extensions requests
+          # Install essential packages for Python 3.11
+          python3.11 -m pip install --upgrade pip
+          python3.11 -m pip install pyyaml setuptools wheel numpy typing_extensions requests
 
           cd /tmp
           git clone --recursive --branch v${{ inputs.torch_version }} https://github.com/pytorch/pytorch.git
@@ -49,13 +49,13 @@ jobs:
           mkdir -p ./dist
           if [ -d /mnt/dockercache/models/tt-ci-models-private/wheels ]; then
             echo "Using pre-built wheels from cache"
-            cp -r /mnt/dockercache/models/tt-ci-models-private/wheels/torch-2.7.0*cp310*.whl ./dist/
+            cp -r /mnt/dockercache/models/tt-ci-models-private/wheels/torch-2.7.0*cp311*.whl ./dist/
           fi
-          python3.10 setup.py develop
+          python3.11 setup.py develop
 
           # Build PyTorch/XLA
           cd xla/
-          python3.10 setup.py bdist_wheel
+          python3.11 setup.py bdist_wheel
 
           # Collect wheels
           mkdir -p /dist

--- a/.github/workflows/build-torch-xla-wheel.yml
+++ b/.github/workflows/build-torch-xla-wheel.yml
@@ -34,7 +34,7 @@ jobs:
           eval "$(pyenv init -)"
           pyenv install 3.11
           pyenv global 3.11
-          ln -sf $HOME/.pyenv/versions/3.11.13/bin/python3.11 /usr/local/bin/python3.11
+          ln -sf $(pyenv which python3.11) /usr/local/bin/python3.11
 
           # Install essential packages for Python 3.11
           python3.11 -m pip install --upgrade pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10' # Specify the Python version you want to use
+          python-version: '3.11' # Specify the Python version you want to use
       - name: Install dependencies
         shell: bash
         run: pip install flake8 flake8-sarif

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: 'pip'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -83,10 +83,12 @@ jobs:
         mv install/wheels/* ${{ steps.strings.outputs.dist-dir }}
         pip install ${{ steps.strings.outputs.dist-dir }}/*.whl
 
-    - name: Show actual installed python dependencies
+    - name: Show python version and actual installed python dependencies
       shell: bash
       run: |
         source env/activate
+        echo "Python version:"
+        python --version
         pip freeze
 
     - name: Validate tt-forge-models runner test config file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11
         args: ["-W 4"]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.7

--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -37,15 +37,15 @@ You should see the Tenstorrent System Management Interface. It allows you to vie
 
 TT-Torch has the following system dependencies:
 * Ubuntu 22.04
-* Python 3.10
-* python3.10-venv
+* Python 3.11
+* python3.11-venv
 * Clang 17
 * GCC 11
 * Ninja
 * CMake 4.0.3
 
 ### Installing Python
-If your system already has Python installed, make sure it is Python 3.10 or higher:
+If your system already has Python installed, make sure it is Python 3.11 or higher:
 
 ```bash
 python3 --version
@@ -54,7 +54,7 @@ python3 --version
 If not, install Python:
 
 ```bash
-sudo apt install python3
+sudo apt install python3.11
 ```
 
 ### Installing CMake 4.0.3

--- a/env/activate
+++ b/env/activate
@@ -10,30 +10,34 @@ if [ -z "$TTMLIR_TOOLCHAIN_DIR" ]; then
   export TTMLIR_TOOLCHAIN_DIR="/opt/ttmlir-toolchain/"
 fi
 if command -v sudo > /dev/null 2>&1; then
-  sudo apt-get install -y python3.10-dev python3.10-venv
+  sudo apt-get install -y python3.11-dev python3.11-venv
 else
-  apt-get install -y python3.10-dev python3.10-venv
+  apt-get install -y python3.11-dev python3.11-venv
 fi
 
 export TT_TORCH_HOME="$(pwd)"
-export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.10/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRRARY_PATH
+export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRRARY_PATH
 
 export TTMLIR_VENV_DIR="$(pwd)/env/venv"
 if [ -d $TTMLIR_VENV_DIR/bin ]; then
   [ -f $TTMLIR_VENV_DIR/bin/activate ] && source $TTMLIR_VENV_DIR/bin/activate
 else
   echo "Creating virtual environment in $TTMLIR_VENV_DIR"
-  python3.10 -m venv $TTMLIR_VENV_DIR
+  python3.11 -m venv $TTMLIR_VENV_DIR
   source $TTMLIR_VENV_DIR/bin/activate
   pip install --upgrade pip
 
-  python3.10 -m pip install -r requirements.txt
+  python3.11 -m pip install -r requirements.txt
 
 fi
+# force install new torch-xla wheel
+python3.11 -m pip uninstall -y torch-xla
+python3.11 -m pip install /localdev/ddilbaz/pytorch_xla_wheel/torch_xla-2.9.0+git4a8c988-cp311-cp311-linux_x86_64.whl
+
 export TTTORCH_ENV_ACTIVATED=1
 export TTXLA_ENV_ACTIVATED=1
 export TTMLIR_ENV_ACTIVATED=1
-export PATH=$TT_TORCH_HOME/third_party/tt-mlir/src/tt-mlir-build/bin:$TT_TORCH_HOME/env/venv/lib/python3.10/site-packages/tt_mlir:$TTMLIR_TOOLCHAIN_DIR/bin:$PATH
+export PATH=$TT_TORCH_HOME/third_party/tt-mlir/src/tt-mlir-build/bin:$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/tt_mlir:$TTMLIR_TOOLCHAIN_DIR/bin:$PATH
 export TOKENIZERS_PARALLELISM=false
 if [ -n "$PROJECT_ROOT" ]; then
     export TT_METAL_HOME="$PROJECT_ROOT/third_party/tt-mlir/src/tt-mlir/third_party/tt-metal/src/tt-metal"

--- a/env/activate
+++ b/env/activate
@@ -10,9 +10,13 @@ if [ -z "$TTMLIR_TOOLCHAIN_DIR" ]; then
   export TTMLIR_TOOLCHAIN_DIR="/opt/ttmlir-toolchain/"
 fi
 if command -v sudo > /dev/null 2>&1; then
-  sudo apt-get install -y python3.11-dev python3.11-venv
+  sudo add-apt-repository ppa:deadsnakes/ppa -y
+  sudo apt-get update
+  sudo apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
 else
-  apt-get install -y python3.11-dev python3.11-venv
+  add-apt-repository ppa:deadsnakes/ppa -y
+  apt-get update
+  apt-get install -y python3.11 python3.11-dev python3.11-venv python3.11-distutils
 fi
 
 export TT_TORCH_HOME="$(pwd)"

--- a/env/activate
+++ b/env/activate
@@ -16,7 +16,7 @@ else
 fi
 
 export TT_TORCH_HOME="$(pwd)"
-export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRRARY_PATH
+export LD_LIBRARY_PATH=$TT_TORCH_HOME/env/venv/lib/python3.11/site-packages/torch/lib:$TTMLIR_TOOLCHAIN_DIR/lib:$TT_TORCH_HOME/install/lib/:$LD_LIBRARY_PATH
 
 export TTMLIR_VENV_DIR="$(pwd)/env/venv"
 if [ -d $TTMLIR_VENV_DIR/bin ]; then
@@ -30,9 +30,6 @@ else
   python3.11 -m pip install -r requirements.txt
 
 fi
-# force install new torch-xla wheel
-python3.11 -m pip uninstall -y torch-xla
-python3.11 -m pip install /localdev/ddilbaz/pytorch_xla_wheel/torch_xla-2.9.0+git4a8c988-cp311-cp311-linux_x86_64.whl
 
 export TTTORCH_ENV_ACTIVATED=1
 export TTXLA_ENV_ACTIVATED=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ efficientnet_pytorch
 torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg. 0.6.0 fails with NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend
 torchxrayvision==0.0.39
 scikit-image>=0.24 # For DenseNet 121 HF XRay model
-ase==3.26.0 # For hippynn
-hippynn==0.1.3
+ase==3.24.0 # For hippynn
+hippynn==0.0.3
 pycocotools
 FlagEmbedding

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ efficientnet_pytorch
 torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg. 0.6.0 fails with NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend
 torchxrayvision==0.0.39
 scikit-image>=0.24 # For DenseNet 121 HF XRay model
-ase==3.24.0 # For hippynn
-hippynn==0.0.3
+ase==3.26.0 # For hippynn
+hippynn==0.1.3
 pycocotools
 FlagEmbedding

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core Dependencies
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.0
+torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitd9f7d39-cp311-cp311-linux_x86_64.whl
 ninja
 pybind11
 protobuf

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Core Dependencies
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.7.0
-torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb87262d-cp310-cp310-linux_x86_64.whl
 ninja
 pybind11
 protobuf
@@ -9,7 +8,7 @@ setuptools==59.6.0 #  pinned torchvision wheel build in env/activate requires lo
 wheel
 onnx==1.17.0 # 1.18.0 fails with "Unsupported model IR version: 11, max supported IR version: 10"
 onnxruntime
-stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp310-cp310-linux_x86_64.whl
+stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp311-cp311-linux_x86_64.whl
 scikit-build
 nanobind
 loguru

--- a/setup.py
+++ b/setup.py
@@ -151,8 +151,8 @@ os.environ["DONT_OVERRIDE_INSTALL_PATH"] = "1"
 
 install_requires = [
     "torch==2.7.0",
-    "torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitb87262d-cp310-cp310-linux_x86_64.whl",
-    "stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp310-cp310-linux_x86_64.whl",
+    "torch-xla@https://pypi.eng.aws.tenstorrent.com/torch-xla/torch_xla-2.9.0%2Bgitd9f7d39-cp311-cp311-linux_x86_64.whl",
+    "stablehlo@https://github.com/openxla/stablehlo/releases/download/v1.0.0/stablehlo-1.0.0.1715728102%2B6051bcdf-cp311-cp311-linux_x86_64.whl",
     "numpy",
     "onnx==1.17.0",
     "onnxruntime",

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ class install_metal_libs(install_lib):
                     ignore=shutil.ignore_patterns(".git"),
                 )
         # copy everything from skbuild cmake-install/tt-metal to self.install_dir/tt-metal
-        src_metal_dir = "_skbuild/linux-x86_64-3.10/cmake-install/tt-metal"
+        src_metal_dir = "_skbuild/linux-x86_64-3.11/cmake-install/tt-metal"
         dest_metal_dir = os.path.join(self.install_dir, "tt-metal")
         if os.path.exists(src_metal_dir):
             os.makedirs(dest_metal_dir, exist_ok=True)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # tt-xla version to use
-set(TT_XLA_VERSION "9b7a8501bf83b3a6c62d846d9a2b2df70ec18fb0")
+set(TT_XLA_VERSION "90c981f6b0547ad7819ac60aca64fce4e82c2e3c")
 
 # Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
 set(TT_MLIR_VERSION "")

--- a/tt_torch/csrc/CMakeLists.txt
+++ b/tt_torch/csrc/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site-packages/pybind11)
-find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
+list(APPEND CMAKE_PREFIX_PATH ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.11/site-packages/pybind11)
+find_package(Python 3.11 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
 add_library(TT_TORCH_MLIR "tt-mlir-interface.cpp")
@@ -37,7 +37,7 @@ target_link_directories(TT_TORCH_MLIR PUBLIC
     ${TTMLIR_INSTALL_PREFIX}/lib
 )
 
-set(TORCH_INSTALL_PREFIX ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.10/site-packages/torch)
+set(TORCH_INSTALL_PREFIX ${TTTORCH_SOURCE_DIR}/env/venv/lib/python3.11/site-packages/torch)
 set(CMAKE_PREFIX_PATH ${TORCH_INSTALL_PREFIX})
 
 find_package(Torch REQUIRED)
@@ -83,7 +83,7 @@ set_target_properties(${TARGET_NAME}
     PROPERTIES
     PREFIX ""  # Disable "lib" prefix.
     LIBRARY_OUTPUT_NAME ${TARGET_NAME}
-    INSTALL_RPATH "$ORIGIN:$ORIGIN/python3.10/site-packages/torch/lib"
+    INSTALL_RPATH "$ORIGIN:$ORIGIN/python3.11/site-packages/torch/lib"
     BUILD_WITH_INSTALL_RPATH TRUE
 )
 install (TARGETS ${TARGET_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/tt_torch/tools/profile_util.py
+++ b/tt_torch/tools/profile_util.py
@@ -96,14 +96,14 @@ class Profiler:
         # For a wheel build, the binaries are in site-packages and need to be properly copied
         else:
             print("Perf tool binaries not found - Installing from wheel.")
-            # expected to be @ env/venv/lib/python3.10/site-packages/tt-metal/tools/profiler/bin/[...]
+            # expected to be @ env/venv/lib/python3.11/site-packages/tt-metal/tools/profiler/bin/[...]
             # in this context the tt_metal_home is at /env/venv/tt_metal
 
             site_packages_dir = os.path.join(
                 self.get_ttmetal_home_path(),
                 "..",
                 "lib",
-                "python3.10",
+                "python3.11",
                 "site-packages",
                 "tt-metal",
                 "tools",


### PR DESCRIPTION
### Ticket
None

### Problem description
We need to uplift tt-torch to python 3.11 as tt-mlir and tt-xla already have. This PR uplifts tt-xla, updates pytorch-xla wheel built using python 3.11, and upgrades python in tt-torch.

We are using deadsnakes PPA to grab the latest python stable version, as tt-xla is also doing. Otherwise, the latest release version might be unstable. 

### What's changed
- New pytorch-xla wheel with python 3.11
- Referencing python 3.11 instead of 3.10 

### Checklist
- [X] New/Existing tests provide coverage for changes
