### PR TITLE
Uplift tt-mlir, change get_op_output_torch_tensor bindings

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,10 +4,10 @@
 #
 
 # tt-xla version to use
-set(TT_XLA_VERSION "90c981f6b0547ad7819ac60aca64fce4e82c2e3c")
+set(TT_XLA_VERSION "5eaa08f2b2a549fa0608ef1f0b116b82fd1928dd")
 
 # Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
-set(TT_MLIR_VERSION "")
+set(TT_MLIR_VERSION "b95164805a576f00fb1fa61767c06f110228755b")
 if(NOT TT_MLIR_VERSION STREQUAL "")
     set(USE_CUSTOM_TT_MLIR_VERSION ON)
     message(STATUS "Overriding TT_MLIR_VERSION in tt-xla build: ${TT_MLIR_VERSION}")

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -414,11 +414,20 @@ torch::Tensor
 get_op_output_torch_tensor(tt::runtime::OpContext opContextHandle,
                            tt::runtime::CallbackContext programContextHandle) {
 
-  tt::runtime::Tensor tensor =
+  auto tensorMap =
       tt::runtime::getOpOutputTensor(opContextHandle, programContextHandle);
 
   // Some ops in a decomposed tfx node may not have valid output tensors (eg.
   // deallocate) For these, return an empty tensor
+
+  if (tensorMap.empty()) {
+    std::cout << "Warning: getOpOutputTensor returned an empty tensor map."
+              << std::endl;
+    return torch::Tensor(); // Return an empty PyTorch tensor
+  }
+
+  // Get the first tensor in the map
+  auto tensor = tensorMap.begin()->second;
 
   if (tensor.handle == nullptr) {
     std::cout << "Warning: getOpOutputTensor returned a null tensor."


### PR DESCRIPTION
### Ticket
None

### Problem description
This is an uplift that works with the latest tt-mlir docker image. 

### What's changed
Set tt-mlir version to track the latest, fixed changed binding.

### Checklist
- [X] New/Existing tests provide coverage for changes
