### PR TITLE
Uplift tt-xla to 69dcd00a87954f2353577597d857623eaf9d7f18

### DIFF
--- a/tests/models/yolov4/test_yolov4_n300.py
+++ b/tests/models/yolov4/test_yolov4_n300.py
@@ -39,6 +39,10 @@ class ThisTester(ModelTester):
     [OpByOpBackend.STABLEHLO, OpByOpBackend.TORCH, None],
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
+@pytest.mark.xfail(
+    reason="Fails due to error: Could not update shapes based on their tensor sharding attributes, tracked in issue https://github.com/tenstorrent/tt-torch/issues/1215",
+    strict=True,
+)
 def test_yolov4(record_property, mode, op_by_op):
     cc = CompilerConfig()
     cc.enable_consteval = True

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # tt-xla version to use
-set(TT_XLA_VERSION "90c981f6b0547ad7819ac60aca64fce4e82c2e3c")
+set(TT_XLA_VERSION "69dcd00a87954f2353577597d857623eaf9d7f18")
 
 # Optional override of tt-xla's TT_MLIR_VERSION. Default to tt-xla's default TT_MLIR_VERSION if we pass an empty string
 set(TT_MLIR_VERSION "")

--- a/tt_torch/csrc/bindings.cpp
+++ b/tt_torch/csrc/bindings.cpp
@@ -414,17 +414,21 @@ torch::Tensor
 get_op_output_torch_tensor(tt::runtime::OpContext opContextHandle,
                            tt::runtime::CallbackContext programContextHandle) {
 
-  tt::runtime::Tensor tensor =
+  auto tensorMap =
       tt::runtime::getOpOutputTensor(opContextHandle, programContextHandle);
 
   // Some ops in a decomposed tfx node may not have valid output tensors (eg.
   // deallocate) For these, return an empty tensor
 
-  if (tensor.handle == nullptr) {
-    std::cout << "Warning: getOpOutputTensor returned a null tensor."
+  if (tensorMap.empty()) {
+    std::cout << "Warning: getOpOutputTensor does not return any tensor."
               << std::endl;
     return torch::Tensor(); // Return an empty PyTorch tensor
   }
+
+  // Return the first tensor in the map. We do not currently support
+  // intermediate comparison for ops with multiple outputs
+  tt::runtime::Tensor tensor = tensorMap.begin()->second;
 
   return create_torch_tensor(tensor);
 }


### PR DESCRIPTION
### Ticket
None

### Problem description
Uplift tt-xla to 

### What's changed
- xfail yolov4 n300 auto batch parallel test, tracked in https://github.com/tenstorrent/tt-torch/issues/1215
- thanks @ddilbazTT for patching tt::runtime::getOpOutputTensor binding due to signature change
### Checklist
- [x] New/Existing tests provide coverage for changes
