### PR TITLE
Extend _extract_outputs support for bge_m3

### DIFF
--- a/tests/models/bge_m3/test_bge_m3.py
+++ b/tests/models/bge_m3/test_bge_m3.py
@@ -34,22 +34,6 @@ class ThisTester(ModelTester):
 
         return forward_inputs
 
-    def _extract_outputs(self, output_object):
-        if isinstance(output_object, dict):
-            tensors = []
-            for key, value in output_object.items():
-                if isinstance(value, torch.Tensor):
-                    tensors.append(value)
-
-            if tensors:
-                return tuple(tensors)
-            else:
-                raise ValueError(
-                    f"No tensors found in output dictionary. Keys: {list(output_object.keys())}"
-                )
-
-            return super()._extract_outputs(output_object)
-
 
 @pytest.mark.parametrize(
     "mode",

--- a/tests/models/bge_m3/test_bge_m3_encode.py
+++ b/tests/models/bge_m3/test_bge_m3_encode.py
@@ -26,29 +26,6 @@ class ThisTester(ModelTester):
             "return_colbert_vecs": True,
         }
 
-    def _extract_outputs(self, output_object):
-        if isinstance(output_object, dict):
-            tensors = []
-            for key, value in output_object.items():
-                if key == "dense_vecs" and isinstance(value, np.ndarray):
-                    tensors.append(torch.from_numpy(value))
-                elif key == "colbert_vecs" and isinstance(value, list):
-                    if value and isinstance(value[0], np.ndarray):
-                        tensors.append(torch.from_numpy(value[0]))
-                elif key == "lexical_weights" and isinstance(value, list):
-                    if value and isinstance(value[0], dict):
-                        weights = list(value[0].values())
-                        tensors.append(torch.tensor(weights))
-                elif isinstance(value, torch.Tensor):
-                    tensors.append(value)
-
-            if tensors:
-                return tuple(tensors)
-            else:
-                raise ValueError(
-                    f"No tensors found in output dictionary. Keys: {list(output_object.keys())}"
-                )
-
 
 @pytest.mark.parametrize(
     "mode",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,13 +350,35 @@ class ModelTester:
                 elif isinstance(value, (np.ndarray)):
                     tensors.append(torch.from_numpy(value))
                 elif isinstance(value, list) and value:
-                    # Handle lists - check first element and convert if it's a numpy array
-                    if isinstance(value[0], np.ndarray):
-                        tensors.append(torch.from_numpy(value[0]))
-                    elif isinstance(value[0], torch.Tensor):
-                        tensors.append(value[0])
+                    # Handle lists - check first element and convert if it's a numpy array or tensor
+                    first_item = value[0]
+                    if isinstance(first_item, torch.Tensor):
+                        tensors.append(first_item)
+                    elif isinstance(first_item, np.ndarray):
+                        tensors.append(torch.from_numpy(first_item))
+                    elif isinstance(first_item, dict):
+                        dict_values = list(first_item.values())
+                        if dict_values and isinstance(
+                            dict_values[0], (np.floating, np.integer, np.number)
+                        ):
+                            tensor_values = [float(val) for val in dict_values]
+                            tensors.append(torch.tensor(tensor_values))
+                        elif dict_values and isinstance(dict_values[0], (int, float)):
+                            tensors.append(torch.tensor(list(dict_values)))
+                    elif np.isscalar(first_item):
+                        tensors.append(torch.tensor(first_item))
+                    else:
+                        # Add warning for unhandled list types
+                        warnings.warn(
+                            f"Key '{key}' with unhandled list type in dict. Add support for its output shape to extract_outputs."
+                        )
                 elif np.isscalar(value):
                     tensors.append(torch.tensor(value))
+                else:
+                    # Add warning for unhandled keys in dict
+                    warnings.warn(
+                        f"Key '{key}' with unhandled type '{type(value).__name__}' not added. Add support for its output shape to extract_outputs."
+                    )
 
             if tensors:
                 return tuple(tensors)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,28 +350,30 @@ class ModelTester:
                 elif isinstance(value, (np.ndarray)):
                     tensors.append(torch.from_numpy(value))
                 elif isinstance(value, list) and value:
-                    # Handle lists - check first element and convert if it's a numpy array or tensor
-                    first_item = value[0]
-                    if isinstance(first_item, torch.Tensor):
-                        tensors.append(first_item)
-                    elif isinstance(first_item, np.ndarray):
-                        tensors.append(torch.from_numpy(first_item))
-                    elif isinstance(first_item, dict):
-                        dict_values = list(first_item.values())
-                        if dict_values and isinstance(
-                            dict_values[0], (np.floating, np.integer, np.number)
-                        ):
-                            tensor_values = [float(val) for val in dict_values]
-                            tensors.append(torch.tensor(tensor_values))
-                        elif dict_values and isinstance(dict_values[0], (int, float)):
-                            tensors.append(torch.tensor(list(dict_values)))
-                    elif np.isscalar(first_item):
-                        tensors.append(torch.tensor(first_item))
-                    else:
-                        # Add warning for unhandled list types
-                        warnings.warn(
-                            f"Key '{key}' with unhandled list type in dict. Add support for its output shape to extract_outputs."
-                        )
+                    # Handle lists - process all items, not just the first one
+                    for item in value:
+                        if isinstance(item, torch.Tensor):
+                            tensors.append(item)
+                        elif isinstance(item, np.ndarray):
+                            tensors.append(torch.from_numpy(item))
+                        elif isinstance(item, dict):
+                            dict_values = list(item.values())
+                            if dict_values and isinstance(
+                                dict_values[0], (np.floating, np.integer, np.number)
+                            ):
+                                tensor_values = [float(val) for val in dict_values]
+                                tensors.append(torch.tensor(tensor_values))
+                            elif dict_values and isinstance(
+                                dict_values[0], (int, float)
+                            ):
+                                tensors.append(torch.tensor(list(dict_values)))
+                        elif np.isscalar(item):
+                            tensors.append(torch.tensor(item))
+                        else:
+                            # Add warning for unhandled list item types
+                            warnings.warn(
+                                f"Key '{key}' contains unhandled list item type '{type(item).__name__}' in dict. Add support for its output shape to extract_outputs."
+                            )
                 elif np.isscalar(value):
                     tensors.append(torch.tensor(value))
                 else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,7 +350,6 @@ class ModelTester:
                 elif isinstance(value, (np.ndarray)):
                     tensors.append(torch.from_numpy(value))
                 elif isinstance(value, list) and value:
-                    # Handle lists - process all items, not just the first one
                     for item in value:
                         if isinstance(item, torch.Tensor):
                             tensors.append(item)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -294,7 +294,6 @@ class ModelTester:
         )
 
     def _extract_outputs(self, output_object):
-
         def flatten_tensor_lists(obj):
             flattened = []
             for item in obj:
@@ -313,9 +312,7 @@ class ModelTester:
                     ):
                         tensor_values = [float(val) for val in dict_values]
                         flattened.append(torch.tensor(tensor_values))
-                    elif dict_values and isinstance(
-                        dict_values[0], (int, float)
-                    ):
+                    elif dict_values and isinstance(dict_values[0], (int, float)):
                         flattened.append(torch.tensor(list(dict_values)))
                 else:
                     raise NotImplementedError(
@@ -361,9 +358,11 @@ class ModelTester:
                 elif isinstance(value, (np.ndarray)):
                     tensors.append(torch.from_numpy(value))
                 elif isinstance(value, list) and value:
-                    flattened_tensors = flatten_tensor_lists(value)                    
+                    flattened_tensors = flatten_tensor_lists(value)
                     if flattened_tensors:
-                        combined_tensor = torch.cat([t.flatten() for t in flattened_tensors])
+                        combined_tensor = torch.cat(
+                            [t.flatten() for t in flattened_tensors]
+                        )
                         tensors.append(combined_tensor)
                 elif np.isscalar(value):
                     tensors.append(torch.tensor(value))


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-xla/issues/1196 

### Problem description
The BAAI/bge_m3 model generates a dictionary output which is not handled in the `_extract_outputs` function of the ModelTester. This is why the bge_m3 tests have custom `_extract_outputs` functions defined. However, tt-forge-models doesn't support creating custom `_extract_outputs` functions and so bge_m3 fails in the runner/test_models infra.

### What's changed
Since bge_m3 is one of the only models that needs custom `_extract_outputs` functions we decided to extend the original `_extract_outputs` definition (in the ModelTester) instead of adding support to tt-forge-models. Additionally, BAAI/bge_m3 does not have `"return_dict" : false` as a config option, so support for dictionary outputs is needed.
- Removed custom `_extract_outputs` definitions from bge_m3 tests
- Added support for dictionary output types seen by bge_m3 `model.model` and `model.encode` to the existing `_extract_outputs` logic.
  - This logic covers basic output types (within the dictionary) and the outputs seen in bge_m3 testing. Warnings were added to serve as early detection for new output formats that might require extending the extraction logic further. 

### Checklist
- [x] New/Existing tests provide coverage for changes
