### PR TITLE
Einnes tt/torch deprecate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,9 @@
-# Contributing guidelines for TT-Torch
+# Contributing Guidelines for TT-Torch
+
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
 
 ## PR Guidelines
-### Community contributions
+### Community Contributions
 Thank you for your interest in the TT-Torch project we appreciate your support.
 For all PRs we have an internal policy listed below which your PR will go through after an initial review has been done.
 
@@ -9,7 +11,7 @@ The initial review will encompase the following:
 * Review the PR for CI / CD Readiness. Includes making sure that the code and PR at a high level makes sense for the project
 * Once approved for CI / CD readiness a Tenstorrent developer will kick off our CI/CD pipeline on your behalf.
 
-### Internal contributions
+### Internal Contributions
 For internal contributions we have the following guidelines:
 
 * A 24 hour merge rule exists. The rule is to wait at least 24 hours since the PR was initially opened for review. This gives members of our teams that span the globe opportunity to provide feedback to PRs.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 # tt-torch
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 tt-torch is a [PyTorch2.0](https://pytorch.org/get-started/pytorch-2.0/) and [torch-mlir](https://github.com/llvm/torch-mlir/) based front-end for [tt-mlir](https://github.com/tenstorrent/tt-mlir/).
 
 -----
@@ -28,18 +30,7 @@ tt-torch is a [PyTorch2.0](https://pytorch.org/get-started/pytorch-2.0/) and [to
 -----
 # What is this Repo?
 
-The tt-torch repository is a PyTorch-based front end compiler that lets developers write standard PyTorch models as well as compile and run those models on Tenstorrent AI accelerators. tt-torch is a bridge between PyTorch models, MLIR dialects (Tenstorrent-specific IRs like ttir and ttgir), and low-level hardware execution on Tenstorrent chips.
-
------
-# Important Notice: Future Direction
-
-**Note:** `tt-torch` is transitioning to an experimental `torch-xla` backend, which will become the primary path forward for this project instead of the current `torch-mlir` approach. This project will be merged with [`tt-xla`](https://github.com/tenstorrent/tt-xla) in the future. This strategic change is based on the following factors:
-
-1. `torch-xla` now supports custom PJRT devices (which we have already developed in `tt-xla`)
-2. We did not find a good way to implement SPMD using `torch-mlir`
-3. `torch-mlir` lacks an eager mode and is fully ahead-of-time (AoT) compiled
-
-Stay tuned for updates as we make this transition.
+The TT-Torch repository is a PyTorch-based front end compiler that lets developers write standard PyTorch models as well as compile and run those models on Tenstorrent AI accelerators. TT-Tsorch is a bridge between PyTorch models, MLIR dialects (Tenstorrent-specific IRs like ttir and ttgir), and low-level hardware execution on Tenstorrent chips.
 
 -----
 # Related Tenstorrent Projects

--- a/docs/src/adding_models.md
+++ b/docs/src/adding_models.md
@@ -1,5 +1,7 @@
 # How to add model tests?
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 ## Requirements
 [Getting Started](https://docs.tenstorrent.com/tt-torch/getting_started.html)
 

--- a/docs/src/controlling.md
+++ b/docs/src/controlling.md
@@ -1,5 +1,7 @@
 ## Controlling Compiler Behavior
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 You can use the following environment variables to override default behavior:
 
 | Environment Variable | Behavior | Default |

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,4 +1,7 @@
 # Getting Started
+
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This document walks you through how to set up TT-Torch. TT-Torch is TT-Forge's front end for converting PyTorch models to different levels of Intermediate Representation (IR) all the way down to TTNN. This is the main Getting Started page. There are two additional Getting Started pages depending on what you want to do. They are all described here, with links provided to each.
 
 The following topics are covered:

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -34,7 +34,7 @@ sudo systemctl enable --now 'dev-hugepages\x2d1G.mount'
 sudo systemctl enable --now tenstorrent-hugepages.service
 ```
 
-4. Please ensure that after you run this script, after you complete reboot, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
+4. Please ensure that after you run the TT-Installer script, after you complete reboot and set up hugepages, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
 
 5. After your environment is running, to check that everything is configured, type the following:
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -27,7 +27,7 @@ Before setup can happen, you must configure your hardware. You can skip this sec
 
 2. Reboot your machine.
 
-3. Make sure **hugepages** is enabled: 
+3. Make sure **hugepages** is enabled:
 
 ```bash
 sudo systemctl enable --now 'dev-hugepages\x2d1G.mount'

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -27,9 +27,16 @@ Before setup can happen, you must configure your hardware. You can skip this sec
 
 2. Reboot your machine.
 
-3. Please ensure that after you run this script, after you complete reboot, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
+3. Make sure **hugepages** is enabled: 
 
-4. After your environment is running, to check that everything is configured, type the following:
+```bash
+sudo systemctl enable --now 'dev-hugepages\x2d1G.mount'
+sudo systemctl enable --now tenstorrent-hugepages.service
+```
+
+4. Please ensure that after you run this script, after you complete reboot, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
+
+5. After your environment is running, to check that everything is configured, type the following:
 
 ```bash
 tt-smi
@@ -78,12 +85,12 @@ pip install requests
 git clone https://github.com/tenstorrent/tt-forge.git
 ```
 
-6. Navigate into **tt-forge**. You are now ready to try running a model.
+6. Navigate into **tt-forge/demos/tt-torch**. You are now ready to try running a model.
 
 7. Run the demo:
 
 ```bash
-python demos/tt-torch/resnet50_demo.py
+python resnet50_demo.py
 ```
 
 If all goes well, you should get a list of top five predictions for what the example image is, with the top one being a cat.

--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -42,7 +42,7 @@ TT-Torch has the following system dependencies:
 * Clang 17
 * GCC 11
 * Ninja
-* CMake 3.20 or higher
+* CMake 4.0.3
 
 ### Installing Python
 If your system already has Python installed, make sure it is Python 3.10 or higher:

--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This document describes how to build the TT-Torch project on your local machine. You must build from source if you want to develop for TT-Torch. If you only want to run models, please choose one of the following sets of instructions instead:
 * [Installing a Wheel and Running an Example](getting_started.md) - You should choose this option if you want to run models.
 * [Using a Docker Container to Run an Example](getting_started_docker.md) - Choose this option if you want to keep the environment separate from your existing environment.

--- a/docs/src/getting_started_docker.md
+++ b/docs/src/getting_started_docker.md
@@ -1,7 +1,7 @@
 # Getting Started with Docker
 This document walks you through how to set up TT-Torch using a Docker image. There are two other available options for getting started:
 * [Installing a Wheel](getting_started.md) - if you do not want to use Docker, and prefer to use a virtual environment by itself instead, use this method.
-* [Building from Source](getting_started_build_from_source.md) - if you plan to develop TT-Torch further, you must build from source, and should use this method.
+* [Building From Source](getting_started_build_from_source.md) - if you plan to develop TT-Torch further, you must build from source, and should use this method.
 
 ## Configuring Hardware
 Before setup can happen, you must configure your hardware. You can skip this section if you already completed the configuration steps. Otherwise, this section of the walkthrough shows you how to do a quick setup using TT-Installer.
@@ -55,7 +55,7 @@ newgrp docker
 docker run -it --rm \
   --device /dev/tenstorrent \
   -v /dev/hugepages-1G:/dev/hugepages-1G \
-  ghcr.io/tenstorrent/tt-forge/tt-torch-slim:latest
+  ghcr.io/tenstorrent/tt-torch-slim:latest
 ```
 
 >**NOTE:** You cannot isolate devices in containers. You must pass through all devices even if you are only using one. You can do this by passing ```--device /dev/tenstorrent```. Do not try to pass ```--device /dev/tenstorrent/1``` or similar, as this type of device-in-container isolation will result in fatal errors later on during execution.
@@ -98,10 +98,10 @@ pip install tabulate
 pip install requests
 ```
 
-5. Run the model:
+5. Navigate into **tt-forge/demos/tt-torch** and run the model:
 
 ```bash
-python demos/tt-torch/resnet50_demo.py
+python resnet50_demo.py
 ```
 
 If all goes well, you should get a list of top five predictions for what the example image is, with the top one being a cat.

--- a/docs/src/getting_started_docker.md
+++ b/docs/src/getting_started_docker.md
@@ -1,4 +1,7 @@
 # Getting Started with Docker
+
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This document walks you through how to set up TT-Torch using a Docker image. There are two other available options for getting started:
 * [Installing a Wheel](getting_started.md) - if you do not want to use Docker, and prefer to use a virtual environment by itself instead, use this method.
 * [Building From Source](getting_started_build_from_source.md) - if you plan to develop TT-Torch further, you must build from source, and should use this method.

--- a/docs/src/getting_started_docker.md
+++ b/docs/src/getting_started_docker.md
@@ -10,9 +10,16 @@ Before setup can happen, you must configure your hardware. You can skip this sec
 
 2. Reboot your machine.
 
-3. Please ensure that after you run this script, after you complete reboot, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
+3. Make sure **hugepages** is enabled:
 
-4. When your environment is running, to check that everything is configured, type the following:
+```bash
+sudo systemctl enable --now 'dev-hugepages\x2d1G.mount'
+sudo systemctl enable --now tenstorrent-hugepages.service
+```
+
+4. Please ensure that after you run the TT-Installer script, after you complete reboot and set up hugepages, you activate the virtual environment it sets up - ```source ~/.tenstorrent-venv/bin/activate```.
+
+5. When your environment is running, to check that everything is configured, type the following:
 
 ```bash
 tt-smi

--- a/docs/src/models/supported_models.md
+++ b/docs/src/models/supported_models.md
@@ -1,5 +1,8 @@
 
 ## Supported Models
+
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 The following models can be currently run through tt-torch as of Feb 3rd, 2025. Please note, there is a known bug causing incorrect output for some models. The [PCC](https://en.wikipedia.org/wiki/Pearson_correlation_coefficient) is displayed at the end of each test below. This issue will be addressed soon.
 
 | Model Name | Variant | Pytest Command |

--- a/docs/src/ops/README.md
+++ b/docs/src/ops/README.md
@@ -1,3 +1,5 @@
 # Ops Documentation
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This section contains documentation for Ops operations.

--- a/docs/src/ops/stablehlo/README.md
+++ b/docs/src/ops/stablehlo/README.md
@@ -1,3 +1,5 @@
 # Stablehlo Documentation
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This section contains documentation for Stablehlo operations.

--- a/docs/src/ops/ttnn/README.md
+++ b/docs/src/ops/ttnn/README.md
@@ -1,5 +1,7 @@
 # TTNN OP Traces
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 The following pages have traces of operations that are currently not being compiled correctly. They can be updated by running:
 ```
 python tt_torch/tools/generate_md.py --excel_path <path to xlsx file> --md_dir docs/src/ops/ttnn --json_dir docs/src/ops/ttnn --failures_only

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -1,5 +1,7 @@
 # tt-torch
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 tt-torch is a [PyTorch2.0](https://pytorch.org/get-started/pytorch-2.0/) and [torch-mlir](https://github.com/llvm/torch-mlir/) based front-end for [tt-mlir](https://github.com/tenstorrent/tt-mlir/).
 
 tt-torch uses venv to keep track of all dependencies. After [compiling](https://docs.tenstorrent.com/tt-torch/getting_started.html) you can activate the venv by running from the project root directory:

--- a/docs/src/pre_commit.md
+++ b/docs/src/pre_commit.md
@@ -1,5 +1,8 @@
 
 ## Pre-Commit
+
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 Pre-Commit applies a Git hook to the local repository, ensuring linting is checked and applied on every git commit action. Install it from the root of the repository using:
 
 ```bash

--- a/docs/src/profiling.md
+++ b/docs/src/profiling.md
@@ -10,6 +10,8 @@ Note: Paths in this document are given relative to the repo root.
 
 ## Prerequisites
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 In the tt-torch building step ([Getting Started](https://docs.tenstorrent.com/tt-torch/getting_started.html#building-tt-torch)), it is required to configure your cmake build with the additional cmake directive `TT_RUNTIME_ENABLE_PERF_TRACE=ON` (i.e. run: `cmake -G Ninja -B build -DTT_RUNTIME_ENABLE_PERF_TRACE=ON`).
 
 

--- a/docs/src/test.md
+++ b/docs/src/test.md
@@ -1,5 +1,7 @@
 # Testing
 
+> **NOTE:** TT-Torch is deprecated. To work with PyTorch and the various features available in TT-Torch, please see the documentation for [TT-XLA](https://github.com/tenstorrent/tt-xla/blob/main/README.md). 
+
 This document walks you through how to test tt-torch after building from source or installing from wheel
 
 * [Infrastructure](#infrastructure)


### PR DESCRIPTION
### Ticket
#1230 

### Problem description
TT-Torch is deprecated and we need to make developers aware of that.

### What's changed
Add notes at the top of .md files indicating that TT-Torch is deprecated, and direct them to TT-XLA. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
