### PR TITLE
add deepwiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,7 @@ This repo is a part of Tenstorrent’s bounty program. If you are interested in 
 
 [codecov]: https://codecov.io/gh/tenstorrent/tt-torch
 [tests]: https://github.com/tenstorrent/tt-torch/actions/workflows/on-push.yml?query=branch%3Amain
+[deepwiki]: https://deepwiki.com/tenstorrent/tt-torch
 [codecov badge]: https://codecov.io/gh/tenstorrent/tt-torch/graph/badge.svg?token=XQJ3JVKIRI
 [tests badge]: https://github.com/tenstorrent/tt-torch/actions/workflows/on-push.yml/badge.svg?query=branch%3Amain
+[deep wiki badge]: https://deepwiki.com/badge.svg

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Tests][tests badge]][tests]
 [![Codecov][codecov badge]][codecov]
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tenstorrent/tt-torch)
 
 <div align="center">
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge/issues/327?issue=tenstorrent%7Ctt-forge%7C449)

### Problem description
TT-Torch, though deprecated, offers a deepwiki page, so we should display it until TT-Torch is set to EOL. 

### What's changed
Describe the approach used to solve the problem.
Add a deepwiki badge to the TT-Torch readme so developers know that's available. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
