### PR TITLE
Aknezevic/ultralytics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,6 @@ timm
 ml_dtypes
 opencv-contrib-python
 gliner==0.2.21
-ultralytics
 efficientnet_pytorch
 torchcodec==0.5.0 # required for whisper test. Requires system dep ffmpeg. 0.6.0 fails with NotImplementedError: Could not run 'torchcodec_ns::create_from_tensor' with arguments from the 'CPU' backend
 torchxrayvision==0.0.39

--- a/tests/models/detr/test_detr_onnx.py
+++ b/tests/models/detr/test_detr_onnx.py
@@ -33,9 +33,7 @@ class ThisTester(OnnxModelTester):
 
     def _load_torch_inputs(self):
         # Images
-        image_file = get_file(
-            "http://images.cocodataset.org/val2017/000000039769.jpg"
-        )
+        image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
         input_image = Image.open(str(image_file))
         m, s = np.mean(input_image, axis=(0, 1)), np.std(input_image, axis=(0, 1))
         preprocess = transforms.Compose(

--- a/tests/models/detr/test_detr_onnx.py
+++ b/tests/models/detr/test_detr_onnx.py
@@ -34,7 +34,7 @@ class ThisTester(OnnxModelTester):
     def _load_torch_inputs(self):
         # Images
         image_file = get_file(
-            "https://huggingface.co/spaces/nakamura196/yolov5-char/resolve/8a166e0aa4c9f62a364dafa7df63f2a33cbb3069/ultralytics/yolov5/data/images/zidane.jpg"
+            "http://images.cocodataset.org/val2017/000000039769.jpg"
         )
         input_image = Image.open(str(image_file))
         m, s = np.mean(input_image, axis=(0, 1)), np.std(input_image, axis=(0, 1))

--- a/tests/models/yolov10/test_yolov10.py
+++ b/tests/models/yolov10/test_yolov10.py
@@ -9,7 +9,6 @@ import requests
 from tests.utils import ModelTester, skip_full_eval_test
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.tools.utils import get_file
-from ultralytics import YOLO
 
 
 class ThisTester(ModelTester):
@@ -41,6 +40,7 @@ class ThisTester(ModelTester):
     ids=["op_by_op_stablehlo", "op_by_op_torch", "full"],
 )
 def test_yolov10(record_property, mode, op_by_op):
+    pytest.xfail()
     model_name = "YOLOv10"
     model_group = "red"
 

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -12,8 +12,6 @@ from tests.utils import ModelTester
 from tt_torch.tools.utils import CompilerConfig, CompileDepth, OpByOpBackend
 from third_party.tt_forge_models.tools.utils import get_file
 
-dependencies = ["ultralytics==8.2.92", "ultralytics-thop==2.0.6"]
-
 
 class ThisTester(ModelTester):
     def _load_model(self):
@@ -117,6 +115,7 @@ class ThisTester(ModelTester):
 def test_yolov5(record_property, mode, op_by_op):
     model_name = "YOLOv5"
 
+    pytest.xfail()
     cc = CompilerConfig()
     cc.enable_consteval = True
     cc.consteval_parameters = True


### PR DESCRIPTION
Removed 'ultralytics' from the development requirements.

Ticket
Link to Github Issue

Problem description
As per our lawyers we cannot use ultralytics until we have a licence from them. It will take too long to get licence, so in the mean time we need to remove it from our repos.

What's changed
Removed ultralytics